### PR TITLE
[Bug] Angular Inputs: Date Picker Input Calendar does not appear on click

### DIFF
--- a/src/angular/projects/spark-core-angular/src/lib/directives/inputs/sprk-datepicker/sprk-datepicker.directive.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/directives/inputs/sprk-datepicker/sprk-datepicker.directive.ts
@@ -1,13 +1,11 @@
 import { Directive, ElementRef, Inject, Input, OnInit } from '@angular/core';
+import TinyDatePicker from 'tiny-date-picker';
 
 @Directive({
   selector: '[sprkDatepicker]'
 })
 export class SprkDatepickerDirective implements OnInit {
-  constructor(
-    public ref: ElementRef,
-    @Inject('TinyDatePicker') public TinyDatePicker: any
-  ) {}
+  constructor(public ref: ElementRef) {}
 
   @Input()
   sprkDatePickerConfig: object;
@@ -31,8 +29,8 @@ export class SprkDatepickerDirective implements OnInit {
           .replace(/[^ -~]/g, '')
     };
 
-    if (this.TinyDatePicker) {
-      this.TinyDatePicker(input, {
+    if (TinyDatePicker) {
+      TinyDatePicker(input, {
         ...tdpConfig,
         ...this.sprkDatePickerConfig
       }).on('select', () => {

--- a/src/angular/projects/spark-core-angular/src/lib/spark-core-angular.module.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/spark-core-angular.module.ts
@@ -43,15 +43,7 @@ import { SparkToggleModule } from './components/sprk-toggle/sprk-toggle.module';
 import { SparkUnorderedListModule } from './components/sprk-unordered-list/sprk-unordered-list.module';
 import { SprkButtonModule } from './directives/inputs/sprk-button/sprk-button.module';
 
-import TinyDatePicker from 'tiny-date-picker';
-
 @NgModule({
-  providers: [
-    {
-      provide: 'TinyDatePicker',
-      useValue: TinyDatePicker
-    }
-  ],
   exports: [
     SparkAlertModule,
     SparkAccordionModule,

--- a/src/angular/src/app/spark-docs/stack-docs/stack-docs.component.ts
+++ b/src/angular/src/app/spark-docs/stack-docs/stack-docs.component.ts
@@ -525,5 +525,6 @@ import { Component } from '@angular/core';
   styles: ['']
 })
 export class StackDocsComponent {
+  text_input = '';
   constructor() {}
 }


### PR DESCRIPTION
## What does this PR do?
When angular is built in --prod, angular date picker input does not work. This is because it's not being packaged correctly with the flag.

Date picker uses a third party library called `tiny-date-picker`. There are a [two ways](https://nitayneeman.com/posts/how-to-add-third-party-library-in-angular-cli/) to bring in external libraries: **Injection**, and **import modules**.

In order to use injection, the library has to have typings, which `tiny-date-picker` does not have.

**Instead of creating one, we are opting to use the second method of importing it for the sake of simplicity.**


#### Concerns addressed:

- There were concerns from @RCopeland that the import module method might an Angular anti-pattern.
  - I couldn't find sources that say it is. Injection vs import is more of a choice based on situation, but neither have been considered bad practice
  - [More conversations on the pros and cons of each](https://softwareengineering.stackexchange.com/questions/336767/module-requiring-vs-dependency-injection-in-javascript)
- Injection would be useful if we needed access to the class constructor of components and services
  - We don't need that for tiny-date-picker

> At a high level, Angular reads the NgModule metadata during the bootstrap process and creates an injector capable of providing these dependencies through the class constructor of components and services throughout the application. -- [angularfirst.com](https://angularfirst.com/when-to-use-es2015-modules-instead-of-angular-dependency-injection-and-when-not-to/)

Tiny Date picker doesn’t need any of these things.

- Injection makes that library global
  - We don't need that for `tiny-date-picker`


Further reading:
- Here's [an opinion ](https://medium.com/@bluepnume/dependency-injection-in-angular-isn-t-worth-it-more-lessons-learned-from-scaling-paypal-checkout-2189ec9c21a0)that thinks injection should be completely out of the question
- https://stackoverflow.com/questions/43861935/angularjs-dependency-injection-vs-es6-import


### Associated Issue 
#1119

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Build Component in Spark Angular
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)