### PR TITLE
Reskin links with green as primary color

### DIFF
--- a/packages/spark-core/base/_links.scss
+++ b/packages/spark-core/base/_links.scss
@@ -5,34 +5,35 @@
 .sprk-b-Link {
   color: $sprk-link-color;
   border-bottom: $sprk-link-underline-width solid $sprk-link-underline-color;
-  font-weight: $sprk-link-inline-font-weight;
+  font-weight: $sprk-link-font-weight;
   position: relative;
   text-decoration: none;
   transition: $sprk-link-transition;
 
   &:visited {
     color: $sprk-link-visited-color;
-    border-bottom: $sprk-link-underline-width solid $sprk-link-visited-color;
+    border-bottom: $sprk-link-underline-width solid $sprk-link-underline-visited-color;
   }
 
   &:hover,
   &:active,
   &:focus {
-    color: $sprk-link-underline-color;
-    border-bottom: $sprk-link-underline-width solid $sprk-link-underline-color;
+    color: $sprk-link-hover-color;
+    border-bottom: $sprk-link-underline-width solid $sprk-link-hover-color;
   }
 }
 
 .sprk-b-Link--standalone {
   color: $sprk-link-standalone-color;
-  border: $sprk-link-underline-width solid transparent;
+  border-bottom: $sprk-link-underline-width solid $sprk-link-standalone-underline-color;
   font-weight: $sprk-link-standalone-font-weight;
 
   &:hover,
   &:active,
   &:focus {
     transition: $sprk-link-transition;
-    border-bottom: $sprk-link-underline-width solid $sprk-link-underline-color;
+    color: $sprk-link-standalone-hover-color;
+    border-bottom: $sprk-link-underline-width solid $sprk-link-standalone-hover-underline-color;
   }
 }
 
@@ -47,6 +48,40 @@
   &:active,
   &:focus {
     color: $sprk-link-muted-color;
+    border-bottom: $sprk-link-muted-underline-width solid $sprk-link-muted-hover-underline-color;
+  }
+}
+
+.sprk-b-Link--icon {
+  border: $sprk-link-icon-underline-width solid $sprk-link-icon-underline-color;
+
+  &:hover,
+  &:active,
+  &:focus,
+  &:visited {
+    border: $sprk-link-icon-underline-width solid $sprk-link-icon-underline-color;
+  }
+}
+
+.sprk-b-Link--icon .sprk-c-Icon {
+  color: $sprk-link-icon-color;
+  stroke: $sprk-link-icon-color;
+  fill: $sprk-link-icon-color;
+}
+
+.sprk-b-Link--disabled,
+.sprk-b-Link--disabled .sprk-c-Icon {
+  color: $sprk-link-disabled-color;
+  pointer-events: none;
+  border-bottom: $sprk-link-disabled-underline-width solid $sprk-link-disabled-color;
+  font-weight: $sprk-link-disabled-font-weight;
+
+  &:visited,
+  &:hover,
+  &:active,
+  &:focus {
+    border-bottom: $sprk-link-disabled-underline-width solid $sprk-link-disabled-color;
+    color: $sprk-link-disabled-color;
   }
 }
 
@@ -58,27 +93,5 @@
   &:focus,
   &:visited {
     border: none;
-  }
-}
-
-.sprk-b-Link--disabled {
-  color: $sprk-link-disabled-color;
-  pointer-events: none;
-  border-bottom: $sprk-link-underline-width solid $sprk-link-disabled-color;
-  font-weight: $sprk-link-disabled-font-weight;
-
-  &:visited {
-    color: $sprk-link-disabled-color;
-    border-bottom: $sprk-link-underline-width solid $sprk-link-disabled-color;
-  }
-
-  &:hover,
-  &:active,
-  &:focus {
-    color: $sprk-link-disabled-color;
-  }
-
-  &::after {
-    background: $sprk-link-disabled-color;
   }
 }

--- a/packages/spark-core/settings/_settings.scss
+++ b/packages/spark-core/settings/_settings.scss
@@ -311,18 +311,28 @@ $sprk-btn-tertiary-letter-spacing: normal !default;
 //
 // Links
 ///
-$sprk-link-color: $sprk-black !default;
-$sprk-link-disabled-color: $sprk-black-tint-50;
-$sprk-link-muted-color: $sprk-black-tint-75;
-$sprk-link-standalone-color: $sprk-red !default;
 $sprk-link-transition: 0.3s !default;
-$sprk-link-underline-color: $sprk-red !default;
-$sprk-link-underline-visited-color: $sprk-red !default;
-$sprk-link-underline-width: 0.0625em !default;
-$sprk-link-visited-color: $sprk-red !default;
+$sprk-link-color: $sprk-black !default;
+$sprk-link-hover-color: $sprk-black !default;
+$sprk-link-underline-color: $sprk-gray-dark !default;
+$sprk-link-underline-width: 0.09375rem !default;
+$sprk-link-font-weight: bold !default;
+$sprk-link-visited-color: $sprk-black-tint-75 !default;
+$sprk-link-underline-visited-color: $sprk-gray-dark !default;
+$sprk-link-standalone-color: $sprk-black !default;
+$sprk-link-standalone-underline-color: transparent !default;
 $sprk-link-standalone-font-weight: bold !default;
-$sprk-link-inline-font-weight: normal !default;
+$sprk-link-standalone-hover-color: $sprk-green !default;
+$sprk-link-standalone-hover-underline-color: $sprk-green !default;
+$sprk-link-icon-underline-width: 0 !default;
+$sprk-link-icon-underline-color: transparent !default;
+$sprk-link-icon-color: $sprk-green !default;
+$sprk-link-muted-color: $sprk-gray-dark !default;
+$sprk-link-muted-underline-width: 0 !default;
+$sprk-link-muted-hover-underline-color: $sprk-gray-dark !default;
+$sprk-link-disabled-color: $sprk-gray-dark !default;
 $sprk-link-disabled-font-weight: bold !default;
+$sprk-link-disabled-underline-width: 0 !default;
 
 //
 // Lists

--- a/src/angular/projects/spark-core-angular/src/lib/components/sprk-link/sprk-link.component.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/components/sprk-link/sprk-link.component.ts
@@ -41,6 +41,9 @@ export class SparkLinkComponent {
       case 'plain':
         classArray.push('sprk-b-Link--plain');
         break;
+      case 'icon':
+        classArray.push('sprk-b-Link--standalone sprk-b-Link--icon');
+        break;
       default:
         break;
     }

--- a/src/angular/projects/spark-core-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -12,7 +12,7 @@ import {
   template: `
     <div class="{{ additionalClasses }}" [attr.data-id]="idString">
       <a
-        class="{{ titleFontClass }} sprk-b-Link sprk-b-Link--standalone sprk-b-Link--plain"
+        class="{{ titleFontClass }} sprk-b-Link sprk-b-Link--standalone sprk-b-Link--icon"
         href="#"
         (click)="toggle($event)"
         [attr.aria-expanded]="isOpen ? 'true' : 'false'"

--- a/src/angular/src/app/spark-docs/link-docs/link-docs.component.ts
+++ b/src/angular/src/app/spark-docs/link-docs/link-docs.component.ts
@@ -14,6 +14,19 @@ import { Component, OnInit } from '@angular/core';
       >
         This is a standard Spark Link!
       </sprk-link>
+
+      <p>
+        Here is a
+        <sprk-link
+          href="/links"
+          idString="link-1"
+          analyticsString="object.action.event"
+          target="_blank"
+        >
+          link
+        </sprk-link>
+        in the middle of a line
+      </p>
     </div>
 
     <div class="drizzle-o-ContentGrouping">
@@ -59,7 +72,7 @@ import { Component, OnInit } from '@angular/core';
       <h2 class="drizzle-b-h2">Icon With Text Link</h2>
 
       <sprk-link
-        linkType="plain"
+        linkType="icon"
         href="/links"
         idString="link-5"
         analyticsString="object.action.event"

--- a/src/pages/tests/link.hbs
+++ b/src/pages/tests/link.hbs
@@ -53,6 +53,37 @@ layout: blank
 </div>
 
 <div class="drizzle-c-Space-inset-m">
+  <h2>Link with Icon</h2>
+</div>
+
+<div class="drizzle-c-Space-inset-m">
+  <a
+    class="sprk-b-Link sprk-b-Link--icon sprk-b-Link--standalone"
+    href="#nogo"
+    data-id="link-1"
+    data-analytics="object.action.event">
+    <svg class="sprk-c-Icon sprk-c-Icon--l sprk-u-mrs sprk-c-Icon--current-color" viewBox="0 0 100 100">
+      <use xlink:href="#communication" />
+    </svg>
+
+    This is text
+  </a>
+</div>
+<div class="drizzle-c-Space-inset-m">
+  <a
+    class="sprk-b-Link sprk-b-Link--icon sprk-b-Link--standalone sprk-b-Link--disabled"
+    href="#nogo"
+    data-id="link-1"
+    data-analytics="object.action.event">
+    <svg class="sprk-c-Icon sprk-c-Icon--l sprk-u-mrs sprk-c-Icon--current-color" viewBox="0 0 100 100">
+      <use xlink:href="#communication" />
+    </svg>
+
+    I'm disabled
+  </a>
+</div>
+
+<div class="drizzle-c-Space-inset-m">
   <h2>Disabled Link</h2>
 </div>
 

--- a/src/patterns/components/footer/footer.hbs
+++ b/src/patterns/components/footer/footer.hbs
@@ -67,31 +67,31 @@ hasAngularCode: true
 
             <ul class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--medium sprk-b-List sprk-b-List--bare">
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   About This
                 </a>
               </li>
 
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   About This Other Thing
                 </a>
               </li>
 
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   About That
                 </a>
               </li>
 
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   Link Item
                 </a>
               </li>
 
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   This Link Item
                 </a>
               </li>
@@ -105,25 +105,25 @@ hasAngularCode: true
 
             <ul class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--medium sprk-b-List sprk-b-List--bare">
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   About This Other Thing
                 </a>
               </li>
 
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   About This
                 </a>
               </li>
 
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   About That
                 </a>
               </li>
 
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   Link Item
                 </a>
               </li>
@@ -137,22 +137,22 @@ hasAngularCode: true
 
             <ul class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--medium sprk-b-List sprk-b-List--bare">
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   Share Your Screen
                 </a>
               </li>
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   Opt Out
                 </a>
               </li>
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   Disclosures and Other Things
                 </a>
               </li>
               <li class="sprk-o-Stack__item">
-                <a class="sprk-b-Link sprk-b-Link--muted sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
+                <a class="sprk-b-Link sprk-b-Link--standalone sprk-u-FontWeight--normal" href="#nogo">
                   We Want Your Feedback
                 </a>
               </li>

--- a/src/patterns/components/links/angular/code/icon-text.hbs
+++ b/src/patterns/components/links/angular/code/icon-text.hbs
@@ -1,4 +1,4 @@
-<sprk-link linkType="plain" href="#" idString="link-3" analyticsString="object.action.event">
+<sprk-link linkType="icon" href="#" idString="link-3" analyticsString="object.action.event">
   <sprk-icon iconType="communication" additionalClasses="sprk-c-Icon--l sprk-c-Icon--current-color sprk-u-mrs"></sprk-icon>
   Message Us
 </sprk-link>

--- a/src/patterns/components/links/angular/info/inline.hbs
+++ b/src/patterns/components/links/angular/info/inline.hbs
@@ -27,7 +27,7 @@
       </td>
 
       <td>
-        Can be 'standalone', 'plain', or 'disabled'. Will cause the appropriate variant type to render.
+        Can be 'standalone', 'icon', 'plain', or 'disabled'. Will cause the appropriate variant type to render.
       </td>
     </tr>
 

--- a/src/patterns/components/links/collection.yaml
+++ b/src/patterns/components/links/collection.yaml
@@ -10,45 +10,77 @@ restrictions:
     ("link-1", "link-2", "link-3", etc).
 sparkPackageCore: true
 variableTable:
-  $sprk-link-color:
-    default: $sprk-black
-    description: The default link color.
-  $sprk-link-disabled-color:
-    default: $sprk-black-tint-50
-    description: The disabled link color.
-  $sprk-link-muted-color:
-    default: $sprk-black-tint-75
-    description: The muted link color.
-  $sprk-link-standalone-color:
-    default: $sprk-red
-    description: The standalone link color.
   $sprk-link-transition:
     default: 0.3s
     description: The transition timing for hover, active and focus style application.
+  $sprk-link-color:
+    default: $sprk-black
+    description: The default link color.
+  $sprk-link-hover-color:
+    default: $sprk-black
+    description: Sets the color of the link text on the hover state.
   $sprk-link-underline-color:
-    default: $sprk-red
+    default: $sprk-gray-dark
     description: Sets the color of the link underline.
-  $sprk-link-underline-visited-color:
-    default: $sprk-red
-    description: Sets the color of the link underline on visited links.
   $sprk-link-underline-width:
-    default: 0.0625em
+    default: 0.09375em
     description: Sets the size of the link underline.
+  $sprk-link-font-weight:
+    default: bold
+    description: The default font weight for links.
   $sprk-link-visited-color:
-    default: $sprk-red
+    default: $sprk-black-tint-75
     description: Sets the color of visited links.
+  $sprk-link-underline-visited-color:
+    default: $sprk-black-tint-75
+    description: Sets the color of the link underline on visited links.
+  $sprk-link-standalone-color:
+    default: $sprk-black
+    description: The standalone link color.
+  $sprk-link-standalone-underline-color:
+    default: transparent
+    description: Sets the color of the standalone link underline.
   $sprk-link-standalone-font-weight:
     default: bold
     description: The font weight for standalone links.
-  $sprk-link-inline-font-weight:
-    default: normal
-    description: The font weight for inline links.
+  $sprk-link-standalone-hover-color:
+    default: $sprk-green
+    description: Sets the color of the standalone link in the hover state.
+  $sprk-link-standalone-hover-underline-color:
+    default: $sprk-green
+    description: Sets the color of the standalone link underline in the hover state.
+  $sprk-link-icon-underline-width:
+    default: 0
+    description: Sets the underline width for links containing icons.
+  $sprk-link-icon-underline-color:
+    default: transparent
+    description: Sets the underline color for links containing icons.
+  $sprk-link-icon-color:
+    default: $sprk-green
+    description: Sets the color of text and icons in links containing colors.
+  $sprk-link-muted-color:
+    default: $sprk-gray-dark
+    description: The muted link color.
+  $sprk-link-muted-underline-width:
+    default: 0
+    description: asdf
+  $sprk-link-muted-hover-underline-color:
+    default: $sprk-gray-dark
+    description: asdf
+  $sprk-link-disabled-color:
+    default: $sprk-gray-dark
+    description: The disabled link color.
   $sprk-link-disabled-font-weight:
     default: bold
     description: The font weight for disabled links.
+  $sprk-link-disabled-underline-width:
+    default: 0
+    description: The width of the underline for disabled links.
 classTable:
   .sprk-b-Link--standalone:
     description: Sets the styles for the standalone link variant.
+  .sprk-b-Link--icon:
+    description: Sets the styles for the variant containing an icon.
   .sprk-b-Link--muted:
     description: Sets the color styles for the muted link variant.
   .sprk-b-Link--plain:

--- a/src/patterns/components/links/icon-text.hbs
+++ b/src/patterns/components/links/icon-text.hbs
@@ -12,7 +12,7 @@ hasAngularCode: true
 hasAngularCodeInfo: true
 ---
 <a
-  class="sprk-b-Link sprk-b-Link--plain"
+  class="sprk-b-Link sprk-b-Link--icon sprk-b-Link--standalone"
   href="#nogo"
   data-id="link-1"
   data-analytics="object.action.event">

--- a/src/patterns/components/toggle/base.hbs
+++ b/src/patterns/components/toggle/base.hbs
@@ -5,7 +5,7 @@ hasAngularCode: true
 hasAngularCodeInfo: true
 ---
 <div data-sprk-toggle="container" data-id="toggle-1">
-  <a class="sprk-b-TypeBodyThree sprk-b-Link sprk-b-Link--standalone sprk-b-Link--plain" data-sprk-toggle="trigger" href="#">
+  <a class="sprk-b-TypeBodyThree sprk-b-Link sprk-b-Link--icon sprk-b-Link--standalone" data-sprk-toggle="trigger" href="#">
       <svg class="sprk-c-Icon sprk-c-Icon--toggle sprk-u-mrs" data-sprk-toggle="icon" viewBox="0 0 64 64">
         <use xlink:href="#chevron-down"></use>
       </svg>


### PR DESCRIPTION
This PR replaces https://github.com/sparkdesignsystem/spark-design-system/pull/934

## What does this PR do?
Updating styles for links. Links are now almost exclusively black. Inline links have a gray underline when they are not visited and a black underline when they are visited. Standalone links have a black underline that fades in on hover. Disabled links are gray with a gray underline.

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.
### Documentation
 - [x] Update Spark Docs Vanilla
 - [x] Update Spark Docs Angular
 - [x] Update Component Sass Var/Class Modifier table

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Build Component in Spark Angular
 - [x] Unit Testing in Spark Vanilla (100% coverage, 100% passing)
 - [x] Unit Testing in Spark Angular (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Design Review
 - [ ] Design reviewed and approved

Issue https://github.com/sparkdesignsystem/spark-design-system/issues/933