### PR TITLE
Update version after new 8.0.5 publish

### DIFF
--- a/src/angular/projects/spark-core-angular/package.json
+++ b/src/angular/projects/spark-core-angular/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sparkdesignsystem/spark-core-angular",
   "description": "A collection of Spark Design System components in Angular 6+",
-  "version": "8.0.2",
+  "version": "8.0.5",
   "scripts": {
     "lint": "ng lint spark-core-angular",
     "test": "ng test spark-core-angular --watch=false",


### PR DESCRIPTION
## What does this PR do?
Updates version after new 8.0.5 publish. I pulled down the new version from npm in an ng app and verified that it's working. Also, verified that the masthead fix is working.