### PR TITLE
Sticky nav overlap

### DIFF
--- a/src/assets/drizzle/styles/components/_navigation.scss
+++ b/src/assets/drizzle/styles/components/_navigation.scss
@@ -112,3 +112,15 @@ svg {
   font-weight: 300;
   line-height: 0.8;
 }
+
+/* Offset jump links so they don't get hidden by the sticky header */
+:target::before {
+  display: block;
+  height: 7rem;
+  margin-top: -7rem;
+
+  @media (max-width: $nav-switch-breakpoint) {
+    height: 5rem;
+    margin-top: -5rem;
+  }
+}

--- a/src/patterns/components/inputs/collection.yaml
+++ b/src/patterns/components/inputs/collection.yaml
@@ -14,8 +14,8 @@ contents:
   Password Input: inputs.html#password-input
   Helper Text: inputs.html#helper-text
   Phone Number: inputs.html#phone-number-input
-  Date Input: inputs.html#date-input
   Date Picker: inputs.html#date-picker
+  Date Input: inputs.html#date-input
 restrictions:
   - You should add the 'novalidate' attribute to your form, since we handle form validation ourselves,
     and don't use the browser's implementation


### PR DESCRIPTION
Fixes issue https://github.com/sparkdesignsystem/spark-design-system/issues/401

Inserts a pseudo-element at ```:target::before``` to offset the target from the top of the screen. This is to push the content down so it isn't hidden behind the navigation header.

Tested in all browsers. IE 11 doesn't support ```position: sticky;``` so the header scrolls off the screen, but it is respecting the new offset and pushing the jump targets down.