### PR TITLE
fix shrinking error icon with long error msgs

### DIFF
--- a/packages/spark-core/base/inputs/_error-container.scss
+++ b/packages/spark-core/base/inputs/_error-container.scss
@@ -1,5 +1,4 @@
 .sprk-b-ErrorContainer {
-  align-items: center;
   display: flex;
   margin-left: $space-s;
   margin-top: $space-s;
@@ -12,7 +11,6 @@
 .sprk-b-ErrorIcon {
   fill: $text-input-error-color;
   flex: 0 0 auto;
-  align-self: flex-start;
   margin-right: $space-s;
   height: $error-icon-size;
   width: $error-icon-size;

--- a/packages/spark-core/base/inputs/_error-container.scss
+++ b/packages/spark-core/base/inputs/_error-container.scss
@@ -11,6 +11,8 @@
 
 .sprk-b-ErrorIcon {
   fill: $text-input-error-color;
+  flex: 0 0 auto;
+  align-self: flex-start;
   margin-right: $space-s;
   height: $error-icon-size;
   width: $error-icon-size;


### PR DESCRIPTION
Right side is WITH this fix. The left side is the current state (without this fix).
This fixes issue https://github.com/sparkdesignsystem/spark-d
![screen shot 2018-11-19 at 10 56 07 am](https://user-images.githubusercontent.com/2117593/48718762-0004f680-ebea-11e8-9068-2c8289707796.png)
