### PR TITLE
Fix Inset-short spacing in example

### DIFF
--- a/src/patterns/fundamentals/space/inset-short.hbs
+++ b/src/patterns/fundamentals/space/inset-short.hbs
@@ -13,27 +13,27 @@ order: 2
     <h4 class="drizzle-b-h4">
       Example:
     </h4>
-    <div class="drizzle-c-Space-inset-tall-xs sprk-u-mbm">
+    <div class="drizzle-c-Space-inset-short-xs sprk-u-mbm">
       <p class="sprk-b-TypeBodyTwo">
         The green border shows the extra small inset short of 2px 4px 2px 4px.
       </p>
     </div>
-    <div class="drizzle-c-Space-inset-tall-s sprk-u-mbm">
+    <div class="drizzle-c-Space-inset-short-s sprk-u-mbm">
       <p class="sprk-b-TypeBodyTwo">
         The green border shows the small inset short of 4px 8px 4px 8px.
       </p>
     </div>
-    <div class="drizzle-c-Space-inset-tall-m sprk-u-mbm">
+    <div class="drizzle-c-Space-inset-short-m sprk-u-mbm">
       <p class="sprk-b-TypeBodyTwo">
         The green border shows the medium inset short of 8px 16px 8px 16px.
       </p>
     </div>
-    <div class="drizzle-c-Space-inset-tall-l sprk-u-mbm">
+    <div class="drizzle-c-Space-inset-short-l sprk-u-mbm">
       <p class="sprk-b-TypeBodyTwo">
         The green border shows the large inset short of 16px 32px 16px 32px.
       </p>
     </div>
-    <div class="drizzle-c-Space-inset-tall-xl sprk-u-mbm">
+    <div class="drizzle-c-Space-inset-short-xl sprk-u-mbm">
       <p class="sprk-b-TypeBodyTwo">
         The green border shows the extra large inset short of 32px 64px 32px 64px.
       </p>


### PR DESCRIPTION
## What does this PR do?
- Updates `inset-tall` to `inset-short` spacing in the example as specified in #598 