### PR TITLE
fix up svg icon bugs

### DIFF
--- a/packages/spark-core/components/_alerts.scss
+++ b/packages/spark-core/components/_alerts.scss
@@ -97,7 +97,6 @@
   padding: $space-m;
 }
 
-// Todo: remove this in favor of reusable sprk-c-Icon--current-color class (breaking html change)
 .sprk-c-Alert__icon,
 .sprk-c-Alert__icon--dismiss .sprk-c-Icon {
   stroke: currentColor;

--- a/packages/spark-core/components/_alerts.scss
+++ b/packages/spark-core/components/_alerts.scss
@@ -97,9 +97,11 @@
   padding: $space-m;
 }
 
+// Todo: remove this in favor of reusable sprk-c-Icon--current-color class (breaking html change)
 .sprk-c-Alert__icon,
 .sprk-c-Alert__icon--dismiss .sprk-c-Icon {
   stroke: currentColor;
+  fill: currentColor;
 }
 
 .sprk-c-Alert .sprk-c-Icon {

--- a/packages/spark-core/components/_icons.scss
+++ b/packages/spark-core/components/_icons.scss
@@ -12,19 +12,9 @@
   }
 }
 
-@if ($icon-using-custom-stroke) {
-  /* required for css to override svg presentational attributes */
-  svg text {
-    stroke-width: 0;
-  }
-
-  svg circle,
-  svg rect,
-  svg path,
-  svg g {
-    stroke: inherit;
-    stroke-width: inherit;
-  }
+.sprk-c-Icon--current-color {
+  fill: currentColor;
+  stroke: currentColor;
 }
 
 .sprk-c-Icon--l {

--- a/packages/spark-core/package-lock.json
+++ b/packages/spark-core/package-lock.json
@@ -903,7 +903,7 @@
     },
     "@sinonjs/formatio": {
       "version": "2.0.0",
-      "resolved": "http://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
       "requires": {
         "samsam": "1.3.0"
@@ -1813,7 +1813,7 @@
     },
     "commander": {
       "version": "2.15.1",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
       "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
@@ -3819,7 +3819,7 @@
     },
     "json5": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
       "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
       "dev": true
     },
@@ -4082,7 +4082,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -4127,7 +4127,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -7796,7 +7796,7 @@
     },
     "text-encoding": {
       "version": "0.6.4",
-      "resolved": "http://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+      "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
       "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
     },
     "through2": {

--- a/packages/spark-extras/package-lock.json
+++ b/packages/spark-extras/package-lock.json
@@ -2465,7 +2465,7 @@
       "dependencies": {
         "align-text": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "requires": {
             "kind-of": "^3.0.2",
@@ -2475,22 +2475,22 @@
         },
         "amdefine": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
           "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "2.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
           "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
         },
         "append-transform": {
           "version": "0.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/append-transform/-/append-transform-0.4.0.tgz",
           "integrity": "sha1-126/jKlNJ24keja61EpLdKthGZE=",
           "requires": {
             "default-require-extensions": "^1.0.0"
@@ -2498,52 +2498,52 @@
         },
         "archy": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
           "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "arr-diff": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
           "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "arr-flatten": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
           "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
         },
         "arr-union": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
           "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-unique": {
           "version": "0.3.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
           "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "arrify": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
           "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
         },
         "assign-symbols": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
           "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "async": {
           "version": "1.5.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "atob": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
           "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio="
         },
         "babel-code-frame": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
           "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
           "requires": {
             "chalk": "^1.1.3",
@@ -2553,7 +2553,7 @@
         },
         "babel-generator": {
           "version": "6.26.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
           "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
           "requires": {
             "babel-messages": "^6.23.0",
@@ -2568,7 +2568,7 @@
         },
         "babel-messages": {
           "version": "6.23.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
           "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
           "requires": {
             "babel-runtime": "^6.22.0"
@@ -2576,7 +2576,7 @@
         },
         "babel-runtime": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
           "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
           "requires": {
             "core-js": "^2.4.0",
@@ -2585,7 +2585,7 @@
         },
         "babel-template": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
           "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -2597,7 +2597,7 @@
         },
         "babel-traverse": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
           "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
           "requires": {
             "babel-code-frame": "^6.26.0",
@@ -2613,7 +2613,7 @@
         },
         "babel-types": {
           "version": "6.26.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
           "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
           "requires": {
             "babel-runtime": "^6.26.0",
@@ -2624,17 +2624,17 @@
         },
         "babylon": {
           "version": "6.18.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
           "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "base": {
           "version": "0.11.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
           "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
           "requires": {
             "cache-base": "^1.0.1",
@@ -2648,7 +2648,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -2656,7 +2656,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -2664,7 +2664,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -2672,7 +2672,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -2682,19 +2682,19 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
             }
           }
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -2703,7 +2703,7 @@
         },
         "braces": {
           "version": "2.3.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
           "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
           "requires": {
             "arr-flatten": "^1.1.0",
@@ -2720,7 +2720,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -2730,12 +2730,12 @@
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
           "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
         },
         "cache-base": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
           "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
           "requires": {
             "collection-visit": "^1.0.0",
@@ -2751,14 +2751,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             }
           }
         },
         "caching-transform": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/caching-transform/-/caching-transform-1.0.1.tgz",
           "integrity": "sha1-bb2y8g+Nj7znnz6U6dF0Lc31wKE=",
           "requires": {
             "md5-hex": "^1.2.0",
@@ -2768,13 +2768,13 @@
         },
         "camelcase": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
           "optional": true
         },
         "center-align": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
           "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
           "optional": true,
           "requires": {
@@ -2784,7 +2784,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "requires": {
             "ansi-styles": "^2.2.1",
@@ -2796,7 +2796,7 @@
         },
         "class-utils": {
           "version": "0.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
           "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
           "requires": {
             "arr-union": "^3.1.0",
@@ -2807,7 +2807,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -2815,14 +2815,14 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             }
           }
         },
         "cliui": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
           "optional": true,
           "requires": {
@@ -2833,7 +2833,7 @@
           "dependencies": {
             "wordwrap": {
               "version": "0.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
               "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
               "optional": true
             }
@@ -2841,12 +2841,12 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "collection-visit": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
           "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
           "requires": {
             "map-visit": "^1.0.0",
@@ -2855,37 +2855,37 @@
         },
         "commondir": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
           "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
         },
         "component-emitter": {
           "version": "1.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
           "integrity": "sha1-E3kY1teCg/ffemt8WmPhQOaUJeY="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "convert-source-map": {
           "version": "1.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
           "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
         },
         "copy-descriptor": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
           "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
         "core-js": {
           "version": "2.5.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.6.tgz",
           "integrity": "sha512-lQUVfQi0aLix2xpyjrrJEvfuYCqPc/HwmTKsC/VNf8q0zsjX7SQZtp4+oRONN5Tsur9GDETPjj+Ub2iDiGZfSQ=="
         },
         "cross-spawn": {
           "version": "4.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
           "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE=",
           "requires": {
             "lru-cache": "^4.0.1",
@@ -2894,7 +2894,7 @@
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -2902,22 +2902,22 @@
         },
         "debug-log": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug-log/-/debug-log-1.0.1.tgz",
           "integrity": "sha1-IwdjLUwEOCuN+KMvcLiVBG1SdF8="
         },
         "decamelize": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
           "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
           "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "default-require-extensions": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
           "integrity": "sha1-836hXT4T/9m0N9M+GnW1+5eHTLg=",
           "requires": {
             "strip-bom": "^2.0.0"
@@ -2925,7 +2925,7 @@
         },
         "define-property": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
           "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
           "requires": {
             "is-descriptor": "^1.0.2",
@@ -2934,7 +2934,7 @@
           "dependencies": {
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -2942,7 +2942,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -2950,7 +2950,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -2960,19 +2960,19 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
             }
           }
         },
         "detect-indent": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
           "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
           "requires": {
             "repeating": "^2.0.0"
@@ -2980,7 +2980,7 @@
         },
         "error-ex": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
           "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
           "requires": {
             "is-arrayish": "^0.2.1"
@@ -2988,17 +2988,17 @@
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
           "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "esutils": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
           "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
         },
         "execa": {
           "version": "0.7.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
           "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
@@ -3012,7 +3012,7 @@
           "dependencies": {
             "cross-spawn": {
               "version": "5.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
               "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
               "requires": {
                 "lru-cache": "^4.0.1",
@@ -3024,7 +3024,7 @@
         },
         "expand-brackets": {
           "version": "2.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "requires": {
             "debug": "^2.3.3",
@@ -3038,7 +3038,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -3046,7 +3046,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -3056,7 +3056,7 @@
         },
         "extend-shallow": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
           "requires": {
             "assign-symbols": "^1.0.0",
@@ -3065,7 +3065,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -3075,7 +3075,7 @@
         },
         "extglob": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
           "requires": {
             "array-unique": "^0.3.2",
@@ -3090,7 +3090,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -3098,7 +3098,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -3106,7 +3106,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -3114,7 +3114,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -3122,7 +3122,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -3132,14 +3132,14 @@
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
             }
           }
         },
         "fill-range": {
           "version": "4.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -3150,7 +3150,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -3160,7 +3160,7 @@
         },
         "find-cache-dir": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-0.1.1.tgz",
           "integrity": "sha1-yN765XyKUqinhPnjHFfHQumToLk=",
           "requires": {
             "commondir": "^1.0.1",
@@ -3170,7 +3170,7 @@
         },
         "find-up": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
           "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
           "requires": {
             "locate-path": "^2.0.0"
@@ -3178,12 +3178,12 @@
         },
         "for-in": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
           "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "foreground-child": {
           "version": "1.5.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-1.5.6.tgz",
           "integrity": "sha1-T9ca0t/elnibmApcCilZN8svXOk=",
           "requires": {
             "cross-spawn": "^4",
@@ -3192,7 +3192,7 @@
         },
         "fragment-cache": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
           "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
           "requires": {
             "map-cache": "^0.2.2"
@@ -3200,27 +3200,27 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
           "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
         },
         "get-value": {
           "version": "2.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
           "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -3233,17 +3233,17 @@
         },
         "globals": {
           "version": "9.18.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
           "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
           "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
         },
         "handlebars": {
           "version": "4.0.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
           "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
           "requires": {
             "async": "^1.4.0",
@@ -3254,7 +3254,7 @@
           "dependencies": {
             "source-map": {
               "version": "0.4.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
               "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
               "requires": {
                 "amdefine": ">=0.0.4"
@@ -3264,7 +3264,7 @@
         },
         "has-ansi": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
           "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -3272,12 +3272,12 @@
         },
         "has-flag": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz",
           "integrity": "sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo="
         },
         "has-value": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
           "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
           "requires": {
             "get-value": "^2.0.6",
@@ -3287,14 +3287,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             }
           }
         },
         "has-values": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
           "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
           "requires": {
             "is-number": "^3.0.0",
@@ -3303,7 +3303,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "requires": {
                 "kind-of": "^3.0.2"
@@ -3311,7 +3311,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -3321,7 +3321,7 @@
             },
             "kind-of": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
               "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
               "requires": {
                 "is-buffer": "^1.1.5"
@@ -3331,17 +3331,17 @@
         },
         "hosted-git-info": {
           "version": "2.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
           "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw=="
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
           "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
@@ -3350,12 +3350,12 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "invariant": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
           "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
           "requires": {
             "loose-envify": "^1.0.0"
@@ -3363,12 +3363,12 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
           "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -3376,17 +3376,17 @@
         },
         "is-arrayish": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
           "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
         },
         "is-buffer": {
           "version": "1.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
         },
         "is-builtin-module": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
           "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
           "requires": {
             "builtin-modules": "^1.0.0"
@@ -3394,7 +3394,7 @@
         },
         "is-data-descriptor": {
           "version": "0.1.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -3402,7 +3402,7 @@
         },
         "is-descriptor": {
           "version": "0.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "requires": {
             "is-accessor-descriptor": "^0.1.6",
@@ -3412,19 +3412,19 @@
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
               "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
             }
           }
         },
         "is-extendable": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
           "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-finite": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
           "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -3432,12 +3432,12 @@
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
         },
         "is-number": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -3445,7 +3445,7 @@
         },
         "is-odd": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
           "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
           "requires": {
             "is-number": "^4.0.0"
@@ -3453,14 +3453,14 @@
           "dependencies": {
             "is-number": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
               "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
             }
           }
         },
         "is-plain-object": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
           "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
           "requires": {
             "isobject": "^3.0.1"
@@ -3468,49 +3468,49 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             }
           }
         },
         "is-stream": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
           "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-utf8": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
           "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
         },
         "is-windows": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
           "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
           "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
           "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "istanbul-lib-coverage": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-1.2.0.tgz",
           "integrity": "sha512-GvgM/uXRwm+gLlvkWHTjDAvwynZkL9ns15calTrmhGgowlwJBbWMYzWbKqE2DT6JDP1AFXKa+Zi0EkqNCUqY0A=="
         },
         "istanbul-lib-hook": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-hook/-/istanbul-lib-hook-1.1.0.tgz",
           "integrity": "sha512-U3qEgwVDUerZ0bt8cfl3dSP3S6opBoOtk3ROO5f2EfBr/SRiD9FQqzwaZBqFORu8W7O0EXpai+k7kxHK13beRg==",
           "requires": {
             "append-transform": "^0.4.0"
@@ -3518,7 +3518,7 @@
         },
         "istanbul-lib-instrument": {
           "version": "1.10.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-1.10.1.tgz",
           "integrity": "sha512-1dYuzkOCbuR5GRJqySuZdsmsNKPL3PTuyPevQfoCXJePT9C8y1ga75neU+Tuy9+yS3G/dgx8wgOmp2KLpgdoeQ==",
           "requires": {
             "babel-generator": "^6.18.0",
@@ -3532,7 +3532,7 @@
         },
         "istanbul-lib-report": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-1.1.3.tgz",
           "integrity": "sha512-D4jVbMDtT2dPmloPJS/rmeP626N5Pr3Rp+SovrPn1+zPChGHcggd/0sL29jnbm4oK9W0wHjCRsdch9oLd7cm6g==",
           "requires": {
             "istanbul-lib-coverage": "^1.1.2",
@@ -3543,7 +3543,7 @@
           "dependencies": {
             "supports-color": {
               "version": "3.2.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.2.3.tgz",
               "integrity": "sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=",
               "requires": {
                 "has-flag": "^1.0.0"
@@ -3553,7 +3553,7 @@
         },
         "istanbul-lib-source-maps": {
           "version": "1.2.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-1.2.3.tgz",
           "integrity": "sha512-fDa0hwU/5sDXwAklXgAoCJCOsFsBplVQ6WBldz5UwaqOzmDhUK4nfuR7/G//G2lERlblUNJB8P6e8cXq3a7MlA==",
           "requires": {
             "debug": "^3.1.0",
@@ -3565,7 +3565,7 @@
           "dependencies": {
             "debug": {
               "version": "3.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
               "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
               "requires": {
                 "ms": "2.0.0"
@@ -3575,7 +3575,7 @@
         },
         "istanbul-reports": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-1.4.0.tgz",
           "integrity": "sha512-OPzVo1fPZ2H+owr8q/LYKLD+vquv9Pj4F+dj808MdHbuQLD7S4ACRjcX+0Tne5Vxt2lxXvdZaL7v+FOOAV281w==",
           "requires": {
             "handlebars": "^4.0.3"
@@ -3583,17 +3583,17 @@
         },
         "js-tokens": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
           "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
         },
         "jsesc": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
           "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
         },
         "kind-of": {
           "version": "3.2.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "requires": {
             "is-buffer": "^1.1.5"
@@ -3601,13 +3601,13 @@
         },
         "lazy-cache": {
           "version": "1.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
           "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
           "optional": true
         },
         "lcid": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
           "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
           "requires": {
             "invert-kv": "^1.0.0"
@@ -3615,7 +3615,7 @@
         },
         "load-json-file": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -3627,7 +3627,7 @@
         },
         "locate-path": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
           "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
           "requires": {
             "p-locate": "^2.0.0",
@@ -3636,24 +3636,24 @@
           "dependencies": {
             "path-exists": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
               "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
             }
           }
         },
         "lodash": {
           "version": "4.17.10",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
           "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "longest": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
         },
         "loose-envify": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
           "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
           "requires": {
             "js-tokens": "^3.0.0"
@@ -3661,7 +3661,7 @@
         },
         "lru-cache": {
           "version": "4.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
           "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
           "requires": {
             "pseudomap": "^1.0.2",
@@ -3670,12 +3670,12 @@
         },
         "map-cache": {
           "version": "0.2.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
           "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
         },
         "map-visit": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
           "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
           "requires": {
             "object-visit": "^1.0.0"
@@ -3683,7 +3683,7 @@
         },
         "md5-hex": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/md5-hex/-/md5-hex-1.3.0.tgz",
           "integrity": "sha1-0sSv6YPENwZiF5uMrRRSGRNQRsQ=",
           "requires": {
             "md5-o-matic": "^0.1.1"
@@ -3691,12 +3691,12 @@
         },
         "md5-o-matic": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/md5-o-matic/-/md5-o-matic-0.1.1.tgz",
           "integrity": "sha1-givM1l4RfFFPqxdrJZRdVBAKA8M="
         },
         "mem": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
           "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
           "requires": {
             "mimic-fn": "^1.0.0"
@@ -3704,7 +3704,7 @@
         },
         "merge-source-map": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.1.0.tgz",
           "integrity": "sha512-Qkcp7P2ygktpMPh2mCQZaf3jhN6D3Z/qVZHSdWvQ+2Ef5HgRAPBO57A77+ENm0CPx2+1Ce/MYKi3ymqdfuqibw==",
           "requires": {
             "source-map": "^0.6.1"
@@ -3712,14 +3712,14 @@
           "dependencies": {
             "source-map": {
               "version": "0.6.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
               "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
             }
           }
         },
         "micromatch": {
           "version": "3.1.10",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
           "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
           "requires": {
             "arr-diff": "^4.0.0",
@@ -3739,19 +3739,19 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
             }
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
           "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -3759,12 +3759,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mixin-deep": {
           "version": "1.3.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
           "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
           "requires": {
             "for-in": "^1.0.2",
@@ -3773,7 +3773,7 @@
           "dependencies": {
             "is-extendable": {
               "version": "1.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
               "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
               "requires": {
                 "is-plain-object": "^2.0.4"
@@ -3783,7 +3783,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -3791,12 +3791,12 @@
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "nanomatch": {
           "version": "1.2.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
           "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
           "requires": {
             "arr-diff": "^4.0.0",
@@ -3815,24 +3815,24 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
               "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
             },
             "array-unique": {
               "version": "0.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
               "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
             }
           }
         },
         "normalize-package-data": {
           "version": "2.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
           "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
           "requires": {
             "hosted-git-info": "^2.1.4",
@@ -3843,7 +3843,7 @@
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
           "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "requires": {
             "path-key": "^2.0.0"
@@ -3851,17 +3851,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-copy": {
           "version": "0.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
           "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
           "requires": {
             "copy-descriptor": "^0.1.0",
@@ -3871,7 +3871,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -3881,7 +3881,7 @@
         },
         "object-visit": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
           "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
           "requires": {
             "isobject": "^3.0.0"
@@ -3889,14 +3889,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             }
           }
         },
         "object.pick": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
           "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
           "requires": {
             "isobject": "^3.0.1"
@@ -3904,14 +3904,14 @@
           "dependencies": {
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             }
           }
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -3919,7 +3919,7 @@
         },
         "optimist": {
           "version": "0.6.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
           "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
           "requires": {
             "minimist": "~0.0.1",
@@ -3928,12 +3928,12 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-locale": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
           "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
           "requires": {
             "execa": "^0.7.0",
@@ -3943,12 +3943,12 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
           "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-limit": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
           "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
           "requires": {
             "p-try": "^1.0.0"
@@ -3956,7 +3956,7 @@
         },
         "p-locate": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
           "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
           "requires": {
             "p-limit": "^1.1.0"
@@ -3964,12 +3964,12 @@
         },
         "p-try": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
           "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M="
         },
         "parse-json": {
           "version": "2.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "requires": {
             "error-ex": "^1.2.0"
@@ -3977,12 +3977,12 @@
         },
         "pascalcase": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
           "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
         "path-exists": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
           "requires": {
             "pinkie-promise": "^2.0.0"
@@ -3990,22 +3990,22 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-key": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
           "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
         },
         "path-type": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -4015,17 +4015,17 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "pinkie": {
           "version": "2.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
           "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
         },
         "pinkie-promise": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
           "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
           "requires": {
             "pinkie": "^2.0.0"
@@ -4033,7 +4033,7 @@
         },
         "pkg-dir": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
           "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
           "requires": {
             "find-up": "^1.0.0"
@@ -4041,7 +4041,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "requires": {
                 "path-exists": "^2.0.0",
@@ -4052,17 +4052,17 @@
         },
         "posix-character-classes": {
           "version": "0.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
           "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "pseudomap": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
           "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "read-pkg": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
           "requires": {
             "load-json-file": "^1.0.0",
@@ -4072,7 +4072,7 @@
         },
         "read-pkg-up": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
           "requires": {
             "find-up": "^1.0.0",
@@ -4081,7 +4081,7 @@
           "dependencies": {
             "find-up": {
               "version": "1.1.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
               "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
               "requires": {
                 "path-exists": "^2.0.0",
@@ -4092,12 +4092,12 @@
         },
         "regenerator-runtime": {
           "version": "0.11.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
           "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
         },
         "regex-not": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
           "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
           "requires": {
             "extend-shallow": "^3.0.2",
@@ -4106,17 +4106,17 @@
         },
         "repeat-element": {
           "version": "1.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.2.tgz",
           "integrity": "sha1-7wiaF40Ug7quTZPrmLT55OEdmQo="
         },
         "repeat-string": {
           "version": "1.6.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "repeating": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
           "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
           "requires": {
             "is-finite": "^1.0.0"
@@ -4124,32 +4124,32 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
           "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
           "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
         },
         "resolve-from": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
           "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         },
         "resolve-url": {
           "version": "0.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
           "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "ret": {
           "version": "0.1.15",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
           "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
         "right-align": {
           "version": "0.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
           "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
           "optional": true,
           "requires": {
@@ -4158,7 +4158,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
             "glob": "^7.0.5"
@@ -4166,7 +4166,7 @@
         },
         "safe-regex": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
           "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
           "requires": {
             "ret": "~0.1.10"
@@ -4174,17 +4174,17 @@
         },
         "semver": {
           "version": "5.5.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
           "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "set-value": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
           "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
           "requires": {
             "extend-shallow": "^2.0.1",
@@ -4195,7 +4195,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -4205,7 +4205,7 @@
         },
         "shebang-command": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
           "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "requires": {
             "shebang-regex": "^1.0.0"
@@ -4213,22 +4213,22 @@
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
           "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "slide": {
           "version": "1.1.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
           "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
         },
         "snapdragon": {
           "version": "0.8.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
           "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
           "requires": {
             "base": "^0.11.1",
@@ -4243,7 +4243,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -4251,7 +4251,7 @@
             },
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -4261,7 +4261,7 @@
         },
         "snapdragon-node": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
           "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
           "requires": {
             "define-property": "^1.0.0",
@@ -4271,7 +4271,7 @@
           "dependencies": {
             "define-property": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
               "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
               "requires": {
                 "is-descriptor": "^1.0.0"
@@ -4279,7 +4279,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -4287,7 +4287,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -4295,7 +4295,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -4305,19 +4305,19 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
             }
           }
         },
         "snapdragon-util": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
           "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
           "requires": {
             "kind-of": "^3.2.0"
@@ -4325,12 +4325,12 @@
         },
         "source-map": {
           "version": "0.5.7",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
         "source-map-resolve": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
           "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
           "requires": {
             "atob": "^2.0.0",
@@ -4342,12 +4342,12 @@
         },
         "source-map-url": {
           "version": "0.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
           "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
         "spawn-wrap": {
           "version": "1.4.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spawn-wrap/-/spawn-wrap-1.4.2.tgz",
           "integrity": "sha512-vMwR3OmmDhnxCVxM8M+xO/FtIp6Ju/mNaDfCMMW7FDcLRTPFWUswec4LXJHTJE2hwTI9O0YBfygu4DalFl7Ylg==",
           "requires": {
             "foreground-child": "^1.5.6",
@@ -4360,7 +4360,7 @@
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
           "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "requires": {
             "spdx-expression-parse": "^3.0.0",
@@ -4369,12 +4369,12 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
           "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
           "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "requires": {
             "spdx-exceptions": "^2.1.0",
@@ -4383,12 +4383,12 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
           "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA=="
         },
         "split-string": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
           "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
           "requires": {
             "extend-shallow": "^3.0.0"
@@ -4396,7 +4396,7 @@
         },
         "static-extend": {
           "version": "0.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
           "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
           "requires": {
             "define-property": "^0.2.5",
@@ -4405,7 +4405,7 @@
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
               "requires": {
                 "is-descriptor": "^0.1.0"
@@ -4415,7 +4415,7 @@
         },
         "string-width": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
@@ -4424,12 +4424,12 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -4439,7 +4439,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4447,7 +4447,7 @@
         },
         "strip-bom": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
           "requires": {
             "is-utf8": "^0.2.0"
@@ -4455,17 +4455,17 @@
         },
         "strip-eof": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
           "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "supports-color": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
           "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         },
         "test-exclude": {
           "version": "4.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-4.2.1.tgz",
           "integrity": "sha512-qpqlP/8Zl+sosLxBcVKl9vYy26T9NPalxSzzCP/OY6K7j938ui2oKgo+kRZYfxAeIpLqpbVnsHq1tyV70E4lWQ==",
           "requires": {
             "arrify": "^1.0.1",
@@ -4477,17 +4477,17 @@
           "dependencies": {
             "arr-diff": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
               "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
             },
             "array-unique": {
               "version": "0.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
               "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
             },
             "braces": {
               "version": "2.3.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
               "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
               "requires": {
                 "arr-flatten": "^1.1.0",
@@ -4504,7 +4504,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -4514,7 +4514,7 @@
             },
             "expand-brackets": {
               "version": "2.1.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
               "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
               "requires": {
                 "debug": "^2.3.3",
@@ -4528,7 +4528,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "0.2.5",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                   "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                   "requires": {
                     "is-descriptor": "^0.1.0"
@@ -4536,7 +4536,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -4544,7 +4544,7 @@
                 },
                 "is-accessor-descriptor": {
                   "version": "0.1.6",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
                   "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -4552,7 +4552,7 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "resolved": false,
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -4562,7 +4562,7 @@
                 },
                 "is-data-descriptor": {
                   "version": "0.1.4",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
                   "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
                   "requires": {
                     "kind-of": "^3.0.2"
@@ -4570,7 +4570,7 @@
                   "dependencies": {
                     "kind-of": {
                       "version": "3.2.2",
-                      "resolved": false,
+                      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                       "requires": {
                         "is-buffer": "^1.1.5"
@@ -4580,7 +4580,7 @@
                 },
                 "is-descriptor": {
                   "version": "0.1.6",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
                   "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
                   "requires": {
                     "is-accessor-descriptor": "^0.1.6",
@@ -4590,14 +4590,14 @@
                 },
                 "kind-of": {
                   "version": "5.1.0",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
                   "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
                 }
               }
             },
             "extglob": {
               "version": "2.0.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
               "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
               "requires": {
                 "array-unique": "^0.3.2",
@@ -4612,7 +4612,7 @@
               "dependencies": {
                 "define-property": {
                   "version": "1.0.0",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                   "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                   "requires": {
                     "is-descriptor": "^1.0.0"
@@ -4620,7 +4620,7 @@
                 },
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -4630,7 +4630,7 @@
             },
             "fill-range": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
               "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -4641,7 +4641,7 @@
               "dependencies": {
                 "extend-shallow": {
                   "version": "2.0.1",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                   "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                   "requires": {
                     "is-extendable": "^0.1.0"
@@ -4651,7 +4651,7 @@
             },
             "is-accessor-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
               "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -4659,7 +4659,7 @@
             },
             "is-data-descriptor": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
               "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
               "requires": {
                 "kind-of": "^6.0.0"
@@ -4667,7 +4667,7 @@
             },
             "is-descriptor": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
               "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
               "requires": {
                 "is-accessor-descriptor": "^1.0.0",
@@ -4677,7 +4677,7 @@
             },
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "requires": {
                 "kind-of": "^3.0.2"
@@ -4685,7 +4685,7 @@
               "dependencies": {
                 "kind-of": {
                   "version": "3.2.2",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                   "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                   "requires": {
                     "is-buffer": "^1.1.5"
@@ -4695,17 +4695,17 @@
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             },
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
             },
             "micromatch": {
               "version": "3.1.10",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
               "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
               "requires": {
                 "arr-diff": "^4.0.0",
@@ -4727,12 +4727,12 @@
         },
         "to-fast-properties": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
           "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
         },
         "to-object-path": {
           "version": "0.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
           "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
           "requires": {
             "kind-of": "^3.0.2"
@@ -4740,7 +4740,7 @@
         },
         "to-regex": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
           "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
           "requires": {
             "define-property": "^2.0.2",
@@ -4751,7 +4751,7 @@
         },
         "to-regex-range": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
           "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
           "requires": {
             "is-number": "^3.0.0",
@@ -4760,7 +4760,7 @@
           "dependencies": {
             "is-number": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
               "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
               "requires": {
                 "kind-of": "^3.0.2"
@@ -4770,12 +4770,12 @@
         },
         "trim-right": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
           "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
         },
         "uglify-js": {
           "version": "2.8.29",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
           "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
           "optional": true,
           "requires": {
@@ -4786,7 +4786,7 @@
           "dependencies": {
             "yargs": {
               "version": "3.10.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
               "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
               "optional": true,
               "requires": {
@@ -4800,13 +4800,13 @@
         },
         "uglify-to-browserify": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
           "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
           "optional": true
         },
         "union-value": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
           "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
           "requires": {
             "arr-union": "^3.1.0",
@@ -4817,7 +4817,7 @@
           "dependencies": {
             "extend-shallow": {
               "version": "2.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
               "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
               "requires": {
                 "is-extendable": "^0.1.0"
@@ -4825,7 +4825,7 @@
             },
             "set-value": {
               "version": "0.4.3",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
               "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
               "requires": {
                 "extend-shallow": "^2.0.1",
@@ -4838,7 +4838,7 @@
         },
         "unset-value": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
           "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
           "requires": {
             "has-value": "^0.3.1",
@@ -4847,7 +4847,7 @@
           "dependencies": {
             "has-value": {
               "version": "0.3.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
               "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
               "requires": {
                 "get-value": "^2.0.3",
@@ -4857,7 +4857,7 @@
               "dependencies": {
                 "isobject": {
                   "version": "2.1.0",
-                  "resolved": false,
+                  "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                   "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
                   "requires": {
                     "isarray": "1.0.0"
@@ -4867,24 +4867,24 @@
             },
             "has-values": {
               "version": "0.1.4",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
               "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
             },
             "isobject": {
               "version": "3.0.1",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
               "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
             }
           }
         },
         "urix": {
           "version": "0.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
           "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
         "use": {
           "version": "3.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/use/-/use-3.1.0.tgz",
           "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
           "requires": {
             "kind-of": "^6.0.2"
@@ -4892,14 +4892,14 @@
           "dependencies": {
             "kind-of": {
               "version": "6.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
               "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
             }
           }
         },
         "validate-npm-package-license": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
           "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
           "requires": {
             "spdx-correct": "^3.0.0",
@@ -4908,7 +4908,7 @@
         },
         "which": {
           "version": "1.3.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
           "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
           "requires": {
             "isexe": "^2.0.0"
@@ -4916,23 +4916,23 @@
         },
         "which-module": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
           "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "window-size": {
           "version": "0.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
           "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
           "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         },
         "wrap-ansi": {
           "version": "2.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
           "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
           "requires": {
             "string-width": "^1.0.1",
@@ -4941,7 +4941,7 @@
           "dependencies": {
             "is-fullwidth-code-point": {
               "version": "1.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
               "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
               "requires": {
                 "number-is-nan": "^1.0.0"
@@ -4949,7 +4949,7 @@
             },
             "string-width": {
               "version": "1.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -4961,12 +4961,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
           "version": "1.3.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-1.3.4.tgz",
           "integrity": "sha1-+Aek8LHZ6ROuekgRLmzDrxmRtF8=",
           "requires": {
             "graceful-fs": "^4.1.11",
@@ -4976,17 +4976,17 @@
         },
         "y18n": {
           "version": "3.2.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
           "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
         },
         "yallist": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
           "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
         },
         "yargs": {
           "version": "11.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-11.1.0.tgz",
           "integrity": "sha512-NwW69J42EsCSanF8kyn5upxvjp5ds+t3+udGBeTbFnERA+lF541DDpMawzo4z6W/QrzNM18D+BPMiOBibnFV5A==",
           "requires": {
             "cliui": "^4.0.0",
@@ -5005,17 +5005,17 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
               "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "camelcase": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
             },
             "cliui": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
               "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
               "requires": {
                 "string-width": "^2.1.1",
@@ -5025,7 +5025,7 @@
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
               "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
@@ -5033,7 +5033,7 @@
             },
             "yargs-parser": {
               "version": "9.0.2",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-9.0.2.tgz",
               "integrity": "sha1-nM9qQ0YP5O1Aqbto9I1DuKaMwHc=",
               "requires": {
                 "camelcase": "^4.1.0"
@@ -5043,7 +5043,7 @@
         },
         "yargs-parser": {
           "version": "8.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-8.1.0.tgz",
           "integrity": "sha512-yP+6QqN8BmrgW2ggLtTbdrOyBNSI7zBa4IykmiV5R1wl1JWNxQvWhMfMdmzIYtKU7oP3OOInY/tl2ov3BDjnJQ==",
           "requires": {
             "camelcase": "^4.1.0"
@@ -5051,7 +5051,7 @@
           "dependencies": {
             "camelcase": {
               "version": "4.1.0",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
               "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
             }
           }

--- a/src/angular/projects/spark-core-angular/src/lib/components/sprk-alert/sprk-alert.component.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/components/sprk-alert/sprk-alert.component.ts
@@ -10,7 +10,7 @@ import { dismissAlert } from '@sparkdesignsystem/spark-core/es5/alerts';
       role="alert"
       [attr.data-analytics]="analyticsString">
       <div class="sprk-c-Alert__content">
-        <sprk-icon iconType="{{ icon }}" additionalClasses="sprk-c-Alert__icon sprk-c-Icon--l" aria-hidden="true"></sprk-icon>
+        <sprk-icon iconType="{{ icon }}" additionalClasses="sprk-c-Alert__icon sprk-c-Icon--l sprk-c-Icon--current-color" aria-hidden="true"></sprk-icon>
 
         <p class="sprk-b-TypeBodyTwo">
           <ng-content></ng-content>
@@ -23,7 +23,7 @@ import { dismissAlert } from '@sparkdesignsystem/spark-core/es5/alerts';
         type="button"
         title="Dismiss"
         (click)="alertDismiss($event)">
-        <sprk-icon iconType="close-circle" additionalClasses="sprk-c-Icon--l" aria-hidden="true"></sprk-icon>
+        <sprk-icon iconType="close-circle" additionalClasses="sprk-c-Icon--l sprk-c-Icon--current-color" aria-hidden="true"></sprk-icon>
       </button>
     </div>
   `

--- a/src/patterns/components/alerts/base.hbs
+++ b/src/patterns/components/alerts/base.hbs
@@ -8,7 +8,7 @@ hidden: true
   role="alert"
   data-sprk-alert="container">
   <div class="sprk-c-Alert__content">
-    <svg class="sprk-c-Alert__icon sprk-c-Icon sprk-c-Icon--l" viewBox="{{viewBox}}" aria-hidden="true">
+    <svg class="sprk-c-Alert__icon sprk-c-Icon sprk-c-Icon--l sprk-c-Icon--current-color" viewBox="{{viewBox}}" aria-hidden="true">
       <use xlink:href="#{{icon}}"></use>
     </svg>
 
@@ -24,7 +24,7 @@ hidden: true
     type="button"
     title="Dismiss"
     data-sprk-alert="dismiss">
-    <svg class="sprk-c-Icon sprk-c-Icon--l" viewBox="0 0 64 64" aria-hidden="true">
+    <svg class="sprk-c-Icon sprk-c-Icon--l sprk-c-Icon--current-color" viewBox="0 0 64 64" aria-hidden="true">
       <use xlink:href="#close-circle"></use>
     </svg>
   </button>


### PR DESCRIPTION
- [x] FF - All : alert icons are red, should be currentColor
- [x] FF - All: inline search icon is red, should be black
- [x] FF - All: narrow nav icons are red, should be black
- [x] FF - All: icons not observing overridden stroke-widths (exceptions listed in new checkbox below)

Have all the issues fixed by removing the SVG presentation attributes from the SVGs themselves. Only have 3 outstanding icons that I need to remove presentational code from so that they will take the stroke-width CSS overrides that we are doing. These three will require some time in sketch.

- [ ] FF - All: exclamation, exclamation filled, and information not observing overridden stroke-widths

**Also to note: declaration in alerts for currentColor can be removed in future in favor of reusuable new CSS class for currentColor icons (that was added to HTML), but to avoid a breaking change, we keep the SCSS there for now**