### PR TITLE
Fix the padding on the drizzle-c-command class

### DIFF
--- a/src/assets/drizzle/styles/components/_command.scss
+++ b/src/assets/drizzle/styles/components/_command.scss
@@ -2,7 +2,7 @@
   background-color: $gray-light;
   display: inline-block;
   overflow: auto;
-  padding: 0.5rem 1rem;
+  padding: 0 0.5rem 0.1rem;
   max-width: 100%;
   vertical-align: middle;
 }


### PR DESCRIPTION
## What does this PR do?
- It updates the padding on the `drizzle-c-command` as it is currently too large
- Fixes #602 


## Previously
![broken-styling](https://user-images.githubusercontent.com/22860561/46463413-80070680-c7cc-11e8-855a-47c5eaab9805.png)

## Updated
<img width="923" alt="css-class-padding-fix" src="https://user-images.githubusercontent.com/22860561/46463333-5948d000-c7cc-11e8-8cc4-0bce60397b28.png">
