### PR TITLE
update sprk-c-Button--full@sm to be consistent naming

### DIFF
--- a/packages/spark-core/components/_buttons.scss
+++ b/packages/spark-core/components/_buttons.scss
@@ -32,7 +32,8 @@
   }
 }
 
-.sprk-c-Button--full\@sm {
+.sprk-c-Button--full\@sm,
+.sprk-c-Button--full\@s {
   width: 100%;
 
   @media screen and (min-width: $sprk-btn-breakpoint-s) {
@@ -42,7 +43,8 @@
 
 .sprk-c-Button--secondary {
   background-color: $sprk-btn-secondary-background-color;
-  border: $sprk-btn-border-width $sprk-btn-border-style $sprk-btn-secondary-border-color;
+  border: $sprk-btn-border-width $sprk-btn-border-style
+    $sprk-btn-secondary-border-color;
   color: $sprk-btn-secondary-text-color;
   letter-spacing: $sprk-btn-secondary-letter-spacing;
 

--- a/src/angular/projects/spark-extras-angular-highlight-board/src/lib/spark-extras-angular-highlight-board.component.ts
+++ b/src/angular/projects/spark-extras-angular-highlight-board/src/lib/spark-extras-angular-highlight-board.component.ts
@@ -37,7 +37,7 @@ import { Component, Input } from '@angular/core';
           <div sprkStackItem class="sprk-c-HighlightBoard__cta">
             <a
               [routerLink]="ctaHref"
-              class="sprk-c-Button sprk-c-Button--primary sprk-c-Button--full@sm"
+              class="sprk-c-Button sprk-c-Button--primary sprk-c-Button--full@s"
               [attr.data-analytics]="analyticsStringCta"
             >
               {{ ctaText }}
@@ -51,7 +51,7 @@ import { Component, Input } from '@angular/core';
           >
             <a
               [routerLink]="ctaHref2"
-              class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--full@sm"
+              class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--full@s"
               [attr.data-analytics]="analyticsStringCta2"
             >
               {{ ctaText2 }}

--- a/src/angular/src/app/spark-docs/masthead-docs/masthead-docs.component.ts
+++ b/src/angular/src/app/spark-docs/masthead-docs/masthead-docs.component.ts
@@ -181,7 +181,7 @@ import { Component } from '@angular/core';
         </ul>
         <div class="sprk-u-mas" narrowNavFooter>
           <a
-            class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@sm"
+            class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@s"
             href="#nogo"
             >Sign In</a
           >

--- a/src/pages/tests/button.hbs
+++ b/src/pages/tests/button.hbs
@@ -43,7 +43,7 @@ layout: blank
       Full Width Button At Small Screens
     </h2>
     {{#embed "patterns.components.buttons.at-small"}}{{/embed}}
-    <a href="#nogo" class="sprk-c-Button sprk-c-Button--full@sm">Link Button</a>
+    <a href="#nogo" class="sprk-c-Button sprk-c-Button--full@s">Link Button</a>
   </li>
 
   <li class="sprk-u-mbm">
@@ -80,9 +80,9 @@ layout: blank
 
 <div class="sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack--split@xs sprk-o-Stack--center-row">
   <div class="sprk-o-Stack__item">
-    <a href="#nogo" class="sprk-c-Button sprk-c-Button--full@sm">Link Button</a>
+    <a href="#nogo" class="sprk-c-Button sprk-c-Button--full@s">Link Button</a>
   </div>
   <div class="sprk-o-Stack__item">
-    <a href="#nogo" class="sprk-c-Button sprk-c-Button--full@sm">Link Button</a>
+    <a href="#nogo" class="sprk-c-Button sprk-c-Button--full@s">Link Button</a>
   </div>
 </div>

--- a/src/patterns/components/buttons/angular/code/at-small.hbs
+++ b/src/patterns/components/buttons/angular/code/at-small.hbs
@@ -1,1 +1,1 @@
-{{#embed "patterns.components.buttons.angular.code.base" classes="sprk-c-Button--full@sm"}}{{/embed}}
+{{#embed "patterns.components.buttons.angular.code.base" classes="sprk-c-Button--full@s"}}{{/embed}}

--- a/src/patterns/components/buttons/at-small.hbs
+++ b/src/patterns/components/buttons/at-small.hbs
@@ -7,4 +7,4 @@ hasAngularCode: true
 hasReactCode: true
 ---
 
-{{#embed "patterns.components.buttons.base" class="sprk-c-Button--full@sm" button=true}}{{/embed}}
+{{#embed "patterns.components.buttons.base" class="sprk-c-Button--full@s" button=true}}{{/embed}}

--- a/src/patterns/components/buttons/collection.yaml
+++ b/src/patterns/components/buttons/collection.yaml
@@ -181,7 +181,7 @@ classTable:
     description: Reduces the padding of the normal button to $space-inset-short-m.
   .sprk-c-Button--full@xs:
     description: Makes the button full width of its parent container until it flips to normal width at the $sprk-btn-breakpoint-xs breakpoint.
-  .sprk-c-Button--full@sm:
+  .sprk-c-Button--full@s:
     description: Makes the button full width of its parent container until it flips to normal width at the $sprk-btn-breakpoint-s breakpoint.
   .sprk-c-Button--secondary:
     description: Styles the button as the secondary variant.

--- a/src/patterns/components/buttons/react/code/at-small.hbs
+++ b/src/patterns/components/buttons/react/code/at-small.hbs
@@ -1,1 +1,1 @@
-{{#embed "patterns.components.buttons.react.code.base" classes="sprk-c-Button--full@sm"}}{{/embed}}
+{{#embed "patterns.components.buttons.react.code.base" classes="sprk-c-Button--full@s"}}{{/embed}}

--- a/src/patterns/components/highlight-board/base.hbs
+++ b/src/patterns/components/highlight-board/base.hbs
@@ -14,13 +14,13 @@ hidden: true
 
     <div class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack--split@xs sprk-o-Stack--center-column {{#if stacked}}sprk-o-Stack--center-row{{/if}}">
       <div class="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
-        <a class="sprk-c-Button sprk-c-Button--full@sm" href="/gettingstarted/designers.html">
+        <a class="sprk-c-Button sprk-c-Button--full@s" href="/gettingstarted/designers.html">
           Designers
         </a>
       </div>
 
       <div class="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
-        <a class="sprk-c-Button sprk-c-Button--full@sm sprk-c-Button--secondary" href="/gettingstarted/developers.html">
+        <a class="sprk-c-Button sprk-c-Button--full@s sprk-c-Button--secondary" href="/gettingstarted/developers.html">
           Developers
         </a>
       </div>

--- a/src/patterns/components/highlight-board/no-image.hbs
+++ b/src/patterns/components/highlight-board/no-image.hbs
@@ -19,13 +19,13 @@ hasReactDocs: true
 
     <div class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack--split@xs sprk-o-Stack--center-column sprk-o-Stack--center-row">
       <div class="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
-        <a class="sprk-c-Button sprk-c-Button--full@sm" href="/gettingstarted/designers.html">
+        <a class="sprk-c-Button sprk-c-Button--full@s" href="/gettingstarted/designers.html">
           Designers
         </a>
       </div>
 
       <div class="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
-        <a class="sprk-c-Button sprk-c-Button--full@sm sprk-c-Button--secondary" href="/gettingstarted/developers.html">
+        <a class="sprk-c-Button sprk-c-Button--full@s sprk-c-Button--secondary" href="/gettingstarted/developers.html">
           Developers
         </a>
       </div>

--- a/src/patterns/components/masthead/angular/code/default.hbs
+++ b/src/patterns/components/masthead/angular/code/default.hbs
@@ -170,7 +170,7 @@
   </ul>
   <div class="sprk-u-mas" narrowNavFooter>
     <a
-      class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@sm"
+      class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@s"
       href="#nogo"
       >Sign In</a
     >

--- a/src/patterns/components/masthead/default.hbs
+++ b/src/patterns/components/masthead/default.hbs
@@ -146,7 +146,7 @@ hasReactCodeInfo: true
         </li>
 
         <li class="sprk-c-MastheadAccordion__item sprk-o-Box">
-          <a class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@sm" href="#nogo">
+          <a class="sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@s" href="#nogo">
             Sign In
           </a>
         </li>

--- a/src/react/projects/spark-core-react/src/SprkHighlightBoard/SprkHighlightBoard.js
+++ b/src/react/projects/spark-core-react/src/SprkHighlightBoard/SprkHighlightBoard.js
@@ -4,7 +4,7 @@ import classnames from 'classnames';
 import { SprkButton } from '@sparkdesignsystem/spark-core-react';
 import warning from 'warning';
 
-const SprkHighlightBoard = (props) => {
+const SprkHighlightBoard = props => {
   const {
     imgSrc,
     imgAlt,
@@ -26,79 +26,82 @@ const SprkHighlightBoard = (props) => {
 
   warning(
     (imgSrc && imgAlt) || (!imgSrc && !imgAlt),
-    'SprkHighlightBoard: If imgSrc is provided, then imgAlt is required (and vice versa).'
+    'SprkHighlightBoard: If imgSrc is provided, then imgAlt is required (and vice versa).',
   );
 
   const classNames = classnames(
     'sprk-c-HighlightBoard',
     'sprk-u-mbm',
     additionalClasses,
-    {'sprk-c-HighlightBoard--has-image': imgSrc},
-    {'sprk-c-HighlightBoard--stacked': variant === 'stacked'},
+    { 'sprk-c-HighlightBoard--has-image': imgSrc },
+    { 'sprk-c-HighlightBoard--stacked': variant === 'stacked' },
   );
 
   return (
     <div className={classNames} data-id={idString} {...other}>
-      {imgSrc &&
+      {imgSrc && (
         <img
-          className='sprk-c-HighlightBoard__image'
+          className="sprk-c-HighlightBoard__image"
           src={imgSrc}
-          alt={imgAlt} />
-      }
+          alt={imgAlt}
+        />
+      )}
 
-      <div className='sprk-c-HighlightBoard__content sprk-o-Stack sprk-o-Stack--large'>
-        { heading &&
+      <div className="sprk-c-HighlightBoard__content sprk-o-Stack sprk-o-Stack--large">
+        {heading && (
           <h1 className="sprk-b-TypeDisplayOne sprk-c-HighlightBoard__heading sprk-o-Stack__item">
             {heading}
           </h1>
-        }
+        )}
 
-        { (ctaText || ctaText2) &&
-        <div className= {
-          classnames(
-            'sprk-o-Stack__item',
-            'sprk-o-Stack',
-            'sprk-o-Stack--medium',
-            'sprk-o-Stack--split@xs',
-            'sprk-o-Stack--center-column',
-            {'sprk-o-Stack--center-row' : variant === 'noImage' || variant === 'stacked'}
-          )
-        } >
+        {(ctaText || ctaText2) && (
+          <div
+            className={classnames(
+              'sprk-o-Stack__item',
+              'sprk-o-Stack',
+              'sprk-o-Stack--medium',
+              'sprk-o-Stack--split@xs',
+              'sprk-o-Stack--center-column',
+              {
+                'sprk-o-Stack--center-row':
+                  variant === 'noImage' || variant === 'stacked',
+              },
+            )}
+          >
+            {ctaText && (
+              <div className="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
+                <SprkButton
+                  element="a"
+                  href={ctaHref}
+                  analyticsString={ctaAnalytics}
+                  idString={ctaIdString}
+                  additionalClasses="sprk-c-Button--full@s"
+                >
+                  {ctaText}
+                </SprkButton>
+              </div>
+            )}
 
-          { ctaText &&
-            <div className="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
-              <SprkButton
-                element="a"
-                href={ctaHref}
-                analyticsString={ctaAnalytics}
-                idString={ctaIdString}
-                additionalClasses='sprk-c-Button--full@sm' >
-
-                {ctaText}
-              </SprkButton>
-            </div>
-          }
-
-          { ctaText2 &&
-            <div className="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
-              <SprkButton
-                variant='secondary'
-                element="a"
-                href={ctaHref2}
-                analyticsString={ctaAnalytics2}
-                idString={ctaIdString2}
-                additionalClasses='sprk-c-Button--full@sm' >
-
-                {ctaText2}
-              </SprkButton>
-            </div>
-          }
-        </div>
-        }
+            {ctaText2 && (
+              <div className="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
+                <SprkButton
+                  variant="secondary"
+                  element="a"
+                  href={ctaHref2}
+                  analyticsString={ctaAnalytics2}
+                  idString={ctaIdString2}
+                  additionalClasses="sprk-c-Button--full@s"
+                >
+                  {ctaText2}
+                </SprkButton>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );
-}
+};
 
 SprkHighlightBoard.propTypes = {
   // The source for the image - required if imgAlt is provided
@@ -128,7 +131,7 @@ SprkHighlightBoard.propTypes = {
   // The string to use for the data-id attribute
   idString: PropTypes.string,
   // Any additional classes to add to the highlight board
-  additionalClasses: PropTypes.string
+  additionalClasses: PropTypes.string,
 };
 
 export default SprkHighlightBoard;

--- a/src/react/projects/spark-core-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/src/react/projects/spark-core-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -61,7 +61,9 @@ class SprkMastheadAccordionItem extends Component {
               onClick={this.toggleAccordionOpen}
               aria-expanded={isOpen ? 'true' : 'false'}
             >
-              <span className="sprk-b-TypeBodyOne sprk-c-MastheadAccordion__heading">{text}</span>
+              <span className="sprk-b-TypeBodyOne sprk-c-MastheadAccordion__heading">
+                {text}
+              </span>
               <SprkIcon
                 additionalClasses={classNames({ 'sprk-c-Icon--open': isOpen })}
                 iconName="chevron-down"
@@ -69,7 +71,7 @@ class SprkMastheadAccordionItem extends Component {
             </a>
             <AnimateHeight duration={300} height={height}>
               <ul className="sprk-b-List sprk-b-List--bare sprk-c-MastheadAccordion__details">
-                {stateLinks.map((subnavlink) => {
+                {stateLinks.map(subnavlink => {
                   const {
                     element: innerElement,
                     href: innerHref,
@@ -81,7 +83,11 @@ class SprkMastheadAccordionItem extends Component {
                   return (
                     <li key={innerId}>
                       <InnerTagName
-                        href={InnerTagName === 'a' ? innerHref || '#nogo' : undefined}
+                        href={
+                          InnerTagName === 'a'
+                            ? innerHref || '#nogo'
+                            : undefined
+                        }
                         className={classNames(
                           'sprk-b-Link sprk-b-Link--plain sprk-c-Masthead__link',
                         )}
@@ -101,13 +107,17 @@ class SprkMastheadAccordionItem extends Component {
             className={classNames(
               { 'sprk-c-MastheadAccordion__summary': !isButton },
               {
-                'sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@sm': isButton,
+                'sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@s': isButton,
               },
             )}
             href={TagName === 'a' ? href : undefined}
             {...rest}
           >
-            <span className={classNames({ 'sprk-c-MastheadAccordion__heading': !isButton })}>
+            <span
+              className={classNames({
+                'sprk-c-MastheadAccordion__heading': !isButton,
+              })}
+            >
               {leadingIcon && (
                 <SprkIcon
                   additionalClasses="sprk-c-Icon--stroke-current-color sprk-c-Icon--l sprk-u-mrs"


### PR DESCRIPTION
## What does this PR do?
Changed references from .sprk-c-Button--full\@sm and sprk-c-Button--full@sm to sprk-c-Button--full\@s and sprk-c-Button--full@s to keep naming consistency.

### Associated Issue 
[1186](https://github.com/sparkdesignsystem/spark-design-system/issues/1186)

### Documentation
 - [x] Update Spark Docs React
 - [x] Update Spark Docs Angular
 - [x] Update Spark Docs Vanilla
 - [x] Update Component Sass Var/Class Modifier table

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)

### Design Review
 - [ ] Design reviewed and approved
