### PR TITLE
[Bug] Angular Inputs: Monetary Input doesnt show the $ icon

### DIFF
--- a/src/angular/src/app/spark-docs/input-docs/input-docs.component.ts
+++ b/src/angular/src/app/spark-docs/input-docs/input-docs.component.ts
@@ -190,11 +190,11 @@ import { Component } from '@angular/core';
           />
         </sprk-icon-input-container>
         <sprk-icon-input-container
-          iconContainerClasses="sprk-b-TextInputIconContainer--monetary"
+          iconContainerClasses="sprk-b-TextInputIconContainer--has-text-icon"
         >
           <label class="sprk-b-Label--monetary" sprkLabel> Payment </label>
           <input
-            class="sprk-b-TextInput--monetary"
+            class="sprk-b-TextInput--has-text-icon"
             name="monetary_input"
             type="text"
             pattern="(^\\$?(\\d+|\\d{1,3}(,\\d{3})*)(\\.\\d+)?$)|^$"

--- a/src/patterns/components/inputs/angular/code/monetary-disabled.hbs
+++ b/src/patterns/components/inputs/angular/code/monetary-disabled.hbs
@@ -1,4 +1,4 @@
-<sprk-input-container iconContainerClasses="sprk-b-TextInputIconContainer sprk-b-TextInputIconContainer--monetary">
+<sprk-input-container iconContainerClasses="sprk-b-TextInputIconContainer sprk-b-TextInputIconContainer--has-text-icon">
   <label
     class="sprk-b-Label--monetary"
     sprkLabel>

--- a/src/patterns/components/inputs/angular/code/monetary-error.hbs
+++ b/src/patterns/components/inputs/angular/code/monetary-error.hbs
@@ -1,4 +1,4 @@
-<sprk-input-container iconContainerClasses="sprk-b-TextInputIconContainer sprk-b-TextInputIconContainer--monetary">
+<sprk-input-container iconContainerClasses="sprk-b-TextInputIconContainer sprk-b-TextInputIconContainer--has-text-icon">
   <label
     class="sprk-b-Label--monetary"
     sprkLabel>

--- a/src/patterns/components/inputs/angular/code/monetary.hbs
+++ b/src/patterns/components/inputs/angular/code/monetary.hbs
@@ -1,4 +1,4 @@
-<sprk-icon-input-container iconContainerClasses="sprk-b-TextInputIconContainer sprk-b-TextInputIconContainer--monetary">
+<sprk-icon-input-container iconContainerClasses="sprk-b-TextInputIconContainer sprk-b-TextInputIconContainer--has-text-icon">
   <label
     class="sprk-b-Label--monetary"
     sprkLabel>

--- a/src/patterns/components/inputs/collection.yaml
+++ b/src/patterns/components/inputs/collection.yaml
@@ -422,5 +422,5 @@ classTable:
     description: Selects that are currently in focus.
   .sprk-b-Select--focusout:
     description: Selects that are currently not in focus.
-  .sprk-b-TextInputIconContainer--monetary:
-    description: Monetary text inputs with icons.
+  .sprk-b-TextInputIconContainer--has-text-icon:
+    description: Text inputs with icons.


### PR DESCRIPTION
## What does this PR do?
When we re-skinned and updated the inputs at the beginning of the year, we missed updating Angular’s monetary input.

It still has older classes from before the refactor so this PR updates them.
`sprk-b-TextInputIconContainer--monetary` -> `sprk-b-TextInputIconContainer--has-text-icon`

`sprk-b-TextInput--monetary` -> `sprk-b-TextInput--has-text-icon`


### Associated Issue 
Fixes #1100

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Component Sass Var/Class Modifier table

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Build Component in Spark Angular
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
