### PR TITLE
feat(package): bump dom-slider

### DIFF
--- a/packages/spark-core/package.json
+++ b/packages/spark-core/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@scalescss/scalescss": "6.0.0-1",
     "chai": "^4.1.2",
-    "dom-slider": "1.5.2",
+    "dom-slider": "1.5.3",
     "fontfaceobserver": "^2.0.13",
     "jsdom": "^11.12.0",
     "nyc": "^11.9.0",


### PR DESCRIPTION
I made this PR: https://github.com/BrentonCozby/dom-slider/pull/7 yesterday. The new version of dom-slider (1.5.3) fixes an issue with greedy monkey-patching of Node.prototype which is causing issues in JSDOM-based testing environments.