### PR TITLE
Add option to use custom icons in Alerts

### DIFF
--- a/src/patterns/components/alerts/react/info/info.hbs
+++ b/src/patterns/components/alerts/react/info/info.hbs
@@ -12,73 +12,105 @@
   </tr>
   </thead>
   <tbody>
-  <tr>
-    <td class="sprk-u-FontWeight--bold">variant</td>
-    <td>String</td>
-    <td>
-      Can be 'info', 'fail', or 'success'. Will cause the
-      appropriate variant type to render.
-    </td>
-  </tr>
-  <tr>
-    <td class="sprk-u-FontWeight--bold">isVisible</td>
-    <td>Boolean</td>
-    <td>
-      This determines whether to render the alert. Change the value of this prop to true
-      to show the alert or false to hide the alert.
-    </td>
-  </tr>
-  <tr>
-    <td class="sprk-u-FontWeight--bold">message</td>
-    <td>String</td>
-    <td>The paragraph content for the alert message.</td>
-  </tr>
-  <tr>
-    <td class="sprk-u-FontWeight--bold">isDismissible</td>
-    <td>Boolean</td>
-    <td>
-      If set to false, the close button will not render.
-      If unset, or set to the default of true then the close button will render.
-      Dismissing does not persist across
-      sessions.
-    </td>
-  </tr>
-  <tr>
-    <td class="sprk-u-FontWeight--bold">idString</td>
-    <td>String</td>
-    <td>
-      The value supplied will be assigned to the 'data-id' attribute on
-      the component. This is intended to be used as a
-      selector for automated tools. This value should be unique per page.
-    </td>
-  </tr>
-  <tr>
-    <td class="sprk-u-FontWeight--bold">analyticsString</td>
-    <td>String</td>
-    <td>
-      The value supplied will be assigned to the 'data-analytics'
-      attribute on the dismiss button. This is intended to be
-      used as a selector for automated tools. This value should
-      be unique per page.
-    </td>
-  </tr>
-  <tr>
-    <td class="sprk-u-FontWeight--bold">additionalClasses</td>
-    <td>String</td>
-    <td>
-      Allows a string of classes to add, in addition to the
-      component classes. Intended for overrides.
-    </td>
-  </tr>
-  <tr>
-    <td class="sprk-u-FontWeight--bold">onDismiss</td>
-    <td>Function</td>
-    <td>
-      A function that is called when the
-      dismiss button is clicked. This function should toggle
-      the isVisible state that is passed to the isVisible
-      prop.
-    </td>
-  </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">variant</td>
+      <td>String</td>
+      <td>
+        Can be 'info', 'fail', or 'success'. Will cause the
+        appropriate variant type to render.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">isVisible</td>
+      <td>Boolean</td>
+      <td>
+        This determines whether to render the alert. Change the value of this prop to true
+        to show the alert or false to hide the alert.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">message</td>
+      <td>String</td>
+      <td>The paragraph content for the alert message.</td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">isDismissible</td>
+      <td>Boolean</td>
+      <td>
+        If set to false, the close button will not render.
+        If unset, or set to the default of true then the close button will render.
+        Dismissing does not persist across
+        sessions.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">idString</td>
+      <td>String</td>
+      <td>
+        The value supplied will be assigned to the 'data-id' attribute on
+        the component. This is intended to be used as a
+        selector for automated tools. This value should be unique per page.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">analyticsString</td>
+      <td>String</td>
+      <td>
+        The value supplied will be assigned to the 'data-analytics'
+        attribute on the dismiss button. This is intended to be
+        used as a selector for automated tools. This value should
+        be unique per page.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">additionalClasses</td>
+      <td>String</td>
+      <td>
+        Allows a string of classes to add, in addition to the
+        component classes. Intended for overrides.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">onDismiss</td>
+      <td>Function</td>
+      <td>
+        A function that is called when the
+        dismiss button is clicked. This function should toggle
+        the isVisible state that is passed to the isVisible
+        prop.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">iconNameDismiss</td>
+      <td>String</td>
+      <td>
+        Allows a custom icon name to be used for the dismiss button.
+        The default is set to use the Spark 'close' icon.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">iconNameSuccess</td>
+      <td>String</td>
+      <td>
+        Allows a custom icon name to be used for the success alert.
+        The default is set to use the Spark 'check-mark' icon.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">iconNameInfo</td>
+      <td>String</td>
+      <td>
+        Allows a custom icon name to be used for the info alert.
+        The default is set to use the Spark 'bell' icon.
+      </td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">iconNameFail</td>
+      <td>String</td>
+      <td>
+        Allows a custom icon name to be used for the fail alert.
+        The default is set to use the Spark 'exclamation' icon.
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/src/react/projects/spark-react/src/SprkAlert/SprkAlert.js
+++ b/src/react/projects/spark-react/src/SprkAlert/SprkAlert.js
@@ -13,6 +13,10 @@ const SprkAlert = props => {
     onDismiss,
     analyticsString,
     isVisible,
+    iconNameSuccess,
+    iconNameInfo,
+    iconNameFail,
+    iconNameDismiss,
     ...other
   } = props;
 
@@ -28,13 +32,13 @@ const SprkAlert = props => {
 
   switch (variant) {
     case 'success':
-      icon = 'check-mark';
+      icon = iconNameSuccess;
       break;
     case 'info':
-      icon = 'bell';
+      icon = iconNameInfo;
       break;
     case 'fail':
-      icon = 'exclamation';
+      icon = iconNameFail;
       break;
     default:
       break;
@@ -62,7 +66,7 @@ const SprkAlert = props => {
           data-analytics={analyticsString}
         >
           <SprkIcon
-            iconName="close"
+            iconName={iconNameDismiss}
             additionalClasses="sprk-c-Icon--stroke-current-color"
             aria-hidden="true"
           />
@@ -73,6 +77,10 @@ const SprkAlert = props => {
 };
 
 SprkAlert.defaultProps = {
+  iconNameFail: 'exclamation',
+  iconNameDismiss: 'close',
+  iconNameInfo: 'bell',
+  iconNameSuccess: 'check-mark',
   isVisible: false,
   isDismissible: true,
 };
@@ -94,6 +102,14 @@ SprkAlert.propTypes = {
   additionalClasses: PropTypes.string,
   // Function that is called when dismiss button is clicked
   onDismiss: PropTypes.func,
+  // The icon name for the fail alert
+  iconNameFail: PropTypes.string,
+  // The icon name for the dismiss button
+  iconNameDismiss: PropTypes.string,
+  // The icon name for the info alert
+  iconNameInfo: PropTypes.string,
+  // The icon name for the success alert
+  iconNameSuccess: PropTypes.string,
 };
 
 export default SprkAlert;

--- a/src/react/projects/spark-react/src/SprkAlert/SprkAlert.js
+++ b/src/react/projects/spark-react/src/SprkAlert/SprkAlert.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import SprkIcon from '../SprkIcon/SprkIcon';
 
-const SprkAlert = (props) => {
+const SprkAlert = props => {
   const {
     message,
     variant,
@@ -20,14 +20,11 @@ const SprkAlert = (props) => {
 
   let icon;
 
-  const classNames = classnames(
-    'sprk-c-Alert',
-    additionalClasses, {
-      'sprk-c-Alert--info': variant === 'info',
-      'sprk-c-Alert--success': variant === 'success',
-      'sprk-c-Alert--fail': variant === 'fail',
-    },
-  );
+  const classNames = classnames('sprk-c-Alert', additionalClasses, {
+    'sprk-c-Alert--info': variant === 'info',
+    'sprk-c-Alert--success': variant === 'success',
+    'sprk-c-Alert--fail': variant === 'fail',
+  });
 
   switch (variant) {
     case 'success':
@@ -46,49 +43,38 @@ const SprkAlert = (props) => {
   return (
     <div className={classNames} role="alert" data-id={idString} {...other}>
       <div className="sprk-c-Alert__content">
-        {variant
-          && (
-            <SprkIcon
-              iconName={icon}
-              additionalClasses="sprk-c-Alert__icon sprk-c-Icon--l sprk-c-Icon--stroke-current-color"
-              aria-hidden="true"
-            />
-          )
-        }
+        {variant && (
+          <SprkIcon
+            iconName={icon}
+            additionalClasses="sprk-c-Alert__icon sprk-c-Icon--l sprk-c-Icon--stroke-current-color"
+            aria-hidden="true"
+          />
+        )}
 
-        <p className="sprk-c-Alert__text">
-          {message}
-        </p>
+        <p className="sprk-c-Alert__text">{message}</p>
       </div>
-      {isDismissible
-        && (
-          <button
-            className="sprk-c-Alert__icon sprk-c-Alert__icon--dismiss"
-            type="button"
-            title="Dismiss"
-            onClick={onDismiss}
-            data-analytics={analyticsString}
-          >
-            <SprkIcon
-              iconName="close"
-              additionalClasses="sprk-c-Icon--stroke-current-color"
-              aria-hidden="true"
-            />
-          </button>
-        )
-      }
+      {isDismissible && (
+        <button
+          className="sprk-c-Alert__icon sprk-c-Alert__icon--dismiss"
+          type="button"
+          title="Dismiss"
+          onClick={onDismiss}
+          data-analytics={analyticsString}
+        >
+          <SprkIcon
+            iconName="close"
+            additionalClasses="sprk-c-Icon--stroke-current-color"
+            aria-hidden="true"
+          />
+        </button>
+      )}
     </div>
   );
 };
 
 SprkAlert.defaultProps = {
   isVisible: false,
-  variant: '',
-  idString: '',
-  analyticsString: '',
-  additionalClasses: '',
   isDismissible: true,
-  onDismiss: () => {},
 };
 
 SprkAlert.propTypes = {
@@ -97,7 +83,7 @@ SprkAlert.propTypes = {
   // The alert message that will be rendered inside the paragraph tab
   message: PropTypes.string.isRequired,
   // The link variant that determines the class names
-  variant: PropTypes.oneOf(['info', 'success', 'fail', '']),
+  variant: PropTypes.oneOf(['info', 'success', 'fail']),
   // The string to use for the data-id attribute
   idString: PropTypes.string,
   // Determines if the dismiss button is added

--- a/src/react/projects/spark-react/src/SprkAlert/SprkAlert.test.js
+++ b/src/react/projects/spark-react/src/SprkAlert/SprkAlert.test.js
@@ -35,18 +35,85 @@ it('should hide the dismiss button when isDismissible is set to false', () => {
 it('should run onDismiss when the dismiss button is clicked', () => {
   const spyFunc = jest.fn();
   const wrapper = mount(<SprkAlert message="test" isVisible onDismiss={spyFunc} />);
-  wrapper.find('button.sprk-c-Alert__icon.sprk-c-Alert__icon--dismiss').simulate('click');
+  wrapper
+    .find('button.sprk-c-Alert__icon.sprk-c-Alert__icon--dismiss')
+    .simulate('click');
   expect(spyFunc.mock.calls.length).toBe(1);
 });
 
 it('should not run onDismiss when the dismiss button is clicked and onDismiss is empty', () => {
   const spyFunc = jest.fn();
   const wrapper = mount(<SprkAlert message="test" isVisible />);
-  wrapper.find('button.sprk-c-Alert__icon.sprk-c-Alert__icon--dismiss').simulate('click');
+  wrapper
+    .find('button.sprk-c-Alert__icon.sprk-c-Alert__icon--dismiss')
+    .simulate('click');
   expect(spyFunc.mock.calls.length).toBe(0);
 });
 
 it('should not render the alert is isVisible is false', () => {
   const wrapper = shallow(<SprkAlert message="test" />);
   expect(wrapper.find('div.sprk-c-Alert').length).toBe(0);
+});
+
+it('should display custom success icon when iconNameSuccess has value', () => {
+  const wrapper = mount(
+    <SprkAlert
+      variant="success"
+      message="test"
+      isVisible
+      iconNameSuccess="facebook"
+    />,
+  );
+  expect(
+    wrapper
+      .find('svg.sprk-c-Alert__icon use')
+      .getDOMNode()
+      .getAttribute('xlink:href'),
+  ).toBe('#facebook');
+});
+
+it('should display custom dismiss icon when iconNameDismiss has value', () => {
+  const wrapper = mount(
+    <SprkAlert
+      variant="success"
+      message="test"
+      isVisible
+      iconNameDismiss="instagram"
+    />,
+  );
+  expect(
+    wrapper
+      .find('.sprk-c-Alert__icon--dismiss use')
+      .getDOMNode()
+      .getAttribute('xlink:href'),
+  ).toBe('#instagram');
+});
+
+it('should display custom alert icon when iconNameInfo has value', () => {
+  const wrapper = mount(
+    <SprkAlert
+      variant="info"
+      message="test"
+      isVisible
+      iconNameInfo="twitter"
+    />,
+  );
+  expect(
+    wrapper
+      .find('svg.sprk-c-Alert__icon use')
+      .getDOMNode()
+      .getAttribute('xlink:href'),
+  ).toBe('#twitter');
+});
+
+it('should display custom alert icon when iconNameFail has value', () => {
+  const wrapper = mount(
+    <SprkAlert variant="fail" message="test" isVisible iconNameFail="camera" />,
+  );
+  expect(
+    wrapper
+      .find('svg.sprk-c-Alert__icon use')
+      .getDOMNode()
+      .getAttribute('xlink:href'),
+  ).toBe('#camera');
 });

--- a/src/react/src/routes/SprkAlertDocs/SprkAlertDocs.js
+++ b/src/react/src/routes/SprkAlertDocs/SprkAlertDocs.js
@@ -97,6 +97,37 @@ class SprkAlertDocs extends Component {
             analyticsString="dismiss-button"
           />
         </div>
+
+        <h2 className="sprk-u-mbl">Info Alert with different Icons</h2>
+        <div className="sprk-u-mbm">
+          <SprkAlert
+            isVisible={isVisible1}
+            message="Information alert message placeholder."
+            variant="info"
+            idString="alert-1"
+            additionalClasses="sprk-u-mbh"
+            iconNameDismiss="facebook"
+            iconNameInfo="instagram"
+            onDismiss={() => {
+              this.setState({ isVisible1: false });
+            }}
+          />
+        </div>
+
+        <h2 className="sprk-u-mbl">Success Alert with different Icon</h2>
+        <div className="sprk-u-mbm">
+          <SprkAlert
+            isVisible={isVisible1}
+            message="Success alert message placeholder."
+            variant="success"
+            idString="alert-1"
+            additionalClasses="sprk-u-mbh"
+            iconNameSuccess="camera"
+            onDismiss={() => {
+              this.setState({ isVisible1: false });
+            }}
+          />
+        </div>
       </CentralColumnLayout>
     );
   }


### PR DESCRIPTION
## What does this PR do?
Adds option to use custom icons in Alerts. Removes default props from alert.

### Associated Issue 
https://github.com/sparkdesignsystem/spark-design-system/issues/1325.

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Code
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)
