### PR TITLE
[Bug] Narrow Nav scrolling in FF / Edge / IE11

### DIFF
--- a/packages/spark-core/components/_masthead.scss
+++ b/packages/spark-core/components/_masthead.scss
@@ -237,9 +237,8 @@
   background-color: $sprk-white;
   height: 100%;
   overflow: auto;
-  position: fixed;
-  top: $sprk-masthead-narrow-height + $sprk-masthead-content-item-padding-top + $sprk-masthead-content-item-padding-top + $sprk-masthead-menu-icon-height + $sprk-masthead-border-bottom-size;   // Adds extra space to account for logo dropping under menu<320px
   padding-bottom: $sprk-masthead-narrow-height + $sprk-masthead-content-item-padding-top + $sprk-masthead-content-item-padding-top + $sprk-masthead-menu-icon-height + $sprk-masthead-border-bottom-size; // So the scroll has enough room to reach the bottom item
+  top: $sprk-masthead-narrow-height + $sprk-masthead-content-item-padding-top + $sprk-masthead-content-item-padding-top + $sprk-masthead-menu-icon-height + $sprk-masthead-border-bottom-size;   // Adds extra space to account for logo dropping under menu<320px
   width: 100%;
 
   @media (min-width: $sprk-split-breakpoint-xxs) {
@@ -257,6 +256,7 @@
 .sprk-c-MastheadMask {
   background-color: $sprk-masthead-mask-color;
   cursor: pointer;
+  position: fixed;
   z-index: $sprk-layer-height-l;
 }
 

--- a/src/angular/projects/spark-core-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -119,98 +119,97 @@ import * as _ from 'lodash';
         </nav>
       </div>
 
-      <div *ngIf="isNarrowNavOpen">
-        <nav
-          class="sprk-c-Masthead__narrow-nav"
-          data-sprk-mobile-nav="mobileNav"
-          role="navigation"
+      <nav
+        *ngIf="isNarrowNavOpen"
+        class="sprk-c-Masthead__narrow-nav"
+        data-sprk-mobile-nav="mobileNav"
+        role="navigation"
+      >
+        <sprk-dropdown
+          *ngIf="narrowSelector"
+          dropdownType="mastheadSelector"
+          additionalClasses="sprk-c-Masthead__selector-dropdown"
+          additionalTriggerClasses="sprk-c-Masthead__selector sprk-b-Link sprk-b-Link--plain sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column"
+          additionalTriggerTextClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@xxs"
+          additionalIconClasses="sprk-Stack__item sprk-u-mrs"
+          [triggerText]="narrowSelector['trigger'].text"
+          selector="Select One"
+          triggerIconType="chevron-down"
+          [choices]="narrowSelector['choices']"
         >
-          <sprk-dropdown
-            *ngIf="narrowSelector"
-            dropdownType="mastheadSelector"
-            additionalClasses="sprk-c-Masthead__selector-dropdown"
-            additionalTriggerClasses="sprk-c-Masthead__selector sprk-b-Link sprk-b-Link--plain sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column"
-            additionalTriggerTextClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@xxs"
-            additionalIconClasses="sprk-Stack__item sprk-u-mrs"
-            [triggerText]="narrowSelector['trigger'].text"
-            selector="Select One"
-            triggerIconType="chevron-down"
-            [choices]="narrowSelector['choices']"
+          <div
+            class="sprk-c-Dropdown__footer sprk-u-TextAlign--center"
+            sprkDropdownFooter
           >
-            <div
-              class="sprk-c-Dropdown__footer sprk-u-TextAlign--center"
-              sprkDropdownFooter
+            <sprk-link
+              linkType="unstyled"
+              additionalClasses="sprk-c-Button sprk-c-Button--tertiary"
             >
-              <sprk-link
-                linkType="unstyled"
-                additionalClasses="sprk-c-Button sprk-c-Button--tertiary"
-              >
-                Go Elsewhere
-              </sprk-link>
-            </div>
-          </sprk-dropdown>
+              Go Elsewhere
+            </sprk-link>
+          </div>
+        </sprk-dropdown>
 
-          <sprk-masthead-accordion [additionalClasses]="getNarrowNavClasses()">
-            <div *ngFor="let narrowLink of narrowNavLinks">
-              <div *ngIf="narrowLink.subNav">
-                <sprk-masthead-accordion-item
-                  iconTypeOpen="chevron-down"
-                  iconTypeClosed="chevron-down"
-                  [leadingIcon]="narrowLink.leadingIcon"
-                  [isActive]="narrowLink.active"
-                  [title]="narrowLink.text"
+        <sprk-masthead-accordion [additionalClasses]="getNarrowNavClasses()">
+          <div *ngFor="let narrowLink of narrowNavLinks">
+            <div *ngIf="narrowLink.subNav">
+              <sprk-masthead-accordion-item
+                iconTypeOpen="chevron-down"
+                iconTypeClosed="chevron-down"
+                [leadingIcon]="narrowLink.leadingIcon"
+                [isActive]="narrowLink.active"
+                [title]="narrowLink.text"
+              >
+                <ul
+                  class="sprk-b-List sprk-b-List--bare sprk-c-MastheadAccordion__details"
                 >
-                  <ul
-                    class="sprk-b-List sprk-b-List--bare sprk-c-MastheadAccordion__details"
+                  <li
+                    class="sprk-c-MastheadAccordion__item"
+                    *ngFor="let subNavLink of narrowLink.subNav"
                   >
-                    <li
-                      class="sprk-c-MastheadAccordion__item"
-                      *ngFor="let subNavLink of narrowLink.subNav"
+                    <sprk-link
+                      linkType="unstyled"
+                      additionalClasses="sprk-c-MastheadAccordion__summary"
+                      [href]="subNavLink.href"
                     >
-                      <sprk-link
-                        linkType="unstyled"
-                        additionalClasses="sprk-c-MastheadAccordion__summary"
-                        [href]="subNavLink.href"
-                      >
-                        <sprk-icon
-                          [iconType]="subNavLink.leadingIcon"
-                          additionalClasses="sprk-c-Icon--stroke-current-color sprk-u-mrs"
-                          *ngIf="subNavLink.leadingIcon"
-                        ></sprk-icon>
-                        {{ subNavLink.text }}
-                      </sprk-link>
-                    </li>
-                  </ul>
-                </sprk-masthead-accordion-item>
-              </div>
-              <div *ngIf="!narrowLink.subNav">
-                <li
-                  [ngClass]="{
-                    'sprk-c-MastheadAccordion__item': true,
-                    'sprk-c-MastheadAccordion__item--active': narrowLink.active
-                  }"
-                >
-                  <sprk-link
-                    linkType="unstyled"
-                    additionalClasses="sprk-c-MastheadAccordion__summary"
-                    [href]="narrowLink.href"
-                  >
-                    <span class="sprk-c-MastheadAccordion__heading">
                       <sprk-icon
-                        [iconType]="narrowLink.leadingIcon"
+                        [iconType]="subNavLink.leadingIcon"
                         additionalClasses="sprk-c-Icon--stroke-current-color sprk-u-mrs"
-                        *ngIf="narrowLink.leadingIcon"
+                        *ngIf="subNavLink.leadingIcon"
                       ></sprk-icon>
-                      {{ narrowLink.text }}
-                    </span>
-                  </sprk-link>
-                </li>
-              </div>
+                      {{ subNavLink.text }}
+                    </sprk-link>
+                  </li>
+                </ul>
+              </sprk-masthead-accordion-item>
             </div>
-          </sprk-masthead-accordion>
-          <ng-content select="[narrowNavFooter]"></ng-content>
-        </nav>
-      </div>
+            <div *ngIf="!narrowLink.subNav">
+              <li
+                [ngClass]="{
+                  'sprk-c-MastheadAccordion__item': true,
+                  'sprk-c-MastheadAccordion__item--active': narrowLink.active
+                }"
+              >
+                <sprk-link
+                  linkType="unstyled"
+                  additionalClasses="sprk-c-MastheadAccordion__summary"
+                  [href]="narrowLink.href"
+                >
+                  <span class="sprk-c-MastheadAccordion__heading">
+                    <sprk-icon
+                      [iconType]="narrowLink.leadingIcon"
+                      additionalClasses="sprk-c-Icon--stroke-current-color sprk-u-mrs"
+                      *ngIf="narrowLink.leadingIcon"
+                    ></sprk-icon>
+                    {{ narrowLink.text }}
+                  </span>
+                </sprk-link>
+              </li>
+            </div>
+          </div>
+        </sprk-masthead-accordion>
+        <ng-content select="[narrowNavFooter]"></ng-content>
+      </nav>
     </header>
   `
 })


### PR DESCRIPTION
## What does this PR do?
**Problem:**
nav gets cut off when there are too many items on IE and FF


**Solution:**
- got rid of position:fixed on `.sprk-c-Masthead__narrow-nav`
- consolidate the angular's `__narrow-nav` `<nav>` with the ngIf `<div>` container

**Reasoning:**
- `.sprk-c-Masthead__narrow-nav` is currently `position: fixed`
- its parent (when open) is also `position: fixed`
- Nested fixed elements are redundant and unecessary, causing browsers like Firefox and IE to break layout padding and positioning.
- This change is safe to do because: `.sprk-c-Masthead__narrow-nav` is only visible when Masthead is in a `.sprk-c-Masthead--open` state.
  - `.sprk-c-Masthead` starts as `position: sticky` but then replaced with `position: fixed` when `.sprk-c-Masthead--open` is applied
- With the first solution, everything BUT angular gets fixed on IE and FF and Safari. With the consolidated markup, it matches all the other implementation, and fixes the bug.

**Note**: some alphabetizing was done as well.

Further reading:
https://www.w3.org/TR/CSS2/visudet.html#containing-block-details
https://stackoverflow.com/questions/1384604/css-positionfixed-inside-of-position-fixed
![image](https://user-images.githubusercontent.com/4342363/55426027-cbb72480-5551-11e9-81b7-49219203d48c.png)

### Associated Issue 
Fixes #1103 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
No changes to documentation, no variable changes necessary

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Build Component in Spark Angular
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
    - [x] Vanilla
    - [x] Angular
    - [x] React
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
    - [x] Vanilla
    - [x] Angular
    - [x] React
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
    - [x] Vanilla
    - [x] Angular
    - [x] React
  - [x] Microsoft Edge
    - [x] Vanilla
    - [x] Angular
    - [x] React
  - [x] Apple Safari
    - [x] Vanilla
    - [x] Angular
    - [x] React
  - [x] Apple Safari (Mobile)