### PR TITLE
Update SprkLink & Masthead for React

### DIFF
--- a/src/patterns/components/links/react/info/inline.hbs
+++ b/src/patterns/components/links/react/info/inline.hbs
@@ -23,7 +23,7 @@
       </td>
 
       <td>
-        string
+        string, function
       </td>
 
       <td>

--- a/src/patterns/components/masthead/react/info/default.hbs
+++ b/src/patterns/components/masthead/react/info/default.hbs
@@ -51,6 +51,16 @@
       <td>Expects a Component to render into the logo area of the masthead.</td>
     </tr>
     <tr>
+      <td class="sprk-u-FontWeight--bold">logoLink</td>
+      <td>string</td>
+      <td>Expects a string that will render as the href for the logo.</td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">logoLinkElement</td>
+      <td>string, function</td>
+      <td>Expects an 'a' or react route link that will determine what element is rendered for the logo link.</td>
+    </tr>
+    <tr>
       <td class="sprk-u-FontWeight--bold">selector</td>
       <td>object</td>
       <td>Expects a selector object that represents choices to be supplied to the selector in the wide viewport

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.js
@@ -10,8 +10,8 @@ const SprkLink = props => {
     additionalClasses,
     idString,
     analyticsString,
-    href,
     onClick,
+    href,
     ...other
   } = props;
   const TagName = element || 'a';
@@ -23,13 +23,23 @@ const SprkLink = props => {
     'sprk-b-Link--simple sprk-b-Link--has-icon': variant === 'has-icon',
   });
 
+  let link;
+  if (href) {
+    link = href;
+  } else if (TagName === 'a' || TagName === 'button') {
+    link = '#';
+  } else {
+    link = undefined;
+  }
+
   let clickEvent;
   function handleClick(e) {
     e.preventDefault();
   }
   if (onClick) {
     clickEvent = onClick;
-  } else if (!onClick && href === '#') {
+  } else if (!onClick && link === '#') {
+    console.log(element);
     clickEvent = handleClick;
   }
 
@@ -38,7 +48,7 @@ const SprkLink = props => {
       className={classNames}
       data-analytics={analyticsString}
       data-id={idString}
-      href={href}
+      href={link}
       onClick={clickEvent}
       {...other}
     >
@@ -68,14 +78,13 @@ SprkLink.propTypes = {
   // Url passed
   href: PropTypes.string,
   // The element that will be rendered
-  element: PropTypes.string,
+  element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   // The event that will fire when the element is clicked
   onClick: PropTypes.func,
 };
 
 SprkLink.defaultProps = {
   variant: 'base',
-  href: '#',
 };
 
 export default SprkLink;

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.js
@@ -26,7 +26,7 @@ const SprkLink = props => {
   let link;
   if (href) {
     link = href;
-  } else if (TagName === 'a' || TagName === 'button') {
+  } else if (TagName === 'a' && !href) {
     link = '#';
   } else {
     link = undefined;

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.js
@@ -39,7 +39,6 @@ const SprkLink = props => {
   if (onClick) {
     clickEvent = onClick;
   } else if (!onClick && link === '#') {
-    console.log(element);
     clickEvent = handleClick;
   }
 

--- a/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
+++ b/src/react/projects/spark-react/src/SprkLink/SprkLink.test.js
@@ -1,5 +1,6 @@
 /* global it, expect, jest */
 import React from 'react';
+import { Link } from 'react-router-dom';
 import Enzyme, { shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import SprkLink from './SprkLink';
@@ -55,4 +56,9 @@ it('should prevent default when no href is provided', () => {
     },
   });
   expect(prevented).toBe(true);
+});
+
+it('should not render an href if none is provided and element passed is a router link', () => {
+  const wrapper = shallow(<SprkLink element={Link} to="button" />);
+  expect(wrapper.find('a[href="#"]').length).toBe(0);
 });

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -62,6 +62,7 @@ class SprkMasthead extends Component {
       utilityContents,
       variant,
       logoLink,
+      logoLinkElement,
     } = this.props;
     const { isScrolled, narrowNavOpen } = this.state;
 
@@ -85,9 +86,23 @@ class SprkMasthead extends Component {
           />
 
           <div className="sprk-c-Masthead__branding sprk-o-Stack__item sprk-o-Stack__item--center-column@xxs">
-            <SprkLink variant="unstyled" href={logoLink}>
-              {siteLogo}
-            </SprkLink>
+            {logoLinkElement !== 'a' ? (
+              <SprkLink
+                variant="unstyled"
+                to={logoLink}
+                element={logoLinkElement}
+              >
+                {siteLogo}
+              </SprkLink>
+            ) : (
+              <SprkLink
+                variant="unstyled"
+                href={logoLink}
+                element={logoLinkElement}
+              >
+                {siteLogo}
+              </SprkLink>
+            )}
           </div>
 
           {(littleNavLinks.length > 0 || utilityContents.length > 0) && (
@@ -194,6 +209,8 @@ SprkMasthead.propTypes = {
   variant: PropTypes.oneOf(['default', 'extended']),
   // the href to render for the logo link
   logoLink: PropTypes.string,
+  // the element link element to render for the logo
+  logoLinkElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 };
 
 SprkMasthead.defaultProps = {
@@ -203,6 +220,7 @@ SprkMasthead.defaultProps = {
   utilityContents: [],
   variant: 'default',
   logoLink: '/',
+  logoLinkElement: 'a',
 };
 
 export default SprkMasthead;

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -61,6 +61,7 @@ class SprkMasthead extends Component {
       selector,
       utilityContents,
       variant,
+      logoLink,
     } = this.props;
     const { isScrolled, narrowNavOpen } = this.state;
 
@@ -84,7 +85,7 @@ class SprkMasthead extends Component {
           />
 
           <div className="sprk-c-Masthead__branding sprk-o-Stack__item sprk-o-Stack__item--center-column@xxs">
-            <SprkLink variant="unstyled" href="/">
+            <SprkLink variant="unstyled" href={logoLink}>
               {siteLogo}
             </SprkLink>
           </div>
@@ -191,6 +192,8 @@ SprkMasthead.propTypes = {
   utilityContents: PropTypes.arrayOf(PropTypes.node),
   // the variant name to render
   variant: PropTypes.oneOf(['default', 'extended']),
+  // the href to render for the logo link
+  logoLink: PropTypes.string,
 };
 
 SprkMasthead.defaultProps = {
@@ -199,6 +202,7 @@ SprkMasthead.defaultProps = {
   bigNavLinks: [],
   utilityContents: [],
   variant: 'default',
+  logoLink: '/',
 };
 
 export default SprkMasthead;

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.test.js
@@ -1,11 +1,14 @@
 /* global it expect window document Event */
 import React from 'react';
+import { BrowserRouter as Router } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import Enzyme, { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import SprkMasthead from './SprkMasthead';
 import SprkMastheadLittleNav from './components/SprkMastheadLittleNav/SprkMastheadLittleNav';
 import SprkMastheadBigNav from './components/SprkMastheadBigNav/SprkMastheadBigNav';
 import SprkMastheadNarrowNav from './components/SprkMastheadNarrowNav/SprkMastheadNarrowNav';
+import SprkLink from '../SprkLink/SprkLink';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -112,4 +115,22 @@ it('should render LittleNav if littleNavlinks is present', () => {
 it('should render NarrowNav if narrowNavlinks is present', () => {
   const wrapper = mount(<SprkMasthead narrowNavLinks={[{ text: 'Hi' }]} />);
   expect(wrapper.find(SprkMastheadNarrowNav).length).toBe(1);
+});
+
+it('should render the correct logoLink if logoLinkElement is an anchor', () => {
+  const wrapper = mount(
+    <SprkMasthead logoLinkElement="a" logoLink="https://google.com" />,
+  );
+  expect(wrapper.find(SprkLink).props().href).toBe('https://google.com');
+  expect(wrapper.find(SprkLink).props().element).toBe('a');
+});
+
+it('should render the correct logoLink if logoLinkElement is router link', () => {
+  const wrapper = mount(
+    <Router>
+      <SprkMasthead logoLinkElement={Link} logoLink="/button" />
+    </Router>,
+  );
+  expect(wrapper.find(SprkLink).props().to).toBe('/button');
+  expect(wrapper.find(SprkLink).props().element).toBe(Link);
 });

--- a/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
+++ b/src/react/src/routes/SprkLinkDocs/SprkLinkDocs.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import { SprkLink, SprkIcon } from '@sparkdesignsystem/spark-react';
 import CentralColumnLayout from '../../containers/CentralColumnLayout/CentralColumnLayout';
 import ExampleContainer from '../../containers/ExampleContainer/ExampleContainer';
@@ -34,11 +35,15 @@ const SprkLinkDocs = () => (
 
     <h2 className="drizzle-b-h2">External Links</h2>
     <ExampleContainer>
-      <SprkLink id="foo" href="https://google.com" target="_blank">https://google.com</SprkLink>
+      <SprkLink id="foo" href="https://google.com" target="_blank">
+        https://google.com
+      </SprkLink>
     </ExampleContainer>
 
     <ExampleContainer>
-      <SprkLink id="foo" href="https://google.com" target="_blank">http://google.com</SprkLink>
+      <SprkLink id="foo" href="https://google.com" target="_blank">
+        http://google.com
+      </SprkLink>
     </ExampleContainer>
 
     <h2 className="drizzle-b-h2">Same Page Links</h2>
@@ -85,6 +90,13 @@ const SprkLinkDocs = () => (
           iconName="communication"
         />
         Message Us
+      </SprkLink>
+    </ExampleContainer>
+
+    <h2 className="drizzle-b-h2">React Router Link</h2>
+    <ExampleContainer>
+      <SprkLink element={Link} to='/button'>
+        To Button
       </SprkLink>
     </ExampleContainer>
 


### PR DESCRIPTION
## What does this PR do?
Refactor SprkLink to accept {Link} as an element.
Updates Masthead in React and Angular to allow a user to provide a different href other than "/". Allows for internal and external links.

### Associated Issue 
#1324
#1346 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs React

### Code
 - [x] Update Component in Spark React
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)