### PR TITLE
Refactor React to use SprkLink

### DIFF
--- a/src/patterns/components/links/react/code/disabled.hbs
+++ b/src/patterns/components/links/react/code/disabled.hbs
@@ -1,3 +1,3 @@
-<SprkLink variant="disabled" idString="link-3" href="#nogo">
+<SprkLink variant="disabled" idString="link-3" href="#">
   Disabled Link
 </SprkLink>

--- a/src/patterns/components/links/react/code/icon-text.hbs
+++ b/src/patterns/components/links/react/code/icon-text.hbs
@@ -1,4 +1,4 @@
-<SprkLink variant="has-icon" idString="link-4" href="#nogo">
+<SprkLink variant="has-icon" idString="link-4" href="#">
   {/* TODO: SVG Component*/}
   <svg className="sprk-c-Icon sprk-c-Icon--xl" viewBox="0 0 100 100">
     <use xlinkHref="#communication" />

--- a/src/patterns/components/links/react/code/inline.hbs
+++ b/src/patterns/components/links/react/code/inline.hbs
@@ -1,3 +1,3 @@
-<SprkLink href="#nogo" id="link-1">
+<SprkLink href="#" id="link-1">
   Base Link
 </SprkLink>

--- a/src/patterns/components/links/react/code/simple.hbs
+++ b/src/patterns/components/links/react/code/simple.hbs
@@ -1,3 +1,3 @@
-<SprkLink variant="simple" idString="link-2" href="#nogo">
+<SprkLink variant="simple" idString="link-2" href="#">
   Simple Link
 </SprkLink>

--- a/src/patterns/components/links/react/info/inline.hbs
+++ b/src/patterns/components/links/react/info/inline.hbs
@@ -10,7 +10,7 @@
 
   <thead>
     <tr>
-      <th>Input</th>
+      <th>Prop</th>
       <th>Type</th>
       <th>Description</th>
     </tr>
@@ -27,7 +27,7 @@
       </td>
 
       <td>
-        Can be 'simple', 'has-icon', 'plain', or 'disabled'. Will cause the appropriate variant type to render.
+        Can be 'simple', 'has-icon', 'plain', 'disabled', or 'unstyled'. Will cause the appropriate variant type to render.
       </td>
     </tr>
 
@@ -41,7 +41,7 @@
       </td>
 
       <td>
-        The URL of the link.
+        The URL of the link. Defaults to '#' and preventDefault() if no href is provided.
       </td>
     </tr>
 

--- a/src/patterns/components/links/react/info/inline.hbs
+++ b/src/patterns/components/links/react/info/inline.hbs
@@ -19,6 +19,19 @@
   <tbody>
     <tr>
       <td class="sprk-u-FontWeight--bold">
+        element
+      </td>
+
+      <td>
+        string
+      </td>
+
+      <td>
+        Can pass a router link or anchor tag. Defaults to anchor tag if no value is passed.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">
         variant
       </td>
 
@@ -42,6 +55,20 @@
 
       <td>
         The URL of the link. Defaults to '#' and preventDefault() if no href is provided.
+      </td>
+    </tr>
+
+    <tr>
+      <td class="sprk-u-FontWeight--bold">
+        onClick
+      </td>
+
+      <td>
+        function
+      </td>
+
+      <td>
+        A function to be called when the element is clicked.
       </td>
     </tr>
 
@@ -72,20 +99,6 @@
       <td>
         The value supplied will be assigned to the 'data-id' attribute on the component. This is intended to be used as a
         selector for automated tools. This value should be unique per page.
-      </td>
-    </tr>
-
-    <tr>
-      <td class="sprk-u-FontWeight--bold">
-        target
-      </td>
-
-      <td>
-        string
-      </td>
-
-      <td>
-        Expects a value to assign to the target attribute of the link.
       </td>
     </tr>
     <tr>

--- a/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.js
@@ -69,15 +69,19 @@ class SprkAccordionItem extends Component {
           onClick={this.toggle}
           aria-expanded={isOpen ? 'true' : 'false'}
         >
-          <h3 className={headingClassNames}>
-            {heading}
-          </h3>
-          <SprkIcon iconName="chevron-up-circle-two-color" additionalClasses={iconClasses} />
+          <h3 className={headingClassNames}>{heading}</h3>
+          <SprkIcon
+            iconName="chevron-up-circle-two-color"
+            additionalClasses={iconClasses}
+          />
         </a>
 
         <AnimateHeight duration={300} height={height}>
           <div
-            className={classnames('sprk-c-Accordion__content', contentAddClasses)}
+            className={classnames(
+              'sprk-c-Accordion__content',
+              contentAddClasses,
+            )}
             id={id}
           >
             {children}

--- a/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.js
@@ -3,6 +3,7 @@ import AnimateHeight from 'react-animate-height';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import SprkIcon from '../../../SprkIcon/SprkIcon';
+import SprkLink from '../../../SprkLink/SprkLink';
 
 class SprkAccordionItem extends Component {
   constructor(props) {
@@ -61,20 +62,21 @@ class SprkAccordionItem extends Component {
 
     return (
       <li className={itemClassNames} data-id={idString} {...other}>
-        <a
+        <SprkLink
+          variant="unstyled"
           aria-controls={id}
-          className="sprk-c-Accordion__summary"
+          additionalClasses="sprk-c-Accordion__summary"
           data-analytics={analyticsString}
-          href="#nogo"
           onClick={this.toggle}
           aria-expanded={isOpen ? 'true' : 'false'}
+          href="#nogo"
         >
           <h3 className={headingClassNames}>{heading}</h3>
           <SprkIcon
             iconName="chevron-up-circle-two-color"
             additionalClasses={iconClasses}
           />
-        </a>
+        </SprkLink>
 
         <AnimateHeight duration={300} height={height}>
           <div
@@ -93,14 +95,7 @@ class SprkAccordionItem extends Component {
 }
 
 SprkAccordionItem.defaultProps = {
-  analyticsString: '',
-  children: '',
-  headingAddClasses: '',
-  additionalClasses: '',
-  idString: '',
   isDefaultOpen: false,
-  iconAddClasses: '',
-  contentAddClasses: '',
 };
 
 SprkAccordionItem.propTypes = {

--- a/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.js
@@ -18,7 +18,6 @@ class SprkAccordionItem extends Component {
 
   toggle(e) {
     const { onToggle } = this.props;
-    e.preventDefault();
     this.setState(prevState => ({
       isOpen: !prevState.isOpen,
       height: !prevState.isOpen ? 'auto' : 0,
@@ -69,7 +68,6 @@ class SprkAccordionItem extends Component {
           data-analytics={analyticsString}
           onClick={this.toggle}
           aria-expanded={isOpen ? 'true' : 'false'}
-          href="#nogo"
         >
           <h3 className={headingClassNames}>{heading}</h3>
           <SprkIcon

--- a/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -46,7 +46,7 @@ it('should add aria-expanded="true" when the toggle is open', () => {
     <SprkAccordionItem heading="test">test</SprkAccordionItem>,
   );
   wrapper.find('a').simulate('click');
-  expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
+  expect(wrapper.find('[aria-expanded="true"]').length).toBe(2);
 });
 
 it('should run callback when passed as prop to onToggle', () => {

--- a/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/src/react/projects/spark-react/src/SprkAccordion/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -7,17 +7,25 @@ import SprkAccordionItem from './SprkAccordionItem';
 Enzyme.configure({ adapter: new Adapter() });
 
 it('should display an element with the correct base class', () => {
-  const wrapper = mount(<SprkAccordionItem heading="test">test</SprkAccordionItem>);
+  const wrapper = mount(
+    <SprkAccordionItem heading="test">test</SprkAccordionItem>,
+  );
   expect(wrapper.find('li.sprk-c-Accordion__item').length).toBe(1);
 });
 
 it('should default to open if defaultOpen is true', () => {
-  const wrapper = mount(<SprkAccordionItem heading="test" isDefaultOpen>test</SprkAccordionItem>);
+  const wrapper = mount(
+    <SprkAccordionItem heading="test" isDefaultOpen>
+      test
+    </SprkAccordionItem>,
+  );
   expect(wrapper.state().isOpen).toBe(true);
 });
 
 it('should toggle open on click', () => {
-  const wrapper = mount(<SprkAccordionItem heading="test">test</SprkAccordionItem>);
+  const wrapper = mount(
+    <SprkAccordionItem heading="test">test</SprkAccordionItem>,
+  );
   expect(wrapper.state().isOpen).toBe(false);
   wrapper.find('a').simulate('click');
   expect(wrapper.state().isOpen).toBe(true);
@@ -26,20 +34,28 @@ it('should toggle open on click', () => {
 });
 
 it('should add a class to icon when opened', () => {
-  const wrapper = mount(<SprkAccordionItem heading="test">test</SprkAccordionItem>);
+  const wrapper = mount(
+    <SprkAccordionItem heading="test">test</SprkAccordionItem>,
+  );
   wrapper.find('a').simulate('click');
   expect(wrapper.find('.sprk-c-Icon--open').length).toBe(1);
 });
 
 it('should add aria-expanded="true" when the toggle is open', () => {
-  const wrapper = mount(<SprkAccordionItem heading="test">test</SprkAccordionItem>);
+  const wrapper = mount(
+    <SprkAccordionItem heading="test">test</SprkAccordionItem>,
+  );
   wrapper.find('a').simulate('click');
   expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
 });
 
 it('should run callback when passed as prop to onToggle', () => {
   const spyFunc = jest.fn();
-  const wrapper = mount(<SprkAccordionItem heading="test" onToggle={spyFunc}>test</SprkAccordionItem>);
+  const wrapper = mount(
+    <SprkAccordionItem heading="test" onToggle={spyFunc}>
+      test
+    </SprkAccordionItem>,
+  );
   wrapper.find('a').simulate('click');
   expect(spyFunc.mock.calls.length).toBe(1);
 });

--- a/src/react/projects/spark-react/src/SprkDropdown/SprkDropdown.js
+++ b/src/react/projects/spark-react/src/SprkDropdown/SprkDropdown.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { uniqueId } from 'lodash';
 import SprkIcon from '../SprkIcon/SprkIcon';
+import SprkLink from '../SprkLink/SprkLink';
 
 class SprkDropdown extends Component {
   constructor(props) {
@@ -11,9 +12,10 @@ class SprkDropdown extends Component {
     this.state = {
       triggerText: props.defaultTriggerText,
       isOpen: false,
-      choiceItems: props.choices.items.map(
-        item => ({ id: uniqueId(), ...item }),
-      ),
+      choiceItems: props.choices.items.map(item => ({
+        id: uniqueId(),
+        ...item,
+      })),
     };
     this.toggleDropdownOpen = this.toggleDropdownOpen.bind(this);
     this.closeOnEsc = this.closeOnEsc.bind(this);
@@ -95,10 +97,10 @@ class SprkDropdown extends Component {
     const { choiceItems, isOpen, triggerText } = this.state;
     return (
       <div ref={this.dropdownRef}>
-        <a
-          className={classNames(
-            'sprk-b-Link',
-            'sprk-b-Link--plain',
+        <SprkLink
+          element="a"
+          variant="plain"
+          additionalClasses={classNames(
             { 'sprk-u-mrs': variant === 'informational' },
             additionalTriggerClasses,
           )}
@@ -122,13 +124,21 @@ class SprkDropdown extends Component {
           )}
           {variant === 'base' && (
             <React.Fragment>
-              <span className={classNames('sprk-u-ScreenReaderText', additionalTriggerTextClasses)}>
+              <span
+                className={classNames(
+                  'sprk-u-ScreenReaderText',
+                  additionalTriggerTextClasses,
+                )}
+              >
                 {screenReaderText}
               </span>
-              <SprkIcon iconName={iconName} additionalClasses={additionalIconClasses} />
+              <SprkIcon
+                iconName={iconName}
+                additionalClasses={additionalIconClasses}
+              />
             </React.Fragment>
           )}
-        </a>
+        </SprkLink>
         {isOpen && (
           <div className={classNames('sprk-c-Dropdown', additionalClasses)}>
             {title !== '' && (
@@ -137,13 +147,24 @@ class SprkDropdown extends Component {
               </div>
             )}
             <ul className="sprk-c-Dropdown__links">
-              {choiceItems.map((choice) => {
+              {choiceItems.map(choice => {
                 const {
-                  content, element, href, isActive, text, value, ...rest
+                  content,
+                  element,
+                  href,
+                  isActive,
+                  text,
+                  value,
+                  ...rest
                 } = choice;
                 const TagName = element || 'a';
                 return (
-                  <li className="sprk-c-Dropdown__item" aria-selected={isActive} role="option" key={choice.id}>
+                  <li
+                    className="sprk-c-Dropdown__item"
+                    aria-selected={isActive}
+                    role="option"
+                    key={choice.id}
+                  >
                     {variant === 'base' && (
                       <TagName
                         className="sprk-c-Dropdown__link"
@@ -177,8 +198,12 @@ class SprkDropdown extends Component {
                           {...rest}
                         >
                           <p className="sprk-b-TypeBodyOne">{content.title}</p>
-                          <p className="sprk-b-TypeBodyTwo">{content.infoLine1}</p>
-                          <p className="sprk-b-TypeBodyTwo">{content.infoLine2}</p>
+                          <p className="sprk-b-TypeBodyTwo">
+                            {content.infoLine1}
+                          </p>
+                          <p className="sprk-b-TypeBodyTwo">
+                            {content.infoLine2}
+                          </p>
                         </TagName>
                       </React.Fragment>
                     )}
@@ -186,13 +211,11 @@ class SprkDropdown extends Component {
                 );
               })}
             </ul>
-            {footer
-            && (
-            <div className="sprk-c-Dropdown__footer sprk-u-TextAlign--center">
-              {footer}
-            </div>
-            )
-          }
+            {footer && (
+              <div className="sprk-c-Dropdown__footer sprk-u-TextAlign--center">
+                {footer}
+              </div>
+            )}
           </div>
         )}
       </div>

--- a/src/react/projects/spark-react/src/SprkDropdown/SprkDropdown.js
+++ b/src/react/projects/spark-react/src/SprkDropdown/SprkDropdown.js
@@ -104,7 +104,6 @@ class SprkDropdown extends Component {
             { 'sprk-u-mrs': variant === 'informational' },
             additionalTriggerClasses,
           )}
-          href="#nogo"
           aria-expanded={isOpen}
           role="listbox"
           data-analytics={analyticsString || 'undefined'}
@@ -168,7 +167,7 @@ class SprkDropdown extends Component {
                     {variant === 'base' && (
                       <TagName
                         className="sprk-c-Dropdown__link"
-                        href={TagName === 'a' ? href || '#nogo' : undefined}
+                        href={TagName === 'a' ? href || '#' : undefined}
                         onClick={() => {
                           this.selectChoice(choice.id, text);
                           this.closeDropdown();
@@ -187,7 +186,7 @@ class SprkDropdown extends Component {
                           className={classNames('sprk-c-Dropdown__link', {
                             'sprk-c-Dropdown__link--active': isActive,
                           })}
-                          href={TagName === 'a' ? href || '#nogo' : undefined}
+                          href={TagName === 'a' ? href || '#' : undefined}
                           onClick={() => {
                             this.selectChoice(choice.id, content.title);
                             this.closeDropdown();

--- a/src/react/projects/spark-react/src/SprkDropdown/SprkDropdown.test.js
+++ b/src/react/projects/spark-react/src/SprkDropdown/SprkDropdown.test.js
@@ -12,7 +12,13 @@ it('should render a trigger with the correct classes', () => {
 });
 
 it('should render a footer if supplied with the choices', () => {
-  const choices = { footer: (<p>hi</p>), items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
+  const choices = {
+    footer: <p>hi</p>,
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
   const wrapper = mount(<SprkDropdown choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('.sprk-c-Dropdown__footer').length).toBe(1);
@@ -25,7 +31,9 @@ it('should add classes to the dropdown when additionalClasses has a value', () =
 });
 
 it('should add classes to the icon when additionalIconClasses has a value', () => {
-  const wrapper = mount(<SprkDropdown additionalIconClasses="sprk-c-Icon--l" />);
+  const wrapper = mount(
+    <SprkDropdown additionalIconClasses="sprk-c-Icon--l" />,
+  );
   expect(wrapper.find('.sprk-c-Icon.sprk-c-Icon--l').length).toBe(1);
 });
 
@@ -35,7 +43,9 @@ it('should add classes to the trigger when additionalTriggerClasses has a value'
 });
 
 it('should add classes to the trigger text when additionalTriggerTextClasses has a value', () => {
-  const wrapper = mount(<SprkDropdown additionalTriggerTextClasses="sprk-u-man" />);
+  const wrapper = mount(
+    <SprkDropdown additionalTriggerTextClasses="sprk-u-man" />,
+  );
   expect(wrapper.find('span.sprk-u-man').length).toBe(1);
 });
 
@@ -62,7 +72,10 @@ it('should assign the choices header when title has a value', () => {
 
 it('should build the correct number of choices from a choices object', () => {
   const choices = {
-    items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }],
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
   };
   const wrapper = mount(<SprkDropdown choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
@@ -73,7 +86,10 @@ it('should run the choiceFunction supplied with the list of choices (base)', () 
   const spyFunc = jest.fn();
   const choices = {
     choiceFunction: spyFunc,
-    items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }],
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
   };
   const wrapper = mount(<SprkDropdown choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
@@ -87,7 +103,10 @@ it('should run the choiceFunction supplied with the list of choices (base)', () 
 it('should not error if choiceFunction is supplied but undefined (base)', () => {
   const choices = {
     choiceFunction: undefined,
-    items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }],
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
   };
   const wrapper = mount(<SprkDropdown choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
@@ -103,7 +122,9 @@ it('should run the choiceFunction supplied with the list of choices (information
     choiceFunction: spyFunc,
     items: [{ text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } }],
   };
-  const wrapper = mount(<SprkDropdown choices={choices} variant="informational" />);
+  const wrapper = mount(
+    <SprkDropdown choices={choices} variant="informational" />,
+  );
   wrapper.find('.sprk-b-Link').simulate('click');
   wrapper
     .find('.sprk-c-Dropdown__link')
@@ -117,7 +138,9 @@ it('should not error if choiceFunction is supplied but undefined (informational)
     choiceFunction: undefined,
     items: [{ text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } }],
   };
-  const wrapper = mount(<SprkDropdown choices={choices} variant="informational" />);
+  const wrapper = mount(
+    <SprkDropdown choices={choices} variant="informational" />,
+  );
   wrapper.find('.sprk-b-Link').simulate('click');
   wrapper
     .find('.sprk-c-Dropdown__link')
@@ -161,7 +184,9 @@ it('should unmount without error', () => {
 });
 
 it('should render the choices with the element specified', () => {
-  const wrapper = mount(<SprkDropdown choices={{ items: [{ element: 'p', text: 'Item 1' }] }} />);
+  const wrapper = mount(
+    <SprkDropdown choices={{ items: [{ element: 'p', text: 'Item 1' }] }} />,
+  );
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('p.sprk-c-Dropdown__link').length).toBe(1);
@@ -169,19 +194,37 @@ it('should render the choices with the element specified', () => {
 
 it('should pass unused keys on choice items through to the dom', () => {
   const wrapper = mount(
-    <SprkDropdown choices={{ items: [{ element: 'p', text: 'Item 1', 'aria-hidden': 'true' }] }} />,
+    <SprkDropdown
+      choices={{
+        items: [{ element: 'p', text: 'Item 1', 'aria-hidden': 'true' }],
+      }}
+    />,
   );
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
   wrapper.find('.sprk-b-Link').simulate('click');
-  expect(wrapper.find('.sprk-c-Dropdown__link[aria-hidden="true"]').length).toBe(1);
+  expect(
+    wrapper.find('.sprk-c-Dropdown__link[aria-hidden="true"]').length,
+  ).toBe(1);
 });
 
 it('should not set href if the supplied tagname is not a', () => {
   const wrapper = mount(
-    <SprkDropdown variant="informational" choices={{ items: [{ element: 'span', text: 'Item 1', content: { title: 'Item 1' } }] }} />,
+    <SprkDropdown
+      variant="informational"
+      choices={{
+        items: [
+          { element: 'span', text: 'Item 1', content: { title: 'Item 1' } },
+        ],
+      }}
+    />,
   );
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('span.sprk-c-Dropdown__link').length).toBe(1);
-  expect(wrapper.find('span.sprk-c-Dropdown__link').instance().getAttribute('href')).toBe(null);
+  expect(
+    wrapper
+      .find('span.sprk-c-Dropdown__link')
+      .instance()
+      .getAttribute('href'),
+  ).toBe(null);
 });

--- a/src/react/projects/spark-react/src/SprkDropdown/SprkDropdown.test.js
+++ b/src/react/projects/spark-react/src/SprkDropdown/SprkDropdown.test.js
@@ -51,12 +51,12 @@ it('should add classes to the trigger text when additionalTriggerTextClasses has
 
 it('should assign data-analytics when analyticsString has a value', () => {
   const wrapper = mount(<SprkDropdown analyticsString="321" />);
-  expect(wrapper.find('[data-analytics="321"]').length).toBe(1);
+  expect(wrapper.find('[data-analytics="321"]').length).toBe(2);
 });
 
 it('should assign data-id when idString has a value', () => {
   const wrapper = mount(<SprkDropdown idString="321" />);
-  expect(wrapper.find('[data-id="321"]').length).toBe(1);
+  expect(wrapper.find('[data-id="321"]').length).toBe(2);
 });
 
 it('should assign screen reader text to the trigger for base dropdowns', () => {

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.js
@@ -10,6 +10,8 @@ const SprkLink = props => {
     additionalClasses,
     idString,
     analyticsString,
+    href,
+    onClick,
     ...other
   } = props;
   const TagName = element || 'a';
@@ -21,11 +23,19 @@ const SprkLink = props => {
     'sprk-b-Link--simple sprk-b-Link--has-icon': variant === 'has-icon',
   });
 
+  const noDefault = e => {
+    e.preventDefault();
+  };
+
+  const clickEvent = href === '#' ? e => noDefault(e) : onClick;
+
   return (
     <TagName
       className={classNames}
       data-analytics={analyticsString}
       data-id={idString}
+      href={href}
+      onClick={clickEvent}
       {...other}
     >
       {children}
@@ -54,11 +64,8 @@ SprkLink.propTypes = {
 };
 
 SprkLink.defaultProps = {
-  children: [],
   variant: 'base',
-  idString: '',
-  analyticsString: '',
-  additionalClasses: '',
+  href: '#',
 };
 
 export default SprkLink;

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.js
@@ -67,6 +67,10 @@ SprkLink.propTypes = {
   additionalClasses: PropTypes.string,
   // Url passed
   href: PropTypes.string,
+  // The element that will be rendered
+  element: PropTypes.string,
+  // The event that will fire when the element is clicked
+  onClick: PropTypes.function,
 };
 
 SprkLink.defaultProps = {

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.js
@@ -23,11 +23,15 @@ const SprkLink = props => {
     'sprk-b-Link--simple sprk-b-Link--has-icon': variant === 'has-icon',
   });
 
-  const noDefault = e => {
+  let clickEvent;
+  function handleClick(e) {
     e.preventDefault();
-  };
-
-  const clickEvent = href === '#' ? e => noDefault(e) : onClick;
+  }
+  if (onClick) {
+    clickEvent = onClick;
+  } else if (!onClick && href === '#') {
+    clickEvent = handleClick;
+  }
 
   return (
     <TagName
@@ -61,6 +65,8 @@ SprkLink.propTypes = {
   analyticsString: PropTypes.string,
   // Any additional classes to add to the link
   additionalClasses: PropTypes.string,
+  // Url passed
+  href: PropTypes.string,
 };
 
 SprkLink.defaultProps = {

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.js
@@ -13,7 +13,8 @@ const SprkLink = props => {
     ...other
   } = props;
   const TagName = element || 'a';
-  const classNames = classnames('sprk-b-Link', additionalClasses, {
+  const classNames = classnames(additionalClasses, {
+    'sprk-b-Link': variant !== 'unstyled',
     'sprk-b-Link--simple': variant === 'simple',
     'sprk-b-Link--plain': variant === 'plain',
     'sprk-b-Link--disabled': variant === 'disabled',
@@ -36,7 +37,14 @@ SprkLink.propTypes = {
   // The children that will be rendered inside the link
   children: PropTypes.node,
   // The link variant that determines the class names
-  variant: PropTypes.oneOf(['base', 'simple', 'has-icon', 'plain', 'disabled']),
+  variant: PropTypes.oneOf([
+    'base',
+    'simple',
+    'has-icon',
+    'plain',
+    'disabled',
+    'unstyled',
+  ]),
   // The string to use for the data-id attribute
   idString: PropTypes.string,
   // The string to use for the data-analytics attribute

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.js
@@ -70,7 +70,7 @@ SprkLink.propTypes = {
   // The element that will be rendered
   element: PropTypes.string,
   // The event that will fire when the element is clicked
-  onClick: PropTypes.function,
+  onClick: PropTypes.func,
 };
 
 SprkLink.defaultProps = {

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
@@ -6,9 +6,14 @@ import SprkLink from './SprkLink';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-it('should display a link element with the correct base class', () => {
+it('should display a link element with the correct base class if the variant is not unstyled', () => {
   const wrapper = shallow(<SprkLink />);
   expect(wrapper.find('a.sprk-b-Link').length).toBe(1);
+});
+
+it('should display a link element without the sprk-b-Link class if the variant is unstyled', () => {
+  const wrapper = shallow(<SprkLink variant="unstyled" />);
+  expect(wrapper.find('a').hasClass('sprk-b-Link')).toBe(false);
 });
 
 it('should display a link element with correct classes when variant is simple', () => {

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
@@ -40,3 +40,8 @@ it('should display a link element with correct classes when variant is disabled'
   expect(wrapper.find('a').hasClass('sprk-b-Link')).toBe(true);
   expect(wrapper.find('a').hasClass('sprk-b-Link--disabled')).toBe(true);
 });
+
+it('href should equal # if not provided', () => {
+  const wrapper = shallow(<SprkLink />);
+  expect(wrapper.find('a[href="#"]').length).toBe(1);
+});

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
@@ -45,3 +45,14 @@ it('href should equal # if not provided', () => {
   const wrapper = shallow(<SprkLink />);
   expect(wrapper.find('a[href="#"]').length).toBe(1);
 });
+
+it('should prevent default when no href is provided', () => {
+  const wrapper = shallow(<SprkLink />);
+  let prevented = false;
+  wrapper.find('a').simulate('click', {
+    preventDefault: () => {
+      prevented = true;
+    },
+  });
+  expect(prevented).toBe(true);
+});

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
@@ -1,3 +1,4 @@
+/* global it, expect, jest */
 import React from 'react';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -6,7 +7,7 @@ import SprkLink from './SprkLink';
 Enzyme.configure({ adapter: new Adapter() });
 
 it('should display a link element with the correct base class', () => {
-  const wrapper = shallow(<SprkLink/>);
+  const wrapper = shallow(<SprkLink />);
   expect(wrapper.find('a.sprk-b-Link').length).toBe(1);
 });
 

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -47,7 +47,6 @@ class SprkMasthead extends Component {
     }
   }
 
-
   render() {
     const {
       additionalClasses,
@@ -78,33 +77,31 @@ class SprkMasthead extends Component {
         data-id={idString}
       >
         <div className="sprk-c-Masthead__content sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--split@xxs">
-          <SprkMastheadMenuIcon toggleNarrowNav={this.toggleNarrowNav} isOpen={narrowNavOpen} />
+          <SprkMastheadMenuIcon
+            toggleNarrowNav={this.toggleNarrowNav}
+            isOpen={narrowNavOpen}
+          />
 
           <div className="sprk-c-Masthead__branding sprk-o-Stack__item sprk-o-Stack__item--center-column@xxs">
-            <a href="/">
-              {siteLogo}
-            </a>
+            <a href="/">{siteLogo}</a>
           </div>
 
-          {(littleNavLinks.length > 0 || utilityContents.length > 0)
-          && (
-          <SprkMastheadLittleNav
-            selector={selector}
-            spacing={variant === 'extended' ? 'medium' : 'large'}
-            links={littleNavLinks}
-            utilityContents={utilityContents}
-          />
-          )
-          }
-
+          {(littleNavLinks.length > 0 || utilityContents.length > 0) && (
+            <SprkMastheadLittleNav
+              selector={selector}
+              spacing={variant === 'extended' ? 'medium' : 'large'}
+              links={littleNavLinks}
+              utilityContents={utilityContents}
+            />
+          )}
         </div>
         {bigNavLinks.length > 0 && <SprkMastheadBigNav links={bigNavLinks} />}
         {narrowNavLinks.length > 0 && (
-        <SprkMastheadNarrowNav
-          selector={narrowSelector}
-          links={narrowNavLinks}
-          isOpen={narrowNavOpen}
-        />
+          <SprkMastheadNarrowNav
+            selector={narrowSelector}
+            links={narrowNavLinks}
+            isOpen={narrowNavOpen}
+          />
         )}
       </header>
     );
@@ -117,69 +114,73 @@ SprkMasthead.propTypes = {
   // assigned to data-analytics
   analyticsString: PropTypes.string,
   // array of link objects to use in building the big nav
-  bigNavLinks: PropTypes.arrayOf(PropTypes.shape(
-    {
+  bigNavLinks: PropTypes.arrayOf(
+    PropTypes.shape({
       element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
       text: PropTypes.string,
-      subNavLinks: PropTypes.arrayOf(PropTypes.shape(
-        {
+      subNavLinks: PropTypes.arrayOf(
+        PropTypes.shape({
           text: PropTypes.string,
           element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-        },
-      )),
-    },
-  )),
+        }),
+      ),
+    }),
+  ),
   // assigned to data-id
   idString: PropTypes.string,
   // array of link objects to use in building the little nav
-  littleNavLinks: PropTypes.arrayOf(PropTypes.shape(
-    {
+  littleNavLinks: PropTypes.arrayOf(
+    PropTypes.shape({
       element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
       text: PropTypes.string,
-      subNavLinks: PropTypes.arrayOf(PropTypes.shape(
-        {
+      subNavLinks: PropTypes.arrayOf(
+        PropTypes.shape({
           element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
           text: PropTypes.string,
-        },
-      )),
-    },
-  )),
+        }),
+      ),
+    }),
+  ),
   // array of link objects to use in building the narrow nav
-  narrowNavLinks: PropTypes.arrayOf(PropTypes.shape(
-    {
+  narrowNavLinks: PropTypes.arrayOf(
+    PropTypes.shape({
       element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
       text: PropTypes.string,
-      subNavLinks: PropTypes.arrayOf(PropTypes.shape(
-        {
+      subNavLinks: PropTypes.arrayOf(
+        PropTypes.shape({
           text: PropTypes.string,
           element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-        },
-      )),
-    },
-  )),
+        }),
+      ),
+    }),
+  ),
   // object containing an array of objects to use in building the narrow selector
   narrowSelector: PropTypes.shape({
     choiceFunction: PropTypes.func,
     footer: PropTypes.node,
-    items: PropTypes.arrayOf(PropTypes.shape({
-      element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-      information: PropTypes.string,
-      text: PropTypes.string,
-      title: PropTypes.string,
-      value: PropTypes.string,
-    })),
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+        information: PropTypes.string,
+        text: PropTypes.string,
+        title: PropTypes.string,
+        value: PropTypes.string,
+      }),
+    ),
   }),
   // object containing an array of objects to use in building the selector
   selector: PropTypes.shape({
     choiceFunction: PropTypes.func,
     footer: PropTypes.node,
-    items: PropTypes.arrayOf(PropTypes.shape({
-      element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-      information: PropTypes.string,
-      text: PropTypes.string,
-      title: PropTypes.string,
-      value: PropTypes.string,
-    })),
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+        information: PropTypes.string,
+        text: PropTypes.string,
+        title: PropTypes.string,
+        value: PropTypes.string,
+      }),
+    ),
   }),
   // expects a component to render the logo
   siteLogo: PropTypes.node,

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -6,6 +6,7 @@ import SprkMastheadMenuIcon from './components/SprkMastheadMenuIcon/SprkMasthead
 import SprkMastheadLittleNav from './components/SprkMastheadLittleNav/SprkMastheadLittleNav';
 import SprkMastheadNarrowNav from './components/SprkMastheadNarrowNav/SprkMastheadNarrowNav';
 import SprkMastheadBigNav from './components/SprkMastheadBigNav/SprkMastheadBigNav';
+import SprkLink from '../SprkLink/SprkLink';
 
 class SprkMasthead extends Component {
   constructor() {
@@ -83,7 +84,9 @@ class SprkMasthead extends Component {
           />
 
           <div className="sprk-c-Masthead__branding sprk-o-Stack__item sprk-o-Stack__item--center-column@xxs">
-            <a href="/">{siteLogo}</a>
+            <SprkLink variant="unstyled" href="/">
+              {siteLogo}
+            </SprkLink>
           </div>
 
           {(littleNavLinks.length > 0 || utilityContents.length > 0) && (
@@ -191,16 +194,8 @@ SprkMasthead.propTypes = {
 };
 
 SprkMasthead.defaultProps = {
-  additionalClasses: '',
-  analyticsString: '',
-  bigNavLinks: [],
-  idString: '',
   littleNavLinks: [],
-  narrowNavLinks: [],
-  narrowSelector: {},
-  selector: {},
-  siteLogo: [],
-  utilityContents: [],
+  bigNavLinks: [],
   variant: 'default',
 };
 

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -195,7 +195,9 @@ SprkMasthead.propTypes = {
 
 SprkMasthead.defaultProps = {
   littleNavLinks: [],
+  narrowNavLinks: [],
   bigNavLinks: [],
+  utilityContents: [],
   variant: 'default',
 };
 

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.test.js
@@ -41,7 +41,9 @@ it('should not add height 100 on html if its already there', () => {
   document.documentElement.style.height = '100%';
   document.documentElement.setAttribute('class', '');
   mount(<SprkMasthead />, { attachTo: div });
-  expect(document.documentElement.classList.contains('sprk-u-Height--100')).toBe(false);
+  expect(
+    document.documentElement.classList.contains('sprk-u-Height--100'),
+  ).toBe(false);
 });
 
 it('should not add height 100 on body if its already there', () => {
@@ -60,7 +62,7 @@ it('should update state on scroll', () => {
   expect(wrapper.state().isScrolled).toBe(true);
 });
 
-it('should update state on scroll', () => {
+it('should update state on scroll to top', () => {
   const wrapper = mount(<SprkMasthead />);
   window.scrollY = 1;
   window.dispatchEvent(new Event('scroll'));
@@ -85,8 +87,10 @@ it('should render the little nav if only utilityContents are provided', () => {
   expect(wrapper.find(SprkMastheadLittleNav).length).toBe(1);
 });
 
-it('should set spacing appropriately', () => {
-  const wrapper = mount(<SprkMasthead littleNavLinks={[{ text: 'Hi' }]} variant="extended" />);
+it('should set spacing appropriately when variant is extended', () => {
+  const wrapper = mount(
+    <SprkMasthead littleNavLinks={[{ text: 'Hi' }]} variant="extended" />,
+  );
   expect(wrapper.find(SprkMastheadLittleNav).props().spacing).toBe('medium');
 });
 

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordion/SprkMastheadAccordion.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordion/SprkMastheadAccordion.js
@@ -57,6 +57,7 @@ SprkMastheadAccordion.propTypes = {
 };
 
 SprkMastheadAccordion.defaultProps = {
+  links: [],
 };
 
 export default SprkMastheadAccordion;

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordion/SprkMastheadAccordion.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordion/SprkMastheadAccordion.js
@@ -57,10 +57,6 @@ SprkMastheadAccordion.propTypes = {
 };
 
 SprkMastheadAccordion.defaultProps = {
-  additionalClasses: '',
-  analyticsString: '',
-  idString: '',
-  links: [],
 };
 
 export default SprkMastheadAccordion;

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordion/SprkMastheadAccordion.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordion/SprkMastheadAccordion.js
@@ -13,23 +13,19 @@ class SprkMastheadAccordion extends React.Component {
   }
 
   render() {
-    const {
-      additionalClasses, analyticsString, idString,
-    } = this.props;
-    const {
-      links,
-    } = this.state;
+    const { additionalClasses, analyticsString, idString } = this.props;
+    const { links } = this.state;
     return (
       <ul
         data-analytics={analyticsString}
         data-id={idString}
-        className={classNames('sprk-c-MastheadAccordion sprk-b-List sprk-b-List--bare', additionalClasses)}
+        className={classNames(
+          'sprk-c-MastheadAccordion sprk-b-List sprk-b-List--bare',
+          additionalClasses,
+        )}
       >
         {links.map(link => (
-          <SprkMastheadAccordionItem
-            {...link}
-            key={link.id}
-          />
+          <SprkMastheadAccordionItem {...link} key={link.id} />
         ))}
       </ul>
     );
@@ -44,16 +40,20 @@ SprkMastheadAccordion.propTypes = {
   // assigned to data-id
   idString: PropTypes.string,
   // used to render SprkMastheadAccordionItems inside
-  links: PropTypes.arrayOf(PropTypes.shape({
-    element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    leadingIcon: PropTypes.string,
-    text: PropTypes.string,
-    subNavLinks: PropTypes.arrayOf(PropTypes.shape({
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
       element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
       leadingIcon: PropTypes.string,
       text: PropTypes.string,
-    })),
-  })),
+      subNavLinks: PropTypes.arrayOf(
+        PropTypes.shape({
+          element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+          leadingIcon: PropTypes.string,
+          text: PropTypes.string,
+        }),
+      ),
+    }),
+  ),
 };
 
 SprkMastheadAccordion.defaultProps = {

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordion/SprkMastheadAccordion.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordion/SprkMastheadAccordion.test.js
@@ -12,12 +12,16 @@ it('should render a trigger with the correct classes', () => {
 });
 
 it('should add classes when additionalClasses has a value', () => {
-  const wrapper = mount(<SprkMastheadAccordion additionalClasses="sprk-u-man" />);
+  const wrapper = mount(
+    <SprkMastheadAccordion additionalClasses="sprk-u-man" />,
+  );
   expect(wrapper.find('.sprk-c-MastheadAccordion.sprk-u-man').length).toBe(1);
 });
 
 it('should assign data-analytics when analyticsString has a value', () => {
-  const wrapper = mount(<SprkMastheadAccordion SprkDropdown analyticsString="321" />);
+  const wrapper = mount(
+    <SprkMastheadAccordion SprkDropdown analyticsString="321" />,
+  );
   expect(wrapper.find('[data-analytics="321"]').length).toBe(1);
 });
 

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -58,7 +58,6 @@ class SprkMastheadAccordionItem extends Component {
           <React.Fragment>
             <SprkLink
               variant="unstyled"
-              href="#nogo"
               additionalClasses="sprk-c-MastheadAccordion__summary"
               onClick={this.toggleAccordionOpen}
               aria-expanded={isOpen ? 'true' : 'false'}
@@ -172,7 +171,6 @@ SprkMastheadAccordionItem.propTypes = {
 SprkMastheadAccordionItem.defaultProps = {
   defaultOpen: false,
   element: 'a',
-  href: '#nogo',
   isActive: false,
   isButton: false,
   subNavLinks: [],

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { uniqueId } from 'lodash';
 import SprkIcon from '../../../SprkIcon/SprkIcon';
+import SprkLink from '../../../SprkLink/SprkLink';
 
 class SprkMastheadAccordionItem extends Component {
   constructor(props) {
@@ -55,9 +56,10 @@ class SprkMastheadAccordionItem extends Component {
       >
         {stateLinks.length > 0 && (
           <React.Fragment>
-            <a
+            <SprkLink
+              variant="unstyled"
               href="#nogo"
-              className="sprk-c-MastheadAccordion__summary"
+              additionalClasses="sprk-c-MastheadAccordion__summary"
               onClick={this.toggleAccordionOpen}
               aria-expanded={isOpen ? 'true' : 'false'}
             >
@@ -68,7 +70,7 @@ class SprkMastheadAccordionItem extends Component {
                 additionalClasses={classNames({ 'sprk-c-Icon--open': isOpen })}
                 iconName="chevron-down"
               />
-            </a>
+            </SprkLink>
             <AnimateHeight duration={300} height={height}>
               <ul className="sprk-b-List sprk-b-List--bare sprk-c-MastheadAccordion__details">
                 {stateLinks.map(subnavlink => {
@@ -168,17 +170,11 @@ SprkMastheadAccordionItem.propTypes = {
 };
 
 SprkMastheadAccordionItem.defaultProps = {
-  additionalClasses: '',
-  analyticsString: '',
   defaultOpen: false,
   element: 'a',
   href: '#nogo',
-  idString: '',
   isActive: false,
   isButton: false,
-  leadingIcon: '',
-  subNavLinks: [],
-  text: '',
 };
 
 export default SprkMastheadAccordionItem;

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -175,6 +175,7 @@ SprkMastheadAccordionItem.defaultProps = {
   href: '#nogo',
   isActive: false,
   isButton: false,
+  subNavLinks: [],
 };
 
 export default SprkMastheadAccordionItem;

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -85,9 +85,7 @@ class SprkMastheadAccordionItem extends Component {
                     <li key={innerId}>
                       <InnerTagName
                         href={
-                          InnerTagName === 'a'
-                            ? innerHref || '#nogo'
-                            : undefined
+                          InnerTagName === 'a' ? innerHref || '#nogo' : undefined
                         }
                         className={classNames(
                           'sprk-b-Link sprk-b-Link--plain sprk-c-Masthead__link',
@@ -174,6 +172,7 @@ SprkMastheadAccordionItem.defaultProps = {
   isActive: false,
   isButton: false,
   subNavLinks: [],
+  href: '#nogo',
 };
 
 export default SprkMastheadAccordionItem;

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
@@ -18,7 +18,10 @@ it('should default to open if defaultOpen is true', () => {
 
 it('should toggle the accordion open on click', () => {
   const wrapper = mount(
-    <SprkMastheadAccordionItem text="Item 1" subNavLinks={[{ text: 'Item 1' }]} />,
+    <SprkMastheadAccordionItem
+      text="Item 1"
+      subNavLinks={[{ text: 'Item 1' }]}
+    />,
   );
   expect(wrapper.state().isOpen).toBe(false);
   wrapper.find('.sprk-c-MastheadAccordion__summary').simulate('click');
@@ -35,7 +38,9 @@ it('should render the supplied element', () => {
 it('should render the supplied href', () => {
   const wrapper = mount(
     <SprkMastheadAccordionItem
-      subNavLinks={[{ text: 'Item 1', element: 'a', href: 'https://www.google.com' }]}
+      subNavLinks={[
+        { text: 'Item 1', element: 'a', href: 'https://www.google.com' },
+      ]}
     />,
   );
   expect(
@@ -48,7 +53,9 @@ it('should render the supplied href', () => {
 
 it('should render the supplied href as #nogo if not supplied', () => {
   const wrapper = mount(
-    <SprkMastheadAccordionItem subNavLinks={[{ text: 'Item 1', element: 'a' }]} />,
+    <SprkMastheadAccordionItem
+      subNavLinks={[{ text: 'Item 1', element: 'a' }]}
+    />,
   );
   expect(
     wrapper
@@ -60,7 +67,9 @@ it('should render the supplied href as #nogo if not supplied', () => {
 
 it('should not render href if element supplied is not a (subnav)', () => {
   const wrapper = mount(
-    <SprkMastheadAccordionItem subNavLinks={[{ text: 'Item 1', element: 'span' }]} />,
+    <SprkMastheadAccordionItem
+      subNavLinks={[{ text: 'Item 1', element: 'span' }]}
+    />,
   );
   expect(
     wrapper
@@ -91,7 +100,9 @@ it('should render href as #nogo if element supplied is a and href is not supplie
 });
 
 it('should render href as supplied value', () => {
-  const wrapper = mount(<SprkMastheadAccordionItem element="a" href="https://www.google.com" />);
+  const wrapper = mount(
+    <SprkMastheadAccordionItem element="a" href="https://www.google.com" />,
+  );
   expect(
     wrapper
       .find('.sprk-c-MastheadAccordion__summary')
@@ -103,24 +114,33 @@ it('should render href as supplied value', () => {
 it('should add a class if isActive is true', () => {
   const wrapper = mount(<SprkMastheadAccordionItem isActive />);
   expect(
-    wrapper.find('.sprk-c-MastheadAccordion__item.sprk-c-MastheadAccordion__item--active').length,
+    wrapper.find(
+      '.sprk-c-MastheadAccordion__item.sprk-c-MastheadAccordion__item--active'
+    ).length,
   ).toBe(1);
 });
 
 it('should render as add classes if isButton is true', () => {
   const wrapper = mount(<SprkMastheadAccordionItem isButton />);
-  expect(wrapper.find('.sprk-c-MastheadAccordion__item.sprk-o-Box').length).toBe(1);
+  expect(
+    wrapper.find('.sprk-c-MastheadAccordion__item.sprk-o-Box').length,
+  ).toBe(1);
   expect(wrapper.find('span.sprk-c-MastheadAccordion__heading').length).toBe(0);
 });
 
 it('should render the right icon if leadingIcon has value', () => {
   const wrapper = mount(<SprkMastheadAccordionItem leadingIcon="settings" />);
-  expect(wrapper.find('.sprk-c-Icon > use[xlinkHref="#settings"]').length).toBe(1);
+  expect(wrapper.find('.sprk-c-Icon > use[xlinkHref="#settings"]').length).toBe(
+    1,
+  );
 });
 
 it('should add aria-expanded="true" when the item is open', () => {
   const wrapper = mount(
-    <SprkMastheadAccordionItem text="Item 1" subNavLinks={[{ text: 'Item 1' }]} />,
+    <SprkMastheadAccordionItem
+      text="Item 1"
+      subNavLinks={[{ text: 'Item 1' }]}
+    />,
   );
   expect(wrapper.state().isOpen).toBe(false);
   wrapper.find('.sprk-c-MastheadAccordion__summary').simulate('click');

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
@@ -144,5 +144,5 @@ it('should add aria-expanded="true" when the item is open', () => {
   );
   expect(wrapper.state().isOpen).toBe(false);
   wrapper.find('.sprk-c-MastheadAccordion__summary').simulate('click');
-  expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
+  expect(wrapper.find('[aria-expanded="true"]').length).toBe(2);
 });

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadBigNav/SprkMastheadBigNav.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadBigNav/SprkMastheadBigNav.js
@@ -13,27 +13,28 @@ class SprkMastheadBigNav extends Component {
   }
 
   render() {
-    const {
-      additionalClasses, analyticsString, idString,
-    } = this.props;
-    const {
-      links,
-    } = this.state;
+    const { additionalClasses, analyticsString, idString } = this.props;
+    const { links } = this.state;
     return (
       <React.Fragment>
         <div className="sprk-o-Stack__item">
           <nav
-            className={classNames('sprk-c-Masthead__big-nav', additionalClasses)}
+            className={classNames(
+              'sprk-c-Masthead__big-nav',
+              additionalClasses,
+            )}
             data-analytics={analyticsString}
             data-id={idString}
             role="navigation"
           >
-            <ul
-              className="sprk-c-Masthead__big-nav-items sprk-o-Stack sprk-o-Stack--misc-a sprk-o-Stack--center-row sprk-o-Stack--split@xxs sprk-b-List sprk-b-List--bare"
-            >
-              {links.map((link) => {
+            <ul className="sprk-c-Masthead__big-nav-items sprk-o-Stack sprk-o-Stack--misc-a sprk-o-Stack--center-row sprk-o-Stack--split@xxs sprk-b-List sprk-b-List--bare">
+              {links.map(link => {
                 const {
-                  element, additionalContainerClasses, isActive, text, ...rest
+                  element,
+                  additionalContainerClasses,
+                  isActive,
+                  text,
+                  ...rest
                 } = link;
                 const TagName = element || 'a';
                 return (
@@ -45,17 +46,22 @@ class SprkMastheadBigNav extends Component {
                     )}
                     key={link.id}
                   >
-                    { !link.subNavLinks
-                        && <TagName className={classNames('sprk-b-Link sprk-b-Link--plain sprk-c-Masthead__link sprk-c-Masthead__link--big-nav')} {...rest}>{text}</TagName>
-                      }
-                    { link.subNavLinks
-                    && (
-                    <SprkMastheadDropdown
-                      choices={{ items: link.subNavLinks }}
-                      triggerText={link.text}
-                    />
-                    )
-                    }
+                    {!link.subNavLinks && (
+                      <TagName
+                        className={classNames(
+                          'sprk-b-Link sprk-b-Link--plain sprk-c-Masthead__link sprk-c-Masthead__link--big-nav',
+                        )}
+                        {...rest}
+                      >
+                        {text}
+                      </TagName>
+                    )}
+                    {link.subNavLinks && (
+                      <SprkMastheadDropdown
+                        choices={{ items: link.subNavLinks }}
+                        triggerText={link.text}
+                      />
+                    )}
                   </li>
                 );
               })}
@@ -75,16 +81,18 @@ SprkMastheadBigNav.propTypes = {
   // assigned to data-id
   idString: PropTypes.string,
   // used to render navigation inside
-  links: PropTypes.arrayOf(PropTypes.shape({
-    // The element to render, can be 'a' or a Component like Link
-    element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    // Classes to apply to the container of the link
-    additionalContainerClasses: PropTypes.string,
-    // Adds a class if the link is active
-    isActive: PropTypes.bool,
-    // The link text
-    text: PropTypes.string,
-  })).isRequired,
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      // The element to render, can be 'a' or a Component like Link
+      element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      // Classes to apply to the container of the link
+      additionalContainerClasses: PropTypes.string,
+      // Adds a class if the link is active
+      isActive: PropTypes.bool,
+      // The link text
+      text: PropTypes.string,
+    }),
+  ).isRequired,
 };
 
 SprkMastheadBigNav.defaultProps = {

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadBigNav/SprkMastheadBigNav.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadBigNav/SprkMastheadBigNav.test.js
@@ -14,13 +14,17 @@ it('should render an element with the correct class', () => {
 
 it('should add classes when additionalClasses has a value', () => {
   const links = [{ text: 'Item 1' }];
-  const wrapper = mount(<SprkMastheadBigNav links={links} additionalClasses="sprk-u-man" />);
+  const wrapper = mount(
+    <SprkMastheadBigNav links={links} additionalClasses="sprk-u-man" />,
+  );
   expect(wrapper.find('.sprk-c-Masthead__big-nav.sprk-u-man').length).toBe(1);
 });
 
 it('should assign data-analytics when analyticsString has a value', () => {
   const links = [{ text: 'Item 1' }];
-  const wrapper = mount(<SprkMastheadBigNav links={links} analyticsString="321" />);
+  const wrapper = mount(
+    <SprkMastheadBigNav links={links} analyticsString="321" />,
+  );
   expect(wrapper.find('[data-analytics="321"]').length).toBe(1);
 });
 

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
@@ -178,6 +178,9 @@ SprkMastheadDropdown.defaultProps = {
   triggerText: 'Choose One...',
   iconName: 'chevron-down',
   variant: 'base',
+  choices: {
+    items: [],
+  },
 };
 
 export default SprkMastheadDropdown;

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { uniqueId } from 'lodash';
 import SprkIcon from '../../../SprkIcon/SprkIcon';
+import SprkLink from '../../../SprkLink/SprkLink';
 
 class SprkMastheadDropdown extends Component {
   constructor(props) {
@@ -74,10 +75,9 @@ class SprkMastheadDropdown extends Component {
     const { choiceItems, isOpen } = this.state;
     return (
       <div ref={this.myRef}>
-        <a
-          className={classNames(
-            'sprk-b-Link',
-            'sprk-b-Link--plain',
+        <SprkLink
+          variant="plain"
+          additionalClasses={classNames(
             { 'sprk-u-mrs': variant === 'informational' },
             additionalTriggerClasses,
           )}
@@ -98,7 +98,7 @@ class SprkMastheadDropdown extends Component {
             )}
             iconName={iconName}
           />
-        </a>
+        </SprkLink>
         {isOpen && (
           <div
             className={classNames(
@@ -175,19 +175,8 @@ SprkMastheadDropdown.propTypes = {
 };
 
 SprkMastheadDropdown.defaultProps = {
-  additionalClasses: '',
-  additionalIconClasses: '',
-  additionalTriggerClasses: '',
-  additionalTriggerTextClasses: '',
-  analyticsString: '',
-  children: [],
-  choices: {
-    items: [],
-  },
   triggerText: 'Choose One...',
   iconName: 'chevron-down',
-  idString: '',
-  title: '',
   variant: 'base',
 };
 

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
@@ -10,7 +10,10 @@ class SprkMastheadDropdown extends Component {
     super(props);
     this.state = {
       isOpen: false,
-      choiceItems: props.choices.items.map(item => ({ id: uniqueId(), ...item })),
+      choiceItems: props.choices.items.map(item => ({
+        id: uniqueId(),
+        ...item,
+      })),
     };
     this.toggleDropdownOpen = this.toggleDropdownOpen.bind(this);
     this.closeOnEsc = this.closeOnEsc.bind(this);
@@ -85,41 +88,48 @@ class SprkMastheadDropdown extends Component {
           role="listbox"
           onClick={this.toggleDropdownOpen}
         >
-          <span className={classNames(additionalTriggerTextClasses)}>{triggerText}</span>
-          <SprkIcon additionalClasses={classNames('sprk-c-Icon--stroke-current-color sprk-u-mls', additionalIconClasses)} iconName={iconName} />
+          <span className={classNames(additionalTriggerTextClasses)}>
+            {triggerText}
+          </span>
+          <SprkIcon
+            additionalClasses={classNames(
+              'sprk-c-Icon--stroke-current-color sprk-u-mls',
+              additionalIconClasses,
+            )}
+            iconName={iconName}
+          />
         </a>
-        {isOpen
-        && (
-        <div className={classNames('sprk-c-Dropdown sprk-u-TextAlign--left', additionalClasses)}>
-          {title !== ''
-          && (
-          <div className="sprk-c-Dropdown__header">
-            <h2 className="sprk-c-Dropdown__title">{title}</h2>
+        {isOpen && (
+          <div
+            className={classNames(
+              'sprk-c-Dropdown sprk-u-TextAlign--left',
+              additionalClasses,
+            )}
+          >
+            {title !== '' && (
+              <div className="sprk-c-Dropdown__header">
+                <h2 className="sprk-c-Dropdown__title">{title}</h2>
+              </div>
+            )}
+            <ul className="sprk-c-Dropdown__links">
+              {choiceItems.map(choice => {
+                const { element, href, text, ...rest } = choice;
+                const TagName = element || 'a';
+                return (
+                  <li className="sprk-c-Dropdown__item" key={choice.id}>
+                    <TagName
+                      href={TagName === 'a' ? href || '#nogo' : undefined}
+                      className="sprk-c-Dropdown__link"
+                      {...rest}
+                    >
+                      {text}
+                    </TagName>
+                  </li>
+                );
+              })}
+            </ul>
           </div>
-          )
-          }
-          <ul className="sprk-c-Dropdown__links">
-            {choiceItems.map((choice) => {
-              const {
-                element, href, text, ...rest
-              } = choice;
-              const TagName = element || 'a';
-              return (
-                <li className="sprk-c-Dropdown__item" key={choice.id}>
-                  <TagName
-                    href={TagName === 'a' ? href || '#nogo' : undefined}
-                    className="sprk-c-Dropdown__link"
-                    {...rest}
-                  >
-                    {text}
-                  </TagName>
-                </li>);
-            })
-            }
-          </ul>
-        </div>
-        )
-        }
+        )}
       </div>
     );
   }
@@ -141,14 +151,16 @@ SprkMastheadDropdown.propTypes = {
   // Choices object that builds the dropdown contents
   choices: PropTypes.shape({
     // An array of objects that describe the items in the menu
-    items: PropTypes.arrayOf(PropTypes.shape({
-      // The element to render for each menu item
-      element: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-      // Assigned to href of the element is 'a'
-      href: PropTypes.string,
-      // The text inside the item
-      text: PropTypes.string,
-    })),
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        // The element to render for each menu item
+        element: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+        // Assigned to href of the element is 'a'
+        href: PropTypes.string,
+        // The text inside the item
+        text: PropTypes.string,
+      }),
+    ),
   }),
   // The text set as the default of the trigger link
   triggerText: PropTypes.string,

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.test.js
@@ -42,12 +42,12 @@ it('should add classes to the trigger text when additionalTriggerTextClasses has
 
 it('should assign data-analytics when analyticsString has a value', () => {
   const wrapper = mount(<SprkMastheadDropdown analyticsString="321" />);
-  expect(wrapper.find('[data-analytics="321"]').length).toBe(1);
+  expect(wrapper.find('[data-analytics="321"]').length).toBe(2);
 });
 
 it('should assign data-id when idString has a value', () => {
   const wrapper = mount(<SprkMastheadDropdown idString="321" />);
-  expect(wrapper.find('[data-id="321"]').length).toBe(1);
+  expect(wrapper.find('[data-id="321"]').length).toBe(2);
 });
 
 it('should assign the choices header when title has a value', () => {

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.test.js
@@ -12,23 +12,31 @@ it('should render a trigger with the correct classes', () => {
 });
 
 it('should add classes to the dropdown when additionalClasses has a value', () => {
-  const wrapper = mount(<SprkMastheadDropdown additionalClasses="sprk-u-man" />);
+  const wrapper = mount(
+    <SprkMastheadDropdown additionalClasses="sprk-u-man" />,
+  );
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('.sprk-c-Dropdown.sprk-u-man').length).toBe(1);
 });
 
 it('should add classes to the icon when additionalIconClasses has a value', () => {
-  const wrapper = mount(<SprkMastheadDropdown additionalIconClasses="sprk-c-Icon--l" />);
+  const wrapper = mount(
+    <SprkMastheadDropdown additionalIconClasses="sprk-c-Icon--l" />,
+  );
   expect(wrapper.find('.sprk-c-Icon.sprk-c-Icon--l').length).toBe(1);
 });
 
 it('should add classes to the trigger when additionalTriggerClasses has a value', () => {
-  const wrapper = mount(<SprkMastheadDropdown additionalTriggerClasses="sprk-u-man" />);
+  const wrapper = mount(
+    <SprkMastheadDropdown additionalTriggerClasses="sprk-u-man" />,
+  );
   expect(wrapper.find('.sprk-b-Link.sprk-u-man').length).toBe(1);
 });
 
 it('should add classes to the trigger text when additionalTriggerTextClasses has a value', () => {
-  const wrapper = mount(<SprkMastheadDropdown additionalTriggerTextClasses="sprk-u-man" />);
+  const wrapper = mount(
+    <SprkMastheadDropdown additionalTriggerTextClasses="sprk-u-man" />,
+  );
   expect(wrapper.find('span.sprk-u-man').length).toBe(1);
 });
 
@@ -49,7 +57,12 @@ it('should assign the choices header when title has a value', () => {
 });
 
 it('should build the correct number of choices from a choices object', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
   const wrapper = mount(<SprkMastheadDropdown choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('.sprk-c-Dropdown__link').length).toBe(2);
@@ -91,15 +104,27 @@ it('should unmount without error', () => {
 });
 
 it('should render the choices with the element specified', () => {
-  const wrapper = mount(<SprkMastheadDropdown choices={{ items: [{ element: 'p', text: 'Item 1' }] }} />);
+  const wrapper = mount(
+    <SprkMastheadDropdown
+      choices={{ items: [{ element: 'p', text: 'Item 1' }] }}
+    />,
+  );
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('p.sprk-c-Dropdown__link').length).toBe(1);
 });
 
 it('should pass unused keys on choice items through to the dom', () => {
-  const wrapper = mount(<SprkMastheadDropdown choices={{ items: [{ element: 'p', text: 'Item 1', 'aria-hidden': 'true' }] }} />);
+  const wrapper = mount(
+    <SprkMastheadDropdown
+      choices={{
+        items: [{ element: 'p', text: 'Item 1', 'aria-hidden': 'true' }]
+      }}
+    />,
+  );
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
   wrapper.find('.sprk-b-Link').simulate('click');
-  expect(wrapper.find('.sprk-c-Dropdown__link[aria-hidden="true"]').length).toBe(1);
+  expect(
+    wrapper.find('.sprk-c-Dropdown__link[aria-hidden="true"]').length,
+  ).toBe(1);
 });

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadLittleNav/SprkMastheadLittleNav.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadLittleNav/SprkMastheadLittleNav.js
@@ -9,7 +9,10 @@ class SprkMastheadLittleNav extends Component {
     super(props);
     const { links, utilityContents } = props;
     this.state = {
-      utilityContents: utilityContents.map(item => ({ id: uniqueId(), ...item })),
+      utilityContents: utilityContents.map(item => ({
+        id: uniqueId(),
+        ...item,
+      })),
       links: links.map(link => ({ id: uniqueId(), ...link })),
     };
   }
@@ -22,27 +25,24 @@ class SprkMastheadLittleNav extends Component {
       selector,
       spacing,
     } = this.props;
-    const {
-      links,
-      utilityContents,
-    } = this.state;
+    const { links, utilityContents } = this.state;
     return (
       <nav
         role="navigation"
         data-analytics={analyticsString}
         data-id={idString}
-        className={
-             classNames('sprk-c-Masthead__little-nav sprk-o-Stack__item sprk-o-Stack__item--flex@xxs sprk-o-Stack sprk-o-Stack--misc-a sprk-o-Stack--split@xxs sprk-o-Stack--end-row', additionalClasses)}
+        className={classNames(
+          'sprk-c-Masthead__little-nav sprk-o-Stack__item sprk-o-Stack__item--flex@xxs sprk-o-Stack sprk-o-Stack--misc-a sprk-o-Stack--split@xxs sprk-o-Stack--end-row',
+          additionalClasses,
+        )}
       >
-        {selector.items
-          && (
+        {selector.items && (
           <div className="sprk-o-Stack__item sprk-o-Stack__item--flex@xxs sprk-o-Stack sprk-o-Stack--center-column sprk-o-Stack--center-row">
             <div className="sprk-o-Stack__item sprk-u-Position--relative">
               <SprkMastheadSelector choices={selector} />
             </div>
           </div>
-          )
-        }
+        )}
         <ul
           className={classNames(
             'sprk-c-Masthead__site-links',
@@ -53,10 +53,8 @@ class SprkMastheadLittleNav extends Component {
             'sprk-o-Stack__item--center-column',
           )}
         >
-          {links.map((link) => {
-            const {
-              element, href, text, ...rest
-            } = link;
+          {links.map(link => {
+            const { element, href, text, ...rest } = link;
             const TagName = element || 'a';
             return (
               <li key={link.id}>
@@ -81,9 +79,7 @@ class SprkMastheadLittleNav extends Component {
           )}
         >
           {utilityContents.map(item => (
-            <li key={item.id}>
-              {item}
-            </li>
+            <li key={item.id}>{item}</li>
           ))}
         </ul>
       </nav>
@@ -99,27 +95,31 @@ SprkMastheadLittleNav.propTypes = {
   // assigned to data-id
   idString: PropTypes.string,
   // used to render navigation inside
-  links: PropTypes.arrayOf(PropTypes.shape({
-    // The element to render, can be 'a' or a Component like Link
-    element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    // Classes to apply to the container of the link
-    additionalContainerClasses: PropTypes.string,
-    // Adds a class if the link is active
-    isActive: PropTypes.bool,
-    // The link text
-    text: PropTypes.string,
-  })),
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      // The element to render, can be 'a' or a Component like Link
+      element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      // Classes to apply to the container of the link
+      additionalContainerClasses: PropTypes.string,
+      // Adds a class if the link is active
+      isActive: PropTypes.bool,
+      // The link text
+      text: PropTypes.string,
+    }),
+  ),
   // Choices object that builds the dropdown contents
   selector: PropTypes.shape({
     // An array of objects that describe the items in the menu
-    items: PropTypes.arrayOf(PropTypes.shape({
-      // The element to render for each menu item
-      element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-      // Assigned to href of the element is 'a'
-      href: PropTypes.string,
-      // The text inside the item
-      text: PropTypes.string,
-    })),
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        // The element to render for each menu item
+        element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+        // Assigned to href of the element is 'a'
+        href: PropTypes.string,
+        // The text inside the item
+        text: PropTypes.string,
+      }),
+    ),
   }),
   // Determines the spacing between little nav items
   spacing: PropTypes.oneOf(['medium', 'large']),

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadLittleNav/SprkMastheadLittleNav.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadLittleNav/SprkMastheadLittleNav.test.js
@@ -16,13 +16,19 @@ it('should render an element with the correct class', () => {
 
 it('should add classes when additionalClasses has a value', () => {
   const links = [{ text: 'Item 1' }];
-  const wrapper = mount(<SprkMastheadLittleNav links={links} additionalClasses="sprk-u-man" />);
-  expect(wrapper.find('.sprk-c-Masthead__little-nav.sprk-u-man').length).toBe(1);
+  const wrapper = mount(
+    <SprkMastheadLittleNav links={links} additionalClasses="sprk-u-man" />,
+  );
+  expect(wrapper.find('.sprk-c-Masthead__little-nav.sprk-u-man').length).toBe(
+    1,
+  );
 });
 
 it('should assign data-analytics when analyticsString has a value', () => {
   const links = [{ text: 'Item 1' }];
-  const wrapper = mount(<SprkMastheadLittleNav links={links} analyticsString="321" />);
+  const wrapper = mount(
+    <SprkMastheadLittleNav links={links} analyticsString="321" />,
+  );
   expect(wrapper.find('[data-analytics="321"]').length).toBe(1);
 });
 
@@ -33,28 +39,68 @@ it('should assign data-id when idString has a value', () => {
 });
 
 it('should render the selector if selector.items is defined', () => {
-  const wrapper = mount(<SprkMastheadLittleNav selector={{ choiceFunction: () => { console.log('hi'); }, items: [{ text: 'Item 1' }] }} />);
+  const wrapper = mount(
+    <SprkMastheadLittleNav
+      selector={{
+        choiceFunction: () => {
+          console.log('hi');
+        },
+        items: [{ text: 'Item 1' }],
+      }}
+    />,
+  );
   expect(wrapper.find(SprkMastheadSelector).length).toBe(1);
 });
 
 it('should not render the selector if selector.items is not defined', () => {
-  const wrapper = mount(<SprkMastheadLittleNav selector={{ choiceFunction: () => { console.log('hi'); } }} />);
+  const wrapper = mount(
+    <SprkMastheadLittleNav
+      selector={{
+        choiceFunction: () => {
+          console.log('hi');
+        },
+      }}
+    />,
+  );
   expect(wrapper.find(SprkMastheadSelector).length).toBe(0);
 });
 
 it('should render href on the link if supplied', () => {
-  const wrapper = mount(<SprkMastheadLittleNav links={[{ text: 'Item 1', href: 'https://www.google.com' }]} />);
-  expect(wrapper.find('.sprk-c-Masthead__link').instance().getAttribute('href')).toBe('https://www.google.com');
+  const wrapper = mount(
+    <SprkMastheadLittleNav
+      links={[{ text: 'Item 1', href: 'https://www.google.com' }]}
+    />,
+  );
+  expect(
+    wrapper
+      .find('.sprk-c-Masthead__link')
+      .instance()
+      .getAttribute('href'),
+  ).toBe('https://www.google.com');
 });
 
 it('should not render href on the link if the element is not a', () => {
-  const wrapper = mount(<SprkMastheadLittleNav links={[{ text: 'Item 1', element: 'span' }]} />);
-  expect(wrapper.find('.sprk-c-Masthead__link').instance().getAttribute('href')).toBe(null);
+  const wrapper = mount(
+    <SprkMastheadLittleNav links={[{ text: 'Item 1', element: 'span' }]} />,
+  );
+  expect(
+    wrapper
+      .find('.sprk-c-Masthead__link')
+      .instance()
+      .getAttribute('href'),
+  ).toBe(null);
 });
 
 it('should not render href as #nogo on the link if the href is not defined', () => {
-  const wrapper = mount(<SprkMastheadLittleNav links={[{ text: 'Item 1', element: 'a' }]} />);
-  expect(wrapper.find('.sprk-c-Masthead__link').instance().getAttribute('href')).toBe('#nogo');
+  const wrapper = mount(
+    <SprkMastheadLittleNav links={[{ text: 'Item 1', element: 'a' }]} />,
+  );
+  expect(
+    wrapper
+      .find('.sprk-c-Masthead__link')
+      .instance()
+      .getAttribute('href'),
+  ).toBe('#nogo');
 });
 
 it('should render the correct number of links', () => {
@@ -76,6 +122,8 @@ it('should render the correct number of links', () => {
 it('should render utilityContents if supplied', () => {
   const utilityContents = [<SprkButton>hi</SprkButton>];
   const links = [{ text: 'Item 1' }];
-  const wrapper = mount(<SprkMastheadLittleNav links={links} utilityContents={utilityContents} />);
+  const wrapper = mount(
+    <SprkMastheadLittleNav links={links} utilityContents={utilityContents} />,
+  );
   expect(wrapper.find('.sprk-c-Button').length).toBe(1);
 });

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadMenuIcon/SprkMastheadMenuIcon.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadMenuIcon/SprkMastheadMenuIcon.js
@@ -3,15 +3,27 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 
 function SprkMastheadMenuIcon({
-  additionalClasses, analyticsString, idString, isOpen, toggleNarrowNav,
+  additionalClasses,
+  analyticsString,
+  idString,
+  isOpen,
+  toggleNarrowNav,
 }) {
   return (
     <div
-      className={classNames('sprk-c-Masthead__menu sprk-o-Stack__item sprk-o-Stack__item--center-column@xxs', additionalClasses)}
+      className={classNames(
+        'sprk-c-Masthead__menu sprk-o-Stack__item sprk-o-Stack__item--center-column@xxs',
+        additionalClasses,
+      )}
       data-analytics={analyticsString}
       data-id={idString}
     >
-      <button onClick={toggleNarrowNav} className="sprk-c-Menu" type="button" aria-expanded={isOpen ? 'true' : 'false'}>
+      <button
+        onClick={toggleNarrowNav}
+        className="sprk-c-Menu"
+        type="button"
+        aria-expanded={isOpen ? 'true' : 'false'}
+      >
         <span className="sprk-u-ScreenReaderText">Toggle Navigation</span>
         <svg
           className={classNames(
@@ -25,14 +37,22 @@ function SprkMastheadMenuIcon({
           xmlns="http://www.w3.org/2000/svg"
         >
           <g>
-            <path className="sprk-c-Menu__line sprk-c-Menu__line--two" d="m8 32h48" />
-            <path className="sprk-c-Menu__line sprk-c-Menu__line--one" d="m8 18.68h48" />
-            <path className="sprk-c-Menu__line sprk-c-Menu__line--three" d="m8 45.32h48" />
+            <path
+              className="sprk-c-Menu__line sprk-c-Menu__line--two"
+              d="m8 32h48"
+            />
+            <path
+              className="sprk-c-Menu__line sprk-c-Menu__line--one"
+              d="m8 18.68h48"
+            />
+            <path
+              className="sprk-c-Menu__line sprk-c-Menu__line--three"
+              d="m8 45.32h48"
+            />
           </g>
         </svg>
       </button>
     </div>
-
   );
 }
 

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadMenuIcon/SprkMastheadMenuIcon.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadMenuIcon/SprkMastheadMenuIcon.test.js
@@ -7,6 +7,12 @@ import SprkMastheadMenuIcon from './SprkMastheadMenuIcon';
 Enzyme.configure({ adapter: new Adapter() });
 
 it('should display an svg element with the correct base class', () => {
-  const wrapper = shallow(<SprkMastheadMenuIcon toggleNarrowNav={() => { console.log('hi'); }} />);
+  const wrapper = shallow(
+    <SprkMastheadMenuIcon
+      toggleNarrowNav={() => {
+        console.log('hi');
+      }}
+    />,
+  );
   expect(wrapper.find('svg.sprk-c-Icon').length).toBe(1);
 });

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadNarrowNav/SprkMastheadNarrowNav.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadNarrowNav/SprkMastheadNarrowNav.js
@@ -3,52 +3,55 @@ import PropTypes from 'prop-types';
 import SprkMastheadAccordion from '../SprkMastheadAccordion/SprkMastheadAccordion';
 import SprkMastheadSelector from '../SprkMastheadSelector/SprkMastheadSelector';
 
-const SprkMastheadNarrowNav = (
-  {
-    idString, isOpen, links, selector, ...rest
-  },
-) => (
+const SprkMastheadNarrowNav = ({
+  idString,
+  isOpen,
+  links,
+  selector,
+  ...rest
+}) => (
   <React.Fragment>
-    { isOpen
-      && (
+    {isOpen && (
       <nav
         className="sprk-c-Masthead__narrow-nav"
         role="navigation"
         data-id={idString}
         {...rest}
       >
-        {selector.items
-          && <SprkMastheadSelector isFlush choices={selector} />
-        }
+        {selector.items && <SprkMastheadSelector isFlush choices={selector} />}
         <SprkMastheadAccordion links={links} />
       </nav>
-      )}
+    )}
   </React.Fragment>
 );
 
 SprkMastheadNarrowNav.propTypes = {
   idString: PropTypes.string,
   isOpen: PropTypes.bool,
-  links: PropTypes.arrayOf(PropTypes.shape({
-    element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    text: PropTypes.string,
-    subNavLinks: PropTypes.arrayOf(PropTypes.shape(
-      {
-        text: PropTypes.string,
-        element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-      },
-    )),
-  })).isRequired,
+  links: PropTypes.arrayOf(
+    PropTypes.shape({
+      element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      text: PropTypes.string,
+      subNavLinks: PropTypes.arrayOf(
+        PropTypes.shape({
+          text: PropTypes.string,
+          element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+        }),
+      ),
+    }),
+  ).isRequired,
   selector: PropTypes.shape({
     choiceFunction: PropTypes.func,
     footer: PropTypes.node,
-    items: PropTypes.arrayOf(PropTypes.shape({
-      element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-      information: PropTypes.string,
-      text: PropTypes.string,
-      title: PropTypes.string,
-      value: PropTypes.string,
-    })),
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+        information: PropTypes.string,
+        text: PropTypes.string,
+        title: PropTypes.string,
+        value: PropTypes.string,
+      }),
+    ),
   }),
 };
 

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadNarrowNav/SprkMastheadNarrowNav.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadNarrowNav/SprkMastheadNarrowNav.test.js
@@ -21,6 +21,12 @@ it('should render the nav if isOpen is true', () => {
 
 it('should render the selector if selector (and items) are defined', () => {
   const links = [{ text: 'Item 1' }];
-  const wrapper = mount(<SprkMastheadNarrowNav isOpen links={links} selector={{ items: [{ text: 'Item 1' }] }} />);
+  const wrapper = mount(
+    <SprkMastheadNarrowNav
+      isOpen
+      links={links}
+      selector={{ items: [{ text: 'Item 1' }] }}
+    />,
+  );
   expect(wrapper.find(SprkMastheadSelector).length).toBe(1);
 });

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadSelector/SprkMastheadSelector.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadSelector/SprkMastheadSelector.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { uniqueId } from 'lodash';
 import SprkIcon from '../../../SprkIcon/SprkIcon';
+import SprkLink from '../../../SprkLink/SprkLink';
 
 class SprkMastheadSelector extends Component {
   constructor(props) {
@@ -94,9 +95,10 @@ class SprkMastheadSelector extends Component {
         }}
       >
         <div className={classNames({ 'sprk-o-Box': isFlush })}>
-          <a
-            className={classNames(
-              'sprk-c-Masthead__selector sprk-b-Link sprk-b-Link--plain sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column',
+          <SprkLink
+            variant="plain"
+            additionalClasses={classNames(
+              'sprk-c-Masthead__selector sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column',
               additionalTriggerClasses,
             )}
             data-analytics={analyticsString}
@@ -122,7 +124,7 @@ class SprkMastheadSelector extends Component {
                 additionalIconClasses,
               )}
             />
-          </a>
+          </SprkLink>
         </div>
 
         {isOpen && (
@@ -134,8 +136,9 @@ class SprkMastheadSelector extends Component {
             data-sprk-dropdown="dropdown-selector"
           >
             <div className="sprk-c-Dropdown__header">
-              <a
-                className="sprk-b-Link sprk-b-Link--plain sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column sprk-u-Width-100"
+              <SprkLink
+                variant="plain"
+                additionalClasses="sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column sprk-u-Width-100"
                 onClick={this.closeDropdown}
                 href="#nogo"
                 aria-haspopup="true"
@@ -147,7 +150,7 @@ class SprkMastheadSelector extends Component {
                   iconName="chevron-up"
                   additionalClasses="sprk-c-Icon--toggle sprk-Stack__item"
                 />
-              </a>
+              </SprkLink>
             </div>
 
             <ul className="sprk-c-Dropdown__links">
@@ -236,15 +239,8 @@ SprkMastheadSelector.propTypes = {
 };
 
 SprkMastheadSelector.defaultProps = {
-  additionalClasses: '',
-  additionalIconClasses: '',
-  additionalTriggerClasses: '',
-  additionalTriggerTextClasses: '',
-  analyticsString: '',
-  children: [],
   defaultTriggerText: 'Choose One...',
   iconName: 'chevron-down',
-  idString: '',
   isFlush: false,
 };
 

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadSelector/SprkMastheadSelector.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadSelector/SprkMastheadSelector.js
@@ -11,7 +11,10 @@ class SprkMastheadSelector extends Component {
     this.state = {
       isOpen: false,
       triggerText: props.defaultTriggerText,
-      choiceItems: props.choices.items.map(item => ({ id: uniqueId(), ...item })),
+      choiceItems: props.choices.items.map(item => ({
+        id: uniqueId(),
+        ...item,
+      })),
     };
     this.openDropdown = this.openDropdown.bind(this);
     this.closeDropdown = this.closeDropdown.bind(this);
@@ -84,7 +87,11 @@ class SprkMastheadSelector extends Component {
         role="dialog"
         ref={this.dropdownRef}
         className={classNames({ 'sprk-c-MastheadMask': isOpen && isFlush })}
-        onClick={() => { if (isOpen) { this.closeDropdown(); } }}
+        onClick={() => {
+          if (isOpen) {
+            this.closeDropdown();
+          }
+        }}
       >
         <div className={classNames({ 'sprk-o-Box': isFlush })}>
           <a
@@ -100,81 +107,90 @@ class SprkMastheadSelector extends Component {
             aria-haspopup="true"
           >
             <span
-              className={classNames('sprk-o-Stack__item sprk-o-Stack__item--flex@xxs', additionalTriggerTextClasses)}
+              className={classNames(
+                'sprk-o-Stack__item sprk-o-Stack__item--flex@xxs',
+                additionalTriggerTextClasses,
+              )}
               role="listbox"
             >
               {triggerText}
             </span>
             <SprkIcon
               iconName={iconName}
-              additionalClasses={
-              classNames('sprk-c-Icon--toggle sprk-Stack__item', additionalIconClasses)}
+              additionalClasses={classNames(
+                'sprk-c-Icon--toggle sprk-Stack__item',
+                additionalIconClasses,
+              )}
             />
           </a>
         </div>
 
-        { isOpen
-        && (
-        <div
-          className={classNames('sprk-c-Masthead__selector-dropdown sprk-c-Dropdown', additionalClasses)}
-          data-sprk-dropdown="dropdown-selector"
-        >
-          <div className="sprk-c-Dropdown__header">
-            <a
-              className="sprk-b-Link sprk-b-Link--plain sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column sprk-u-Width-100"
-              onClick={this.closeDropdown}
-              href="#nogo"
-              aria-haspopup="true"
-            >
-              <span
-                className="sprk-c-Dropdown__title sprk-b-TypeBodyTwo sprk-o-Stack__item sprk-o-Stack__item--flex@xxs"
+        {isOpen && (
+          <div
+            className={classNames(
+              'sprk-c-Masthead__selector-dropdown sprk-c-Dropdown',
+              additionalClasses,
+            )}
+            data-sprk-dropdown="dropdown-selector"
+          >
+            <div className="sprk-c-Dropdown__header">
+              <a
+                className="sprk-b-Link sprk-b-Link--plain sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column sprk-u-Width-100"
+                onClick={this.closeDropdown}
+                href="#nogo"
+                aria-haspopup="true"
               >
-                {triggerText}
-              </span>
-              <SprkIcon iconName="chevron-up" additionalClasses="sprk-c-Icon--toggle sprk-Stack__item" />
-            </a>
-          </div>
-
-          <ul className="sprk-c-Dropdown__links">
-            {choiceItems.map((item) => {
-              const {
-                element, href, title, information, value, ...rest
-              } = item;
-              const TagName = element || 'a';
-              return (
-                <li className="sprk-c-Dropdown__item" key={item.id}>
-                  <TagName
-                    className="sprk-c-Dropdown__link sprk-u-ptm"
-                    href={TagName === 'a' ? href || '#nogo' : undefined}
-                    onClick={() => {
-                      this.updateTriggerText(title);
-                      this.closeDropdown();
-                      if (choiceFunction) {
-                        choiceFunction(value);
-                      }
-                    }}
-                    role="option"
-                    {...rest}
-                  >
-                    <p className="sprk-b-TypeBodyOne">{title}</p>
-                    <p>{information}</p>
-                  </TagName>
-                </li>
-              );
-            })}
-
-          </ul>
-
-          {footer
-            && (
-            <div className="sprk-c-Dropdown__footer sprk-u-TextAlign--center">
-              {footer}
+                <span className="sprk-c-Dropdown__title sprk-b-TypeBodyTwo sprk-o-Stack__item sprk-o-Stack__item--flex@xxs">
+                  {triggerText}
+                </span>
+                <SprkIcon
+                  iconName="chevron-up"
+                  additionalClasses="sprk-c-Icon--toggle sprk-Stack__item"
+                />
+              </a>
             </div>
-            )
-          }
-        </div>
-        )
-        }
+
+            <ul className="sprk-c-Dropdown__links">
+              {choiceItems.map(item => {
+                const {
+                  element,
+                  href,
+                  title,
+                  information,
+                  value,
+                  ...rest
+                } = item;
+                const TagName = element || 'a';
+                return (
+                  <li className="sprk-c-Dropdown__item" key={item.id}>
+                    <TagName
+                      className="sprk-c-Dropdown__link sprk-u-ptm"
+                      href={TagName === 'a' ? href || '#nogo' : undefined}
+                      onClick={() => {
+                        this.updateTriggerText(title);
+                        this.closeDropdown();
+                        if (choiceFunction) {
+                          choiceFunction(value);
+                        }
+                      }}
+                      role="option"
+                      {...rest}
+                    >
+                      <p className="sprk-b-TypeBodyOne">{title}</p>
+                      <p>{information}</p>
+                    </TagName>
+                  </li>
+                );
+              })}
+            </ul>
+
+            {footer && (
+              <div className="sprk-c-Dropdown__footer sprk-u-TextAlign--center">
+                {footer}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     );
   }
@@ -196,14 +212,16 @@ SprkMastheadSelector.propTypes = {
     // A node to render at the foot of the dropdown menu
     footer: PropTypes.node,
     // An array of objects that describe the items in the menu
-    items: PropTypes.arrayOf(PropTypes.shape({
-      // The element to render for each menu item
-      element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-      // Assigned to href of the element is 'a'
-      href: PropTypes.string,
-      // The text inside the item
-      text: PropTypes.string,
-    })).isRequired,
+    items: PropTypes.arrayOf(
+      PropTypes.shape({
+        // The element to render for each menu item
+        element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+        // Assigned to href of the element is 'a'
+        href: PropTypes.string,
+        // The text inside the item
+        text: PropTypes.string,
+      }),
+    ).isRequired,
   }).isRequired,
   // Incoming children
   children: PropTypes.node,

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadSelector/SprkMastheadSelector.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadSelector/SprkMastheadSelector.test.js
@@ -7,63 +7,142 @@ import SprkMastheadSelector from './SprkMastheadSelector';
 Enzyme.configure({ adapter: new Adapter() });
 
 it('should render a trigger with the correct classes', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
   const wrapper = mount(<SprkMastheadSelector choices={choices} />);
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
 });
 
 it('should render a footer if supplied with the choices', () => {
-  const choices = { footer: (<p>hi</p>), items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
+  const choices = {
+    footer: <p>hi</p>,
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
   const wrapper = mount(<SprkMastheadSelector choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('.sprk-c-Dropdown__footer').length).toBe(1);
 });
 
 it('should render the correct text if defaultTriggerText is defined', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} defaultTriggerText="Hello, World!" />);
-  expect(wrapper.find('.sprk-b-Link').instance().textContent).toBe('Hello, World!');
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector
+      choices={choices}
+      defaultTriggerText="Hello, World!"
+    />,
+  );
+  expect(wrapper.find('.sprk-b-Link').instance().textContent).toBe(
+    'Hello, World!',
+  );
 });
 
 it('should add classes to the selector when additionalClasses has a value', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} additionalClasses="sprk-u-man" />);
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector choices={choices} additionalClasses="sprk-u-man" />,
+  );
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('.sprk-c-Dropdown.sprk-u-man').length).toBe(1);
 });
 
 it('should add classes to the icon when additionalIconClasses has a value', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} additionalIconClasses="sprk-c-Icon--l" />);
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector
+      choices={choices}
+      additionalIconClasses="sprk-c-Icon--l"
+    />,
+  );
   expect(wrapper.find('.sprk-c-Icon.sprk-c-Icon--l').length).toBe(1);
 });
 
 it('should add classes to the trigger when additionalTriggerClasses has a value', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} additionalTriggerClasses="sprk-u-man" />);
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector
+      choices={choices}
+      additionalTriggerClasses="sprk-u-man"
+    />,
+  );
   expect(wrapper.find('.sprk-b-Link.sprk-u-man').length).toBe(1);
 });
 
 it('should add classes to the trigger text when additionalTriggerTextClasses has a value', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} additionalTriggerTextClasses="sprk-u-man" />);
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector
+      choices={choices}
+      additionalTriggerTextClasses="sprk-u-man"
+    />,
+  );
   expect(wrapper.find('span.sprk-u-man').length).toBe(1);
 });
 
 it('should assign data-analytics when analyticsString has a value', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} analyticsString="321" />);
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector choices={choices} analyticsString="321" />,
+  );
   expect(wrapper.find('[data-analytics="321"]').length).toBe(1);
 });
 
 it('should assign data-id when idString has a value', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} idString="321" />);
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector choices={choices} idString="321" />,
+  );
   expect(wrapper.find('[data-id="321"]').length).toBe(1);
 });
 
 it('should build the correct number of choices from a choices object', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
   const wrapper = mount(<SprkMastheadSelector choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('.sprk-c-Dropdown__link').length).toBe(2);
@@ -71,34 +150,68 @@ it('should build the correct number of choices from a choices object', () => {
 
 it('should run the choiceFunction supplied with the list of choices (base)', () => {
   const spyFunc = jest.fn();
-  const choices = { choiceFunction: spyFunc, items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
+  const choices = {
+    choiceFunction: spyFunc,
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
   const wrapper = mount(<SprkMastheadSelector choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
-  wrapper.find('.sprk-c-Dropdown__link').first().simulate('click');
+  wrapper
+    .find('.sprk-c-Dropdown__link')
+    .first()
+    .simulate('click');
   expect(spyFunc.mock.calls.length).toBe(1);
 });
 
 it('should run the choiceFunction supplied with the list of choices (informational)', () => {
   const spyFunc = jest.fn();
-  const choices = { choiceFunction: spyFunc, items: [{ text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} variant="informational" />);
+  const choices = {
+    choiceFunction: spyFunc,
+    items: [{ text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } }],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector choices={choices} variant="informational" />
+  );
   wrapper.find('.sprk-b-Link').simulate('click');
-  wrapper.find('.sprk-c-Dropdown__link').first().simulate('click');
+  wrapper
+    .find('.sprk-c-Dropdown__link')
+    .first()
+    .simulate('click');
   expect(spyFunc.mock.calls.length).toBe(1);
 });
 
 it('should not error if the choiceFunction is supplied, but undefined with the list of choices (base)', () => {
-  const choices = { choiceFunction: undefined, items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
+  const choices = {
+    choiceFunction: undefined,
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
   const wrapper = mount(<SprkMastheadSelector choices={choices} />);
   wrapper.find('.sprk-b-Link').simulate('click');
-  wrapper.find('.sprk-c-Dropdown__link').first().simulate('click');
+  wrapper
+    .find('.sprk-c-Dropdown__link')
+    .first()
+    .simulate('click');
 });
 
 it('should not error if the choiceFunction is supplied, but undefined with the list of choices (informational)', () => {
-  const choices = { choiceFunction: undefined, items: [{ text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } }] };
-  const wrapper = mount(<SprkMastheadSelector choices={choices} variant="informational" />);
+  const choices = {
+    choiceFunction: undefined,
+    items: [{ text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } }],
+  };
+  const wrapper = mount(
+    <SprkMastheadSelector choices={choices} variant="informational" />
+  );
   wrapper.find('.sprk-b-Link').simulate('click');
-  wrapper.find('.sprk-c-Dropdown__link').first().simulate('click');
+  wrapper
+    .find('.sprk-c-Dropdown__link')
+    .first()
+    .simulate('click');
 });
 
 it('should close the dropdown on click outside', () => {
@@ -130,7 +243,12 @@ it('should close the dropdown on keydown (Escape)', () => {
 });
 
 it('should unmount without error', () => {
-  const choices = { items: [{ text: 'Item 1', value: 'item-1' }, { text: 'Item 2', value: 'item-2' }] };
+  const choices = {
+    items: [
+      { text: 'Item 1', value: 'item-1' },
+      { text: 'Item 2', value: 'item-2' },
+    ],
+  };
   const wrapper = mount(<SprkMastheadSelector choices={choices} />);
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
   wrapper.unmount();
@@ -138,15 +256,27 @@ it('should unmount without error', () => {
 });
 
 it('should render the choices with the element specified', () => {
-  const wrapper = mount(<SprkMastheadSelector choices={{ items: [{ element: 'span', text: 'Item 1' }] }} />);
+  const wrapper = mount(
+    <SprkMastheadSelector
+      choices={{ items: [{ element: 'span', text: 'Item 1' }] }}
+    />,
+  );
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
   wrapper.find('.sprk-b-Link').simulate('click');
   expect(wrapper.find('span.sprk-c-Dropdown__link').length).toBe(1);
 });
 
 it('should pass unused keys on choice items through to the dom', () => {
-  const wrapper = mount(<SprkMastheadSelector choices={{ items: [{ element: 'span', text: 'Item 1', 'aria-hidden': 'true' }] }} />);
+  const wrapper = mount(
+    <SprkMastheadSelector
+      choices={{
+        items: [{ element: 'span', text: 'Item 1', 'aria-hidden': 'true' }],
+      }}
+    />,
+  );
   expect(wrapper.find('.sprk-b-Link').length).toBe(1);
   wrapper.find('.sprk-b-Link').simulate('click');
-  expect(wrapper.find('.sprk-c-Dropdown__link[aria-hidden="true"]').length).toBe(1);
+  expect(
+    wrapper.find('.sprk-c-Dropdown__link[aria-hidden="true"]').length,
+  ).toBe(1);
 });

--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadSelector/SprkMastheadSelector.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadSelector/SprkMastheadSelector.test.js
@@ -120,7 +120,7 @@ it('should assign data-analytics when analyticsString has a value', () => {
   const wrapper = mount(
     <SprkMastheadSelector choices={choices} analyticsString="321" />,
   );
-  expect(wrapper.find('[data-analytics="321"]').length).toBe(1);
+  expect(wrapper.find('[data-analytics="321"]').length).toBe(2);
 });
 
 it('should assign data-id when idString has a value', () => {
@@ -133,7 +133,7 @@ it('should assign data-id when idString has a value', () => {
   const wrapper = mount(
     <SprkMastheadSelector choices={choices} idString="321" />,
   );
-  expect(wrapper.find('[data-id="321"]').length).toBe(1);
+  expect(wrapper.find('[data-id="321"]').length).toBe(2);
 });
 
 it('should build the correct number of choices from a choices object', () => {

--- a/src/react/projects/spark-react/src/SprkPagination/SprkPagination.js
+++ b/src/react/projects/spark-react/src/SprkPagination/SprkPagination.js
@@ -69,7 +69,6 @@ const SprkPagination = props => {
       >
         <li>
           <SprkLink
-            href="#nogo"
             onClick={e => goToPage(e, currentPage - 1)}
             additionalClasses={leftLinkClasses}
             variant="plain"
@@ -85,7 +84,6 @@ const SprkPagination = props => {
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, 1)}
-              href="#nogo"
               additionalClasses={classnames('sprk-c-Pagination__link', {
                 'sprk-c-Pagination__link--current': currentPage === 1,
               })}
@@ -107,7 +105,6 @@ const SprkPagination = props => {
             <li key={uniqueId('sprk_page_')}>
               <SprkLink
                 onClick={e => goToPage(e, currentPage)}
-                href="#nogo"
                 additionalClasses={classnames(
                   'sprk-c-Pagination__link',
                   'sprk-c-Pagination__link--current',
@@ -130,7 +127,6 @@ const SprkPagination = props => {
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, totalPages)}
-              href="#nogo"
               additionalClasses={classnames('sprk-c-Pagination__link', {
                 'sprk-c-Pagination__link--current': currentPage === totalPages,
               })}
@@ -149,7 +145,6 @@ const SprkPagination = props => {
             <li key={uniqueId('sprk_page_')}>
               <SprkLink
                 onClick={e => goToPage(e, 2)}
-                href="#nogo"
                 additionalClasses={classnames('sprk-c-Pagination__link', {
                   'sprk-c-Pagination__link--current': currentPage === 2,
                 })}
@@ -168,7 +163,6 @@ const SprkPagination = props => {
             <li key={uniqueId('sprk_page_')}>
               <SprkLink
                 onClick={e => goToPage(e, 3)}
-                href="#nogo"
                 additionalClasses={classnames('sprk-c-Pagination__link', {
                   'sprk-c-Pagination__link--current': currentPage === 3,
                 })}
@@ -183,7 +177,6 @@ const SprkPagination = props => {
 
         <li>
           <SprkLink
-            href="#nogo"
             onClick={e => goToPage(e, currentPage + 1)}
             additionalClasses={rightLinkClasses}
             variant="plain"
@@ -229,13 +222,8 @@ SprkPagination.propTypes = {
 SprkPagination.defaultProps = {
   variant: 'default',
   currentPage: 1,
-  additionalClasses: null,
   nextLinkText: 'Next Page',
   prevLinkText: 'Previous Page',
-  analyticsStringNext: null,
-  analyticsStringPrev: null,
-  analyticsStringPage: null,
-  idString: null,
 };
 
 export default SprkPagination;

--- a/src/react/projects/spark-react/src/SprkPagination/SprkPagination.js
+++ b/src/react/projects/spark-react/src/SprkPagination/SprkPagination.js
@@ -5,7 +5,7 @@ import { uniqueId } from 'lodash';
 import SprkLink from '../SprkLink/SprkLink';
 import SprkIcon from '../SprkIcon/SprkIcon';
 
-const SprkPagination = (props) => {
+const SprkPagination = props => {
   const goToPage = (e, page) => {
     e.preventDefault();
 
@@ -14,8 +14,12 @@ const SprkPagination = (props) => {
     const totalPages = Math.ceil(totalItems / itemsPerPage);
 
     let newPage = page;
-    if (page > totalPages) { newPage = totalPages; }
-    if (page < 1) { newPage = 1; }
+    if (page > totalPages) {
+      newPage = totalPages;
+    }
+    if (page < 1) {
+      newPage = 1;
+    }
 
     onChangeCallback({ e, newPage });
   };
@@ -53,19 +57,14 @@ const SprkPagination = (props) => {
   }
 
   return (
-    <nav
-      aria-label="Pagination Navigation"
-      data-id={idString}
-    >
+    <nav aria-label="Pagination Navigation" data-id={idString}>
       <ul
-        className={
-          classnames(
-            'sprk-c-Pagination',
-            'sprk-o-HorizontalList',
-            'sprk-o-HorizontalList--spacing-medium',
-            additionalClasses,
-          )
-        }
+        className={classnames(
+          'sprk-c-Pagination',
+          'sprk-o-HorizontalList',
+          'sprk-o-HorizontalList--spacing-medium',
+          additionalClasses,
+        )}
         {...other}
       >
         <li>
@@ -82,16 +81,14 @@ const SprkPagination = (props) => {
           </SprkLink>
         </li>
 
-        { variant === 'default' && (
+        {variant === 'default' && (
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, 1)}
               href="#nogo"
-              additionalClasses={
-                classnames(
-                  'sprk-c-Pagination__link',
-                  { 'sprk-c-Pagination__link--current': currentPage === 1 },
-                )}
+              additionalClasses={classnames('sprk-c-Pagination__link', {
+                'sprk-c-Pagination__link--current': currentPage === 1,
+              })}
               aria-label="Page 1"
               aria-current={currentPage === 1}
               data-analytics={analyticsStringPage}
@@ -101,49 +98,42 @@ const SprkPagination = (props) => {
           </li>
         )}
 
-        { longVariant && currentPage > 2 && (
-          <li key={uniqueId('sprk_page_')}>
-            ...
-          </li>
-        )}
+        {longVariant &&
+          currentPage > 2 && <li key={uniqueId('sprk_page_')}>...</li>}
 
-        { longVariant && currentPage > 1 && currentPage < totalPages && (
-          <li key={uniqueId('sprk_page_')}>
-            <SprkLink
-              onClick={e => goToPage(e, currentPage)}
-              href="#nogo"
-              additionalClasses={
-                classnames(
+        {longVariant &&
+          currentPage > 1 &&
+          currentPage < totalPages && (
+            <li key={uniqueId('sprk_page_')}>
+              <SprkLink
+                onClick={e => goToPage(e, currentPage)}
+                href="#nogo"
+                additionalClasses={classnames(
                   'sprk-c-Pagination__link',
                   'sprk-c-Pagination__link--current',
-                )
-              }
-              aria-label={`Page ${currentPage}`}
-              aria-current="true"
-              data-analytics={analyticsStringPage}
-            >
-              {currentPage}
-            </SprkLink>
-          </li>
-        )}
+                )}
+                aria-label={`Page ${currentPage}`}
+                aria-current="true"
+                data-analytics={analyticsStringPage}
+              >
+                {currentPage}
+              </SprkLink>
+            </li>
+          )}
 
-        { longVariant && currentPage < totalPages - 1 && (
-          <li key={uniqueId('sprk_page_')}>
-            ...
-          </li>
-        )}
+        {longVariant &&
+          currentPage < totalPages - 1 && (
+            <li key={uniqueId('sprk_page_')}>...</li>
+          )}
 
-        { longVariant && (
+        {longVariant && (
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, totalPages)}
               href="#nogo"
-              additionalClasses={
-                classnames(
-                  'sprk-c-Pagination__link',
-                  { 'sprk-c-Pagination__link--current': currentPage === totalPages },
-                )
-              }
+              additionalClasses={classnames('sprk-c-Pagination__link', {
+                'sprk-c-Pagination__link--current': currentPage === totalPages,
+              })}
               aria-label={`Page ${totalPages}`}
               aria-current={currentPage === totalPages}
               data-analytics={analyticsStringPage}
@@ -153,43 +143,43 @@ const SprkPagination = (props) => {
           </li>
         )}
 
-        { variant === 'default' && !longVariant && totalItems / itemsPerPage > 1 && (
-          <li key={uniqueId('sprk_page_')}>
-            <SprkLink
-              onClick={e => goToPage(e, 2)}
-              href="#nogo"
-              additionalClasses={
-                classnames(
-                  'sprk-c-Pagination__link',
-                  { 'sprk-c-Pagination__link--current': currentPage === 2 },
-                )}
-              aria-label="Page 2"
-              aria-current={currentPage === 2}
-              data-analytics={analyticsStringPage}
-            >
-              2
-            </SprkLink>
-          </li>
-        )}
+        {variant === 'default' &&
+          !longVariant &&
+          totalItems / itemsPerPage > 1 && (
+            <li key={uniqueId('sprk_page_')}>
+              <SprkLink
+                onClick={e => goToPage(e, 2)}
+                href="#nogo"
+                additionalClasses={classnames('sprk-c-Pagination__link', {
+                  'sprk-c-Pagination__link--current': currentPage === 2,
+                })}
+                aria-label="Page 2"
+                aria-current={currentPage === 2}
+                data-analytics={analyticsStringPage}
+              >
+                2
+              </SprkLink>
+            </li>
+          )}
 
-        { variant === 'default' && !longVariant && totalItems / itemsPerPage > 2 && (
-          <li key={uniqueId('sprk_page_')}>
-            <SprkLink
-              onClick={e => goToPage(e, 3)}
-              href="#nogo"
-              additionalClasses={
-                classnames(
-                  'sprk-c-Pagination__link',
-                  { 'sprk-c-Pagination__link--current': currentPage === 3 },
-                )}
-              aria-label="Page 3"
-              aria-current={currentPage === 3}
-              data-analytics={analyticsStringPage}
-            >
-              3
-            </SprkLink>
-          </li>
-        )}
+        {variant === 'default' &&
+          !longVariant &&
+          totalItems / itemsPerPage > 2 && (
+            <li key={uniqueId('sprk_page_')}>
+              <SprkLink
+                onClick={e => goToPage(e, 3)}
+                href="#nogo"
+                additionalClasses={classnames('sprk-c-Pagination__link', {
+                  'sprk-c-Pagination__link--current': currentPage === 3,
+                })}
+                aria-label="Page 3"
+                aria-current={currentPage === 3}
+                data-analytics={analyticsStringPage}
+              >
+                3
+              </SprkLink>
+            </li>
+          )}
 
         <li>
           <SprkLink
@@ -208,7 +198,6 @@ const SprkPagination = (props) => {
     </nav>
   );
 };
-
 
 SprkPagination.propTypes = {
   // The pagination variant

--- a/src/react/projects/spark-react/src/SprkPagination/SprkPagination.js
+++ b/src/react/projects/spark-react/src/SprkPagination/SprkPagination.js
@@ -70,7 +70,7 @@ const SprkPagination = (props) => {
       >
         <li>
           <SprkLink
-            href="#"
+            href="#nogo"
             onClick={e => goToPage(e, currentPage - 1)}
             additionalClasses={leftLinkClasses}
             variant="plain"
@@ -86,7 +86,7 @@ const SprkPagination = (props) => {
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, 1)}
-              href="#"
+              href="#nogo"
               additionalClasses={
                 classnames(
                   'sprk-c-Pagination__link',
@@ -111,7 +111,7 @@ const SprkPagination = (props) => {
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, currentPage)}
-              href="#"
+              href="#nogo"
               additionalClasses={
                 classnames(
                   'sprk-c-Pagination__link',
@@ -137,7 +137,7 @@ const SprkPagination = (props) => {
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, totalPages)}
-              href="#"
+              href="#nogo"
               additionalClasses={
                 classnames(
                   'sprk-c-Pagination__link',
@@ -157,7 +157,7 @@ const SprkPagination = (props) => {
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, 2)}
-              href="#"
+              href="#nogo"
               additionalClasses={
                 classnames(
                   'sprk-c-Pagination__link',
@@ -176,7 +176,7 @@ const SprkPagination = (props) => {
           <li key={uniqueId('sprk_page_')}>
             <SprkLink
               onClick={e => goToPage(e, 3)}
-              href="#"
+              href="#nogo"
               additionalClasses={
                 classnames(
                   'sprk-c-Pagination__link',
@@ -193,7 +193,7 @@ const SprkPagination = (props) => {
 
         <li>
           <SprkLink
-            href="#"
+            href="#nogo"
             onClick={e => goToPage(e, currentPage + 1)}
             additionalClasses={rightLinkClasses}
             variant="plain"

--- a/src/react/projects/spark-react/src/SprkPromo/SprkPromo.js
+++ b/src/react/projects/spark-react/src/SprkPromo/SprkPromo.js
@@ -237,27 +237,4 @@ SprkPromo.propTypes = {
   hasBorder: PropTypes.bool,
 };
 
-SprkPromo.defaultProps = {
-  children: [],
-  title: '',
-  subtitle: '',
-  additionalClasses: '',
-  additionalClassesContent: '',
-  cta: '',
-  ctaText: '',
-  ctaHref: '',
-  ctaAnalytics: '',
-  ctaIdString: '',
-  imgSrc: '',
-  imgAlt: '',
-  imgLinkHref: '',
-  imgLinkAnalytics: '',
-  imgLinkIdString: '',
-  additionalClassesImgLink: '',
-  idString: '',
-  isFlag: false,
-  mediaRev: false,
-  hasBorder: false,
-};
-
 export default SprkPromo;

--- a/src/react/projects/spark-react/src/SprkToggle/SprkToggle.js
+++ b/src/react/projects/spark-react/src/SprkToggle/SprkToggle.js
@@ -3,6 +3,7 @@ import AnimateHeight from 'react-animate-height';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import SprkIcon from '../SprkIcon/SprkIcon';
+import SprkLink from '../SprkLink/SprkLink';
 
 class SprkToggle extends Component {
   constructor(props) {
@@ -49,8 +50,8 @@ class SprkToggle extends Component {
 
     return (
       <div data-id={idString} {...other} className={additionalClasses}>
-        <a
-          className={titleClassNames}
+        <SprkLink
+          additionalClasses={titleClassNames}
           href="#nogo"
           data-analytics={analyticsString}
           onClick={this.toggleOpen}
@@ -58,7 +59,7 @@ class SprkToggle extends Component {
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
           {title}
-        </a>
+        </SprkLink>
         <AnimateHeight duration={300} height={height}>
           <div>{children}</div>
         </AnimateHeight>
@@ -68,11 +69,6 @@ class SprkToggle extends Component {
 }
 
 SprkToggle.defaultProps = {
-  idString: '',
-  additionalClasses: '',
-  analyticsString: '',
-  titleAddClasses: '',
-  iconAddClasses: '',
   toggleIconName: 'chevron-down-circle-two-color',
 };
 

--- a/src/react/projects/spark-react/src/SprkToggle/SprkToggle.js
+++ b/src/react/projects/spark-react/src/SprkToggle/SprkToggle.js
@@ -52,7 +52,6 @@ class SprkToggle extends Component {
       <div data-id={idString} {...other} className={additionalClasses}>
         <SprkLink
           additionalClasses={titleClassNames}
-          href="#nogo"
           data-analytics={analyticsString}
           onClick={this.toggleOpen}
           aria-expanded={isOpen ? 'true' : 'false'}

--- a/src/react/projects/spark-react/src/SprkToggle/SprkToggle.test.js
+++ b/src/react/projects/spark-react/src/SprkToggle/SprkToggle.test.js
@@ -25,7 +25,9 @@ it('should default to open if defaultOpen is true', () => {
 });
 
 it('should toggle open on click', () => {
-  const wrapper = mount(<SprkToggle title="Toggle title">Body text</SprkToggle>);
+  const wrapper = mount(
+    <SprkToggle title="Toggle title">Body text</SprkToggle>,
+  );
   expect(wrapper.state().isOpen).toBe(false);
   wrapper.find('a').simulate('click');
   expect(wrapper.state().isOpen).toBe(true);
@@ -34,13 +36,17 @@ it('should toggle open on click', () => {
 });
 
 it('should add a class to icon when opened', () => {
-  const wrapper = mount(<SprkToggle title="Toggle title">Body text</SprkToggle>);
+  const wrapper = mount(
+    <SprkToggle title="Toggle title">Body text</SprkToggle>,
+  );
   wrapper.find('a').simulate('click');
   expect(wrapper.find('.sprk-c-Icon--open').length).toBe(1);
 });
 
 it('should add aria-expanded="true" when the toggle is open', () => {
-  const wrapper = mount(<SprkToggle title="Toggle title">Body text</SprkToggle>);
+  const wrapper = mount(
+    <SprkToggle title="Toggle title">Body text</SprkToggle>,
+  );
   wrapper.find('a').simulate('click');
   expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
 });

--- a/src/react/projects/spark-react/src/SprkToggle/SprkToggle.test.js
+++ b/src/react/projects/spark-react/src/SprkToggle/SprkToggle.test.js
@@ -48,5 +48,5 @@ it('should add aria-expanded="true" when the toggle is open', () => {
     <SprkToggle title="Toggle title">Body text</SprkToggle>,
   );
   wrapper.find('a').simulate('click');
-  expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
+  expect(wrapper.find('[aria-expanded="true"]').length).toBe(2);
 });

--- a/src/react/src/routes/SprkButtonDocs/SprkButtonDocs.js
+++ b/src/react/src/routes/SprkButtonDocs/SprkButtonDocs.js
@@ -28,7 +28,7 @@ const SprkButtonDocs = () => {
         <SprkButton loading>Button Text</SprkButton>
       </ExampleContainer>
       <ExampleContainer heading="Incoming Element">
-        <div id="foo" />
+        <div id="jumpLinkTarget" />
         <SprkButton element={Link} to="/links">
           React Router Link
         </SprkButton>

--- a/src/react/src/routes/SprkButtonDocs/SprkButtonDocs.js
+++ b/src/react/src/routes/SprkButtonDocs/SprkButtonDocs.js
@@ -28,6 +28,7 @@ const SprkButtonDocs = () => {
         <SprkButton loading>Button Text</SprkButton>
       </ExampleContainer>
       <ExampleContainer heading="Incoming Element">
+        <div id="foo" />
         <SprkButton element={Link} to="/links">
           React Router Link
         </SprkButton>

--- a/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
+++ b/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
@@ -5,6 +5,33 @@ import ExampleContainer from '../../containers/ExampleContainer/ExampleContainer
 
 const SprkLinkDocs = () => (
   <CentralColumnLayout>
+    <h2 className="drizzle-b-h2">Links</h2>
+    <ExampleContainer>
+      <SprkLink href="/">This is a standard Spark Link!</SprkLink>
+    </ExampleContainer>
+
+    <ExampleContainer>
+      <p>
+        Here is a
+        <SprkLink href="/"> link </SprkLink>
+        in the middle of a line.
+      </p>
+    </ExampleContainer>
+
+    <ExampleContainer>
+      <SprkLink variant="unstyled">Unstyled Link</SprkLink>
+    </ExampleContainer>
+
+    <ExampleContainer>
+      <SprkLink variant="simple" idString="simple-link">
+        Simple Link
+      </SprkLink>
+    </ExampleContainer>
+
+    <ExampleContainer>
+      <SprkLink variant="plain">Plain Link</SprkLink>
+    </ExampleContainer>
+
     <h2 className="drizzle-b-h2">External Links</h2>
     <ExampleContainer>
       <SprkLink id="foo" href="https://google.com" target="_blank">https://google.com</SprkLink>
@@ -23,35 +50,44 @@ const SprkLinkDocs = () => (
       <SprkLink href="/button#foo">Jump Link with Page</SprkLink>
     </ExampleContainer>
 
+    <h2 className="drizzle-b-h2">Link with no href provided</h2>
     <ExampleContainer>
-      <SprkLink variant="unstyled">Unstyled Link</SprkLink>
+      <SprkLink>No href provided.</SprkLink>
     </ExampleContainer>
 
+    <h2 className="drizzle-b-h2">Link Using Tel</h2>
     <ExampleContainer>
-      <SprkLink variant="simple" idString="simple-link">
-        Simple Link
+      <SprkLink href="tel:+123456789">Tel Link</SprkLink>
+    </ExampleContainer>
+
+    <h2 className="drizzle-b-h2">Link Using mailto</h2>
+    <ExampleContainer>
+      <SprkLink href="mailto:example@example.com">mailto Link</SprkLink>
+    </ExampleContainer>
+
+    <h2 className="drizzle-b-h2">Additional Classes</h2>
+    <ExampleContainer>
+      <SprkLink additionalClasses="sprk-u-mbm">
+        Link with Margin Bottom class
       </SprkLink>
     </ExampleContainer>
 
+    <h2 className="drizzle-b-h2">Disabled Link</h2>
+    <ExampleContainer>
+      <SprkLink variant="disabled">Disabled Link</SprkLink>
+    </ExampleContainer>
+
+    <h2 className="drizzle-b-h2">Icon With Text Link</h2>
     <ExampleContainer>
       <SprkLink variant="has-icon" target="_blank" analyticsString="foo">
         <SprkIcon
           additionalClasses="sprk-c-Icon--xl"
           iconName="communication"
         />
-        Icon With Text Link
+        Message Us
       </SprkLink>
     </ExampleContainer>
 
-    <ExampleContainer>
-      <SprkLink variant="disabled">Disabled Link</SprkLink>
-    </ExampleContainer>
-
-    <ExampleContainer>
-      <SprkLink variant="plain" additionalClasses="foo">
-        Plain Link
-      </SprkLink>
-    </ExampleContainer>
     <div id="info">Hi, I'm info!</div>
   </CentralColumnLayout>
 );

--- a/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
+++ b/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
@@ -47,7 +47,7 @@ const SprkLinkDocs = () => (
     </ExampleContainer>
 
     <ExampleContainer>
-      <SprkLink href="/button#foo">Jump Link with Page</SprkLink>
+      <SprkLink href="/button#jumpLinkTarget">Jump Link with Page</SprkLink>
     </ExampleContainer>
 
     <h2 className="drizzle-b-h2">Link with no href provided</h2>

--- a/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
+++ b/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
@@ -5,8 +5,22 @@ import ExampleContainer from '../../containers/ExampleContainer/ExampleContainer
 
 const SprkLinkDocs = () => (
   <CentralColumnLayout>
+    <h2 className="drizzle-b-h2">External Links</h2>
     <ExampleContainer>
-      <SprkLink id="foo">Base Link</SprkLink>
+      <SprkLink id="foo" href="https://google.com" target="_blank">https://google.com</SprkLink>
+    </ExampleContainer>
+
+    <ExampleContainer>
+      <SprkLink id="foo" href="https://google.com" target="_blank">http://google.com</SprkLink>
+    </ExampleContainer>
+
+    <h2 className="drizzle-b-h2">Same Page Links</h2>
+    <ExampleContainer>
+      <SprkLink href="#info">Jump Link</SprkLink>
+    </ExampleContainer>
+
+    <ExampleContainer>
+      <SprkLink href="/button#foo">Jump Link with Page</SprkLink>
     </ExampleContainer>
 
     <ExampleContainer>
@@ -38,6 +52,7 @@ const SprkLinkDocs = () => (
         Plain Link
       </SprkLink>
     </ExampleContainer>
+    <div id="info">Hi, I'm info!</div>
   </CentralColumnLayout>
 );
 

--- a/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
+++ b/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
@@ -6,30 +6,21 @@ import ExampleContainer from '../../containers/ExampleContainer/ExampleContainer
 const SprkLinkDocs = () => (
   <CentralColumnLayout>
     <ExampleContainer>
-      <SprkLink href="#nogo" id="foo">
-        Base Link
-      </SprkLink>
+      <SprkLink id="foo">Base Link</SprkLink>
     </ExampleContainer>
 
     <ExampleContainer>
-      <SprkLink href="#nogo" variant="unstyled">
-        Unstyled Link
-      </SprkLink>
+      <SprkLink variant="unstyled">Unstyled Link</SprkLink>
     </ExampleContainer>
 
     <ExampleContainer>
-      <SprkLink variant="simple" href="/button" idString="simple-link">
+      <SprkLink variant="simple" idString="simple-link">
         Simple Link
       </SprkLink>
     </ExampleContainer>
 
     <ExampleContainer>
-      <SprkLink
-        variant="has-icon"
-        target="_blank"
-        href="#nogo"
-        analyticsString="foo"
-      >
+      <SprkLink variant="has-icon" target="_blank" analyticsString="foo">
         <SprkIcon
           additionalClasses="sprk-c-Icon--xl"
           iconName="communication"
@@ -39,13 +30,11 @@ const SprkLinkDocs = () => (
     </ExampleContainer>
 
     <ExampleContainer>
-      <SprkLink variant="disabled" href="#nogo">
-        Disabled Link
-      </SprkLink>
+      <SprkLink variant="disabled">Disabled Link</SprkLink>
     </ExampleContainer>
 
     <ExampleContainer>
-      <SprkLink variant="plain" additionalClasses="foo" href="#nogo">
+      <SprkLink variant="plain" additionalClasses="foo">
         Plain Link
       </SprkLink>
     </ExampleContainer>

--- a/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
+++ b/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
@@ -12,6 +12,12 @@ const SprkLinkDocs = () => (
     </ExampleContainer>
 
     <ExampleContainer>
+      <SprkLink href="#nogo" variant="unstyled">
+        Unstyled Link
+      </SprkLink>
+    </ExampleContainer>
+
+    <ExampleContainer>
       <SprkLink variant="simple" href="/button" idString="simple-link">
         Simple Link
       </SprkLink>


### PR DESCRIPTION
## What does this PR do?
Refactor SprkDropdown, SprkAccordionItem, SprkMastheadAccordionItem, SprkMastheadDropdown, SprkMastheadSelector, SprkMasthead, and SprkToggle to use the SprkLink component instead of their own a tags.

### Associated Issue 
Fixes #1181 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs React

### Code
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
