### PR TITLE
[Doc] Fix Spark React code copy blocks in docs

### DIFF
--- a/gulp/drizzle/config.js
+++ b/gulp/drizzle/config.js
@@ -150,6 +150,8 @@ module.exports = {
       indent_size: 2,
       indent_with_tabs: false,
       max_preserve_newlines: 1,
+      e4x: true,
+      wrap_attributes: 'force-expand-multiline',
       wrap_line_length: 0,
       unformatted: `a abbr acronym address b bdo big cite code col del dfn dt em font
         h1 h2 h3 h4 h5 h6 i img ins kbd mark pre q s samp small span


### PR DESCRIPTION
## Before
copyable code blocks have extra spaces that break the code
![Screen Shot 2019-04-16 at 1 16 16 PM](https://user-images.githubusercontent.com/4342363/56230320-02a93200-604a-11e9-9e8a-e6199403d9b0.png)

## After
jsx support is added to Beautifier which doesn't cause the extra spaces
![image](https://user-images.githubusercontent.com/4342363/56230352-0e94f400-604a-11e9-99d3-6237c447cb64.png)

## Additional Improvements
Added a config that puts attributes into separated lines. Makes everything more readable and match closer to how we as front-end devs would implement a component. (Affects react, angular and vanilla)

### Before
![image](https://user-images.githubusercontent.com/4342363/56230608-a5fa4700-604a-11e9-8a6c-3589a834ef54.png)


### After
![image](https://user-images.githubusercontent.com/4342363/56230543-806d3d80-604a-11e9-8f73-69dad89d73bf.png)



### Associated Issue 
#1243 