### PR TITLE
Correct purple to purple medium

### DIFF
--- a/src/data/colors.yaml
+++ b/src/data/colors.yaml
@@ -29,10 +29,10 @@
     color: "#44235D"
     rgb: "rgb(68,35,93)"
     property: "$purple-dark"
-  - label: Purple
+  - label: Purple Medium
     color: "#551387"
     rgb: "rgb(85,19,135)"
-    property: "$purple"
+    property: "$purple-medium"
   - label: Orange Dark
     color: "#E67800"
     rgb: "rgb(230,120,0)"


### PR DESCRIPTION
Because that's correct––there's never just "purple" it's "purple medium"

![image](https://user-images.githubusercontent.com/4342363/45572971-fef5c880-b838-11e8-8e76-d453f1017d83.png)
