### PR TITLE
add back defaultProps to promo

### DIFF
--- a/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
@@ -106,7 +106,7 @@ class SprkMastheadDropdown extends Component {
               additionalClasses,
             )}
           >
-            {title !== '' && (
+            {title && (
               <div className="sprk-c-Dropdown__header">
                 <h2 className="sprk-c-Dropdown__title">{title}</h2>
               </div>

--- a/src/react/projects/spark-react/src/SprkPromo/SprkPromo.js
+++ b/src/react/projects/spark-react/src/SprkPromo/SprkPromo.js
@@ -237,4 +237,10 @@ SprkPromo.propTypes = {
   hasBorder: PropTypes.bool,
 };
 
+SprkPromo.defaultProps = {
+  isFlag: false,
+  mediaRev: false,
+  hasBorder: false,
+};
+
 export default SprkPromo;


### PR DESCRIPTION
## What does this PR do?

- Adds back default props to promo that were removed accidentally in the SprkLink PR.
- Fix masthead dropdown from rendering a blank header on big nav items. This was caused by removing the title defaultProp from MastheadDropdown.

### Associated Issue 
https://github.com/sparkdesignsystem/spark-design-system/issues/1339t.
