### PR TITLE
Money input $ gets misplaced when field label wraps to multiple lines

### DIFF
--- a/packages/spark-core/base/inputs/_text-icon-input.scss
+++ b/packages/spark-core/base/inputs/_text-icon-input.scss
@@ -6,8 +6,8 @@
     font-weight: $sprk-input-text-icon-font-weight;
     line-height: 1;
     margin-left: $sprk-input-text-icon-offset-x;
-    margin-top: $sprk-input-text-icon-offset-y;
     position: absolute;
+    top: calc(100% - #{$sprk-input-text-icon-offset-y});
     z-index: $sprk-input-text-icon-z-index;
   }
 }

--- a/packages/spark-core/settings/_settings.scss
+++ b/packages/spark-core/settings/_settings.scss
@@ -535,7 +535,7 @@ $sprk-date-picker-years-modal-max-height: 500px !default;
 // Text Icon Inputs
 ///
 $sprk-input-text-icon-offset-x: $sprk-space-m !default;
-$sprk-input-text-icon-offset-y: 38px !default;
+$sprk-input-text-icon-offset-y: 2em !default;
 $sprk-input-text-icon-font-size: 1rem !default;
 $sprk-input-text-icon-font-weight: 700 !default;
 $sprk-text-input-has-text-icon-padding: 12px 13px 12px 37px !default;
@@ -728,7 +728,8 @@ $sprk-masthead-selector-border: 2px solid $sprk-black-tint-25 !default;
 $sprk-masthead-selector-font-weight: 300 !default;
 $sprk-masthead-selector-border-radius: 5px !default;
 $sprk-masthead-selector-dropdown-border-bottom-mask-open: 2px solid $sprk-gray !default;
-$sprk-masthead-selector-dropdown-box-shadow-mask-open: 0 5px 10px rgba(0, 0, 0, 0.1) !default;
+$sprk-masthead-selector-dropdown-box-shadow-mask-open: 0 5px 10px
+  rgba(0, 0, 0, 0.1) !default;
 $sprk-masthead-selector-border-color-mask-open: $sprk-white !default;
 $sprk-masthead-selector-font-color: $sprk-black !default;
 $sprk-masthead-selector-bg-color: $sprk-white !default;

--- a/src/patterns/components/inputs/collection.yaml
+++ b/src/patterns/components/inputs/collection.yaml
@@ -361,7 +361,7 @@ variableTable:
     default: $sprk-space-m
     description: The X offset of text icons inside input elements.
   $sprk-input-text-icon-offset-y:
-    default: 38px
+    default: 2em
     description: The Y offset of text icons inside input elements.
   $sprk-input-text-icon-font-size:
     default: 1rem


### PR DESCRIPTION
## What does this PR do?
This PR updates the positioning of the money input `$` so that no matter the length of the label the `$` does not get misplaced in the text box
Fixes #1083 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.
### Documentation
 - [X] Update Spark Docs Angular
 - [X] Update Spark Docs Vanilla
 - [X] Update Component Sass Var/Class Modifier table

### Code
 - [X] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [X] Build Component in Spark Angular
 - [X] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
 - [X] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)

### Accessibility
- [X] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [X] Google Chrome
  - [X] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [X] Apple Safari
  - [X] Apple Safari (Mobile)

### Design Review
 - [x] Design reviewed and approved

### Screenshots
![screen shot 2019-01-18 at 2 55 50 pm](https://user-images.githubusercontent.com/8762118/51411920-b8daa980-1b37-11e9-8929-964d1d416664.png)
![screen shot 2019-01-18 at 2 56 16 pm](https://user-images.githubusercontent.com/8762118/51411921-b8daa980-1b37-11e9-9454-28b0a43227fd.png)

