### PR TITLE
masthead tweaks

### DIFF
--- a/packages/spark-core/components/_masthead.scss
+++ b/packages/spark-core/components/_masthead.scss
@@ -85,6 +85,8 @@
 }
 
 .sprk-c-Masthead__site-links {
+  position: relative;
+
   @media all and (min-width: $masthead-breakpoint) {
     border-right: 1px solid $black-tint-25;
     padding-right: $space-l;

--- a/packages/spark-core/components/_masthead.scss
+++ b/packages/spark-core/components/_masthead.scss
@@ -18,6 +18,11 @@
   left: 0;
   right: 0;
   height: 100%;
+
+  @media all and (min-width: $masthead-breakpoint) {
+    position: sticky;
+    height: auto;
+  }
 }
 
 .sprk-c-Masthead__content,

--- a/packages/spark-core/settings/_settings.scss
+++ b/packages/spark-core/settings/_settings.scss
@@ -500,7 +500,7 @@ $big-nav-bg: $gray-tint-25 !default;
 $big-nav-active-color: $red !default;
 $masthead-logo-max-width: 192px !default;
 $masthead-logo-min-width: 174px !default;
-$mobile-masthead-height: 117px !default;
+$mobile-masthead-height: 113px !default;
 $narrow-nav-left-border: 5px solid $red !default;
 $narrow-nav-link-font-weight: normal !default;
 

--- a/src/assets/drizzle/styles/utility/_toolkit-overrides.scss
+++ b/src/assets/drizzle/styles/utility/_toolkit-overrides.scss
@@ -5,7 +5,8 @@
 }
 
 [data-template-id^='masthead-default'] .sprk-c-Masthead,
-[data-template-id^='masthead-with-extended-navigation'] .sprk-c-Masthead {
+[data-template-id^='masthead-with-extended-navigation'] .sprk-c-Masthead,
+.#{$app-namespace}-c-Preview .sprk-c-Dropdown {
   z-index: 100001;
 }
 

--- a/src/patterns/components/masthead/collection.yaml
+++ b/src/patterns/components/masthead/collection.yaml
@@ -4,6 +4,7 @@ information:
   - There are three custom configurations that you must do in order for the Masthead's narrow navigation to work properly (see below restrictions).
   - The Masthead is "sticky" and content will flow under it.
   - All content used here is placeholder content. Please use your own logo, content, and hrefs.
+  - Make sure you leave the 'data-sprk-masthead' attribute on the main Masthead element as it functions as a Spark JS hook. It's already included in the provided code.
 restrictions:
   - You must configure the size of your own logo asset. If you don't then the logo will be automatically sized
     between the $masthead-logo-max-width (192px) and $masthead-logo-min-width (174px). You can additionally override those

--- a/src/patterns/components/masthead/default.hbs
+++ b/src/patterns/components/masthead/default.hbs
@@ -144,7 +144,7 @@ hasAngularCodeInfo: true
         </li>
 
         <li class="sprk-c-Accordion__item sprk-o-Box">
-          <a class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-u-Width-100" href="#nogo">
+          <a class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@sm" href="#nogo">
             Sign In
           </a>
         </li>

--- a/src/patterns/components/masthead/extended.hbs
+++ b/src/patterns/components/masthead/extended.hbs
@@ -285,7 +285,7 @@ hasAngularCodeInfo: true
             <svg class="sprk-c-Icon sprk-c-Icon--current-color sprk-c-Icon--l" viewBox="0 0 64 64">
               <use xlink:href="#landline" />
             </svg>
-            (555) 555-555
+            (555) 555-5555
           </span>
         </a>
       </li>
@@ -312,15 +312,44 @@ hasAngularCodeInfo: true
         </a>
       </li>
 
-      <li class="sprk-c-Accordion__item">
-        <a class="sprk-c-Accordion__summary" href="#">
+      <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
+        <a
+          aria-controls="details4"
+          class="sprk-c-Accordion__summary"
+          data-sprk-toggle="trigger"
+          data-sprk-toggle-type="accordion"
+          href="#">
           <span class="sprk-b-TypeBodyOne sprk-c-Accordion__heading">
             <svg class="sprk-c-Icon sprk-c-Icon--current-color sprk-c-Icon--l sprk-u-mrs" viewBox="0 0 64 64">
               <use xlink:href="#user" />
             </svg>
             My Account
           </span>
+
+          <svg class="sprk-c-Icon sprk-c-Icon--l sprk-c-Accordion__icon" data-sprk-toggle="icon" viewBox="0 0 64 64">
+            <use xlink:href="#chevron-down"></use>
+          </svg>
         </a>
+
+        <ul id="details4" class="sprk-b-List sprk-b-List--bare sprk-c-Accordion__details" data-sprk-toggle="content">
+          <li>
+            <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-pam" href="#">
+              Change Username
+            </a>
+          </li>
+
+          <li>
+            <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-pam" href="#">
+              Change Password
+            </a>
+          </li>
+
+          <li>
+            <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-pam" href="#">
+              Sign Out
+            </a>
+          </li>
+        </ul>
       </li>
     </ul>
   </nav>

--- a/src/patterns/components/masthead/extended.hbs
+++ b/src/patterns/components/masthead/extended.hbs
@@ -65,24 +65,22 @@ hasAngularCodeInfo: true
           <ul class="sprk-c-Dropdown__links">
             <li class="sprk-c-Dropdown__item">
               <a class="sprk-c-Dropdown__link" href="#nogo" data-sprk-dropdown-choice="Choice Title 1" role="option">
-                <p class="sprk-b-TypeBodyOne">Choice Title</p>
-                <p>Information about this choice</p>
-                <p>More information</p>
+                <p class="sprk-b-TypeBodyOne">Choice Title 1</p>
+                <p>Info here.</p>
               </a>
             </li>
 
             <li class="sprk-c-Dropdown__item" data-sprk-dropdown-choice="Choice Title 2">
               <a class="sprk-c-Dropdown__link" href="#nogo" role="option">
-                <p class="sprk-b-TypeBodyOne">Choice Title</p>
-                <p>Information about this choice</p>
-                <p>More information</p>
+                <p class="sprk-b-TypeBodyOne">Choice Title 2</p>
+                <p>Info here.</p>
               </a>
             </li>
           </ul>
 
           <div class="sprk-c-Dropdown__footer sprk-u-TextAlign--center">
             <a class="sprk-c-Button sprk-c-Button--compact sprk-c-Button--tertiary" href="#nogo">
-              Go Elsewhere
+              Placeholder
             </a>
           </div>
         </div>

--- a/src/patterns/components/masthead/extended.hbs
+++ b/src/patterns/components/masthead/extended.hbs
@@ -88,7 +88,7 @@ hasAngularCodeInfo: true
         </div>
       </div>
 
-      <ul class="sprk-o-Stack__item sprk-o-HorizontalList sprk-o-HorizontalList--spacing-large sprk-o-Stack--center-column">
+      <ul class="sprk-o-Stack__item sprk-o-HorizontalList sprk-o-HorizontalList--spacing-large sprk-o-Stack--center-column sprk-u-Position--relative">
         <li>
           <a class="sprk-b-Link sprk-b-Link--plain sprk-b-Link--standalone" href="tel:555-555-5555">
             (555) 555-5555
@@ -123,7 +123,7 @@ hasAngularCodeInfo: true
             <span class="sprk-u-ScreenReaderText">User Account</span>
           </a>
 
-          <div class="sprk-c-Dropdown sprk-u-Display--none sprk-u-Right--zero sprk-u-mrs" data-sprk-dropdown="dropdown02">
+          <div class="sprk-c-Dropdown sprk-u-Display--none sprk-u-Right--zero" data-sprk-dropdown="dropdown02">
             <div class="sprk-c-Dropdown__header">
               <h2 class="sprk-c-Dropdown__title sprk-b-TypeDisplayEight">
                 My Account

--- a/src/patterns/utilities/single-property/height.hbs
+++ b/src/patterns/utilities/single-property/height.hbs
@@ -1,0 +1,26 @@
+---
+doclayout: true
+order: 8
+name: Height
+description:
+  This utility sets the height of an
+  element to a percentage value.
+---
+<table class="drizzle-c-Table">
+  <colgroup>
+    <col class="sprk-u-Width-40">
+    <col>
+  </colgroup>
+  <thead>
+    <tr>
+      <th>Class</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">.sprk-u-Height--100</td>
+      <td>Changes the height of the element to 100 percent.</td>
+    </tr>
+  </tbody>
+</table>


### PR DESCRIPTION
- [x] add possible max-width on sign in btn?
- [x] height of 'top:' of narrow nav needs to be reset for new svg that was added
- [x] dropdown user account opens up out to the right
- [x] make my account an accordion in narrow nav
- [x] add data-sprk-masthead documention
- [x] document height 100 util