### PR TITLE
Allow cards to be full width - #1241

### DIFF
--- a/packages/spark-card/_card.scss
+++ b/packages/spark-card/_card.scss
@@ -93,3 +93,24 @@ $sprk-card-header-text-color: $sprk-white !default;
     min-width: 0%;
   }
 }
+
+.sprk-c-Card--full {
+  max-width: 100%;
+}
+
+.sprk-c-Card--full\@xs {
+  max-width: 100%;
+
+  @media screen and (min-width: $sprk-btn-breakpoint-xs) {
+    max-width: 100%;
+  }
+}
+
+.sprk-c-Card--full\@sm,
+.sprk-c-Card--full\@s {
+  max-width: 100%;
+
+  @media screen and (min-width: $sprk-btn-breakpoint-s) {
+    max-width: 100%;
+  }
+}

--- a/packages/spark-card/_card.scss
+++ b/packages/spark-card/_card.scss
@@ -97,20 +97,3 @@ $sprk-card-header-text-color: $sprk-white !default;
 .sprk-c-Card--full {
   max-width: 100%;
 }
-
-.sprk-c-Card--full\@xs {
-  max-width: 100%;
-
-  @media screen and (min-width: $sprk-btn-breakpoint-xs) {
-    max-width: 100%;
-  }
-}
-
-.sprk-c-Card--full\@sm,
-.sprk-c-Card--full\@s {
-  max-width: 100%;
-
-  @media screen and (min-width: $sprk-btn-breakpoint-s) {
-    max-width: 100%;
-  }
-}

--- a/src/patterns/components/card/collection.yaml
+++ b/src/patterns/components/card/collection.yaml
@@ -50,3 +50,5 @@ variableTable:
 classTable:
   .sprk-c-Card--standout:
     description: Use on cards that you would like to standout from the rest.
+  .sprk-c-Card--full:
+    description: Sets `max-width` to 100%, allowing card to fill entire width of it's container. Best used with base cards 


### PR DESCRIPTION
## What does this PR do?
Adds a modifier to allow cards to be the full width of their container.

### Associated Issue 
Fixes #1241

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs Vanilla
 - [x] Update Component Sass Var/Class Modifier table

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Design Review
 - [x] Design reviewed and approved

