### PR TITLE
Updating Divider color, thickness, and docs

### DIFF
--- a/packages/spark-core/settings/_settings.scss
+++ b/packages/spark-core/settings/_settings.scss
@@ -121,7 +121,8 @@ $sprk-page-title-mark-padding-wide-viewport: 0 0 $sprk-space-m;
 
 // Display One
 $sprk-color-display-one: $sprk-black !default;
-$sprk-font-family-display-one: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-display-one: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-display-one: 2.75rem !default;
 $sprk-font-size-display-one-wide: 3.375rem !default;
 $sprk-type-display-one-breakpoint: 43.75rem !default;
@@ -131,7 +132,8 @@ $sprk-line-height-display-one-wide: 1.03 !default;
 
 // Display Two
 $sprk-color-display-two: $sprk-black !default;
-$sprk-font-family-display-two: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-display-two: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-display-two: 2rem !default;
 $sprk-font-size-display-two-wide: 2.5rem !default;
 $sprk-type-display-two-breakpoint: 43.75rem !default;
@@ -141,7 +143,8 @@ $sprk-line-height-display-two-wide: 1 !default;
 
 // Display Three
 $sprk-color-display-three: $sprk-black !default;
-$sprk-font-family-display-three: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-display-three: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-display-three: 1.75rem !default;
 $sprk-font-size-display-three-wide: 2.125rem !default;
 $sprk-type-display-three-breakpoint: 43.75rem !default;
@@ -151,55 +154,63 @@ $sprk-line-height-display-three-wide: 1.32 !default;
 
 // Display Four
 $sprk-color-display-four: $sprk-black !default;
-$sprk-font-family-display-four: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-display-four: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-display-four: 1.625rem !default;
 $sprk-font-weight-display-four: bold !default;
 $sprk-line-height-display-four: 1.23 !default;
 
 // Display Five
 $sprk-color-display-five: $sprk-black !default;
-$sprk-font-family-display-five: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-display-five: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-display-five: 1.25rem !default;
 $sprk-font-weight-display-five: 500 !default;
 $sprk-line-height-display-five: 1.2 !default;
 
 // Display Six
 $sprk-color-display-six: $sprk-black !default;
-$sprk-font-family-display-six: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-display-six: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-display-six: 1.25rem !default;
 $sprk-font-weight-display-six: 300 !default;
 $sprk-line-height-display-six: 1.2 !default;
 
 // Display Seven
-$sprk-font-family-display-seven: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-display-seven: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-display-seven: 1rem !default;
 $sprk-color-display-seven: $sprk-black !default;
 $sprk-line-height-display-seven: 1 !default;
 $sprk-font-weight-display-seven: 500 !default;
 
 // Body One
-$sprk-font-family-body-one: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-body-one: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-body-one: 0.9375rem !default;
 $sprk-color-body-one: $sprk-black !default;
 $sprk-line-height-body-one: 1.6 !default;
 $sprk-font-weight-body-one: 500 !default;
 
 // Body Two
-$sprk-font-family-body-two: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-body-two: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-body-two: 0.9375rem !default;
 $sprk-color-body-two: $sprk-black !default;
 $sprk-line-height-body-two: 1.6 !default;
 $sprk-font-weight-body-two: 300 !default;
 
 // Body Three
-$sprk-font-family-body-three: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-body-three: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-body-three: 0.9375rem !default;
 $sprk-color-body-three: $sprk-black !default;
 $sprk-line-height-body-three: 2 !default;
 $sprk-font-weight-body-three: 300 !default;
 
 // Body Four
-$sprk-font-family-body-four: RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif !default;
+$sprk-font-family-body-four: RocketSans, Helvetica, 'Helvetica Neue', Arial,
+  sans-serif !default;
 $sprk-font-size-body-four: 0.8125rem !default;
 $sprk-color-body-four: $sprk-black !default;
 $sprk-line-height-body-four: 1.84 !default;
@@ -227,13 +238,15 @@ $sprk-alert-icon-size: 40px !default;
 $sprk-alert-font-size: 1rem;
 $sprk-alert-font-weight: 400;
 $sprk-alert-line-height: 1.5;
-$sprk-alert-content-padding: $sprk-space-m $sprk-space-m $sprk-space-m $sprk-space-misc-a;
+$sprk-alert-content-padding: $sprk-space-m $sprk-space-m $sprk-space-m
+  $sprk-space-misc-a;
 $sprk-alert-dismiss-padding: $sprk-space-m;
 $sprk-alert-icon-margin: 0 $sprk-space-misc-a 0 0;
 $sprk-alert-shadow: 0 2px 5px rgba(0, 0, 0, 0.2) !default;
 $sprk-alert-shadow-info: inset $sprk-alert-bar-width 0 0 $sprk-alert-color-info !default;
 $sprk-alert-shadow-hover-info: inset -80px 0 0 $sprk-alert-color-info !default;
-$sprk-alert-shadow-success: inset $sprk-alert-bar-width 0 0 $sprk-alert-color-success !default;
+$sprk-alert-shadow-success: inset $sprk-alert-bar-width 0 0
+  $sprk-alert-color-success !default;
 $sprk-alert-shadow-hover-success: inset -80px 0 0 $sprk-alert-color-success !default;
 $sprk-alert-shadow-fail: inset $sprk-alert-bar-width 0 0 $sprk-alert-color-fail !default;
 $sprk-alert-shadow-hover-fail: inset -80px 0 0 $sprk-alert-color-fail !default;
@@ -468,7 +481,8 @@ $sprk-toggle-transistion-timing: 0.3s ease !default;
 //
 // Dividers
 ///
-$sprk-divider-border: 1px solid $sprk-black-tint-25 !default;
+$sprk-divider-color: rgb(230, 230, 230) !default;
+$sprk-divider-border: 2px solid $sprk-divider-color !default;
 
 //
 // Dropdown

--- a/src/patterns/components/dividers/collection.yaml
+++ b/src/patterns/components/dividers/collection.yaml
@@ -1,19 +1,19 @@
 description: |
-  This is used primarily when you want to separate a page into sections. It represents a thematic break between paragraph-level elements.
-  Think of it as a way to distinguish topics within HTML. It’s a way to visually distinguish between 2 different topics, sections, paragraphs, etc.
-
-  Paragraph section 1.
-  <hr>
-  Paragraph section 2.
-  <hr>
-  Paragraph section 3.
-  <hr>
+  Dividers are used for visually breaking up sections of a page.
 restrictions:
-  - The data-id property is provided as a hook for automated tools. If you have multiple
-    instances of the same variant of a component on the same page, make sure each instance
-    has a unique data-id property ("divider-1", "divider-2", etc).
+  - The &lt;hr&gt; element has the same style as dividers, but should only be used
+    when there is a thematic break between paragraph-level elements, for
+    example, a change of scene in a story or a shift of topic within a section.
+    If you are simply creating a visual separation, use a divider.
+  - The data-id property is provided as a hook for automated tools. If you have
+    multiple instances of the same variant of a component on the same page, make
+    sure each instance has a unique data-id property ("divider-1", "divider-2",
+    etc).
 sparkPackageCore: true
 variableTable:
   $sprk-divider-border:
-    default: 1px solid $sprk-black-tint-25
+    default: 2px solid $sprk-divider-color
     description: Sets the divider border.
+  $sprk-divider-color:
+    default: rgb(230, 230, 230)
+    description: Sets the color of the divider.


### PR DESCRIPTION
## What does this PR do?
This updates the color, thickness, and docs for Dividers. I hard-coded the color because it is not a color we want used anywhere else due to accessibility concerns. No markup was changed. This PR closes #919

### Screenshot
<img width="835" alt="screen shot 2018-12-27 at 3 52 04 pm" src="https://user-images.githubusercontent.com/308696/50494168-a2857600-09ef-11e9-9e97-09f510a1c55f.png">

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.
### Documentation
 - [x] Update Spark Docs Vanilla
 - [x] Update Component Sass Var/Class Modifier table

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Unit Testing in Spark Vanilla (100% coverage, 100% passing)

### Accessibility
This is a completely superficial element. The color doesn't pass color contrast guidelines, but it doesn't need to.

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Design Review
 - [ ] Design review