### PR TITLE
fix bug #1104

### DIFF
--- a/packages/spark-core/base/inputs/_selection-container.scss
+++ b/packages/spark-core/base/inputs/_selection-container.scss
@@ -14,6 +14,7 @@
 
 .sprk-b-SelectionContainer [type='radio'],
 .sprk-b-SelectionContainer [type='checkbox'] {
+  flex: 0 0 auto;
   height: $sprk-selection-container-input-height;
   width: $sprk-selection-container-input-width;
   margin: $sprk-selection-container-input-margin;


### PR DESCRIPTION
## What does this PR do?
Fixes a bug in Safari mobile where long checkbox labels causes the checkbox to shrink.

### Associated Issue 
Fixes https://github.com/sparkdesignsystem/spark-design-system/issues/1104.

### Code
 - [x] Build Component in Spark Vanilla (Sass)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
