### PR TITLE
Show React code switch in staging

### DIFF
--- a/src/assets/drizzle/scripts/code-example-switch.js
+++ b/src/assets/drizzle/scripts/code-example-switch.js
@@ -23,29 +23,7 @@ const showSections = (values) => {
   });
 };
 
-// TODO: Remove once React is published
-// If query string present bool:true
-// then show code button
-// else clear localStorage that could include reat
-const toggleCodeButton = (hasQueryString, codeButton) => {
-  const isSetToReact = localStorage.getItem('code-example-switch') === 'react';
-  if (hasQueryString) {
-    codeButton.classList.remove('sprk-u-Display--none');
-  } else {
-    codeButton.classList.add('sprk-u-Display--none');
-    if (isSetToReact) {
-      localStorage.setItem('code-example-switch', 'none');
-    }
-  }
-};
-
 const bindUIEvents = (element) => {
-  // TODO: Remove once React is published
-  const reactButton = element.querySelector('[data-code-example-switch-react]');
-  const hasReactQueryString = window.location.search.indexOf('react') > -1;
-  toggleCodeButton(hasReactQueryString, reactButton);
-  // END TODO
-
   element.querySelectorAll('label').forEach((label) => {
     label.addEventListener('keydown', (e) => {
       if (e.keyCode === 13) {

--- a/src/templates/drizzle/code-example-switch.hbs
+++ b/src/templates/drizzle/code-example-switch.hbs
@@ -13,7 +13,7 @@
       <input class="drizzle-c-CodeExampleSwitch__input" value="angular" type="radio" id="angular" name="code-examples" />
       <label tabindex="0" class="drizzle-c-CodeExampleSwitch__label" for="angular">Angular</label>
     </div>
-    <div class="drizzle-c-CodeExampleSwitch__radio-container sprk-u-Display--none" data-code-example-switch-react>
+    <div class="drizzle-c-CodeExampleSwitch__radio-container">
       <input class="drizzle-c-CodeExampleSwitch__input" value="react" type="radio" id="react" name="code-examples" />
       <label tabindex="0" class="drizzle-c-CodeExampleSwitch__label" for="react">React</label>
     </div>


### PR DESCRIPTION
## What does this PR do?
Shows the React code switch in staging. There's no harm in having this in staging and we need it for the demo. The nav doesn't have `?react` after every component and I'd rather not have us  add `?react` during the demo all the time.

### Associated Issue 
Fixes #1164.