### PR TITLE
Suggestion for content edit: clarify the placement for TypeKit

### DIFF
--- a/src/patterns/fundamentals/typography/typekit.hbs
+++ b/src/patterns/fundamentals/typography/typekit.hbs
@@ -40,8 +40,8 @@ doclayout: true
   <h3 class="drizzle-b-h3" id="typekit-loader">Typekit Loader</h3>
   <p class="drizzle-b-P">You'll need to include the following snippet into your
         site's code. Spark includes fallback font definitions, so
-        it's recommended that you include it before the closing
-        tag, in order to avoid render blocking.</p>
+        it's recommended that you include it inside of the <em>&lt;body&gt;</em>
+        tag, towards the end of your document, in order to avoid render blocking.</p>
   <p class="drizzle-b-P"><strong>You'll need to insert your new kit's id into the snippet below.</strong></p>
   <p class="drizzle-b-P">Included in the code below is an event that gets dispatched when the fonts
       have finished loading ('fonts-active').</p>


### PR DESCRIPTION
Today, it says "before the closing tag." That's not very specific. So, making some assumptions, I've provided a suggestion for editing that content.