### PR TITLE
Fix bug #1178 & #1182

### DIFF
--- a/src/angular/projects/spark-core-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -1,4 +1,5 @@
 import { Component, HostListener, Input, Renderer2 } from '@angular/core';
+import { Router, Event, NavigationEnd } from '@angular/router';
 import * as _ from 'lodash';
 
 @Component({
@@ -211,7 +212,13 @@ import * as _ from 'lodash';
   `
 })
 export class SparkMastheadComponent {
-  constructor(private renderer: Renderer2) {}
+  constructor(private renderer: Renderer2, router: Router) {
+    router.events.subscribe((event: Event) => {
+      if (event instanceof NavigationEnd) {
+        this.closeNarrowNav();
+      }
+    });
+  }
 
   @Input()
   logoHref = '/';

--- a/src/patterns/components/masthead/angular/info/default.hbs
+++ b/src/patterns/components/masthead/angular/info/default.hbs
@@ -43,11 +43,6 @@
       <td>Expects an array of link objects, to be represented in the narrow nav element of the masthead component. See below for link object details.</td>
     </tr>
     <tr>
-      <td class="sprk-u-FontWeight--bold">narrowNavLinks</td>
-      <td>object[]</td>
-      <td>Expects an array of link objects, to be represented in the narrow nav element of the masthead component. See below for link object details.</td>
-    </tr>
-    <tr>
       <td class="sprk-u-FontWeight--bold">narrowSelector</td>
       <td>object</td>
       <td>Expects a narrowSelector object that represents choices to be supplied to the dropdown above the narrow


### PR DESCRIPTION
## What does this PR do?
Closes the mobile navigation when router link navigation is complete.
Removes duplicate prop in Angular Docs

### Associated Issue 
issue #1178 
issue #1182 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs Angular

### Code
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Apple Safari (Mobile)
