### PR TITLE
Fix bug #1131

### DIFF
--- a/packages/spark-core/base/inputs/_selection-container.scss
+++ b/packages/spark-core/base/inputs/_selection-container.scss
@@ -14,6 +14,7 @@
 
 .sprk-b-SelectionContainer [type='radio'],
 .sprk-b-SelectionContainer [type='checkbox'] {
+  flex: 0 0 auto;
   height: $sprk-selection-container-input-height;
   width: $sprk-selection-container-input-width;
   margin: $sprk-selection-container-input-margin;

--- a/src/angular/projects/spark-core-angular/src/lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.component.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.component.ts
@@ -68,9 +68,7 @@ export class SparkTabbedNavigationComponent implements AfterContentInit {
 
   @HostListener('keydown', ['$event'])
   onKeydown($event) {
-    const isPanel = (event.target as HTMLTextAreaElement).classList.contains(
-      'sprk-c-Tabs__content'
-    );
+    const isPanel = $event.target.classList.contains('sprk-c-Tabs__content');
     if (isPanel) {
       return;
     }

--- a/src/angular/projects/spark-core-angular/src/lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.component.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.component.ts
@@ -68,6 +68,13 @@ export class SparkTabbedNavigationComponent implements AfterContentInit {
 
   @HostListener('keydown', ['$event'])
   onKeydown($event) {
+    const isPanel = (event.target as HTMLTextAreaElement).classList.contains(
+      'sprk-c-Tabs__content'
+    );
+    if (isPanel) {
+      return;
+    }
+
     const keys = {
       end: 35,
       home: 36,


### PR DESCRIPTION
## What does this PR do?
Adds a check to make sure the keydown event didn't happen while on the tab panel.
Still uses the Angular @HostListener so that event listening is setup and tore down appropriately. 

### Associated Issue 
Fixes https://github.com/sparkdesignsystem/spark-design-system/issues/1131.

### Code
 - [x] Build Component in Spark Angular
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
