### PR TITLE
[Bug] React icon non-working code samples

### DIFF
--- a/src/templates/drizzle/icon-gallery.hbs
+++ b/src/templates/drizzle/icon-gallery.hbs
@@ -42,7 +42,7 @@
                 </button>
                 <pre class="sprk-u-ptl">
                   <code class="drizzle-c-Preview__markup language-markup" id="clipboard-{{toSlug name}}">
-&lt;SprkIcon iconType="{{ name }}" additionalClasses=&quot;sprk-c-Icon--l&quot; /&gt;
+&lt;SprkIcon iconName="{{ name }}" additionalClasses=&quot;sprk-c-Icon--l&quot; /&gt;
                     </code>
                 </pre>
               </div>

--- a/src/templates/drizzle/icon-gallery.hbs
+++ b/src/templates/drizzle/icon-gallery.hbs
@@ -42,7 +42,7 @@
                 </button>
                 <pre class="sprk-u-ptl">
                   <code class="drizzle-c-Preview__markup language-markup" id="clipboard-{{toSlug name}}">
-&lt;SprkIcon iconType="{{ name }}" additionalClasses=&quot;sprk-c-Icon--l&quot;&gt; /&gt;
+&lt;SprkIcon iconType="{{ name }}" additionalClasses=&quot;sprk-c-Icon--l&quot; /&gt;
                     </code>
                 </pre>
               </div>


### PR DESCRIPTION
## What does this PR do?
There was an extra `&gt;` in `icon-gallery.hbs` that added an extra carat. This PR fixes all code samples for react icon

### Associated Issue 
https://github.com/sparkdesignsystem/spark-design-system/issues/1253

### Documentation
 - [x] Update Spark Docs React