### PR TITLE
chore(dependencies): bump dom-slider to 1.5.2

### DIFF
--- a/packages/spark-core/package.json
+++ b/packages/spark-core/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@scalescss/scalescss": "6.0.0-1",
     "chai": "^4.1.2",
-    "dom-slider": "1.5.1",
+    "dom-slider": "1.5.2",
     "fontfaceobserver": "^2.0.13",
     "jsdom": "^11.12.0",
     "nyc": "^11.9.0",


### PR DESCRIPTION
Closes [877](https://github.com/sparkdesignsystem/spark-design-system/issues/877)