### PR TITLE
Fix external links in sprk-dropdown - Angular

### DIFF
--- a/src/angular/projects/spark-core-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/src/angular/projects/spark-core-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -131,7 +131,6 @@ export class SparkDropdownComponent {
   constructor(public ref: ElementRef) {}
 
   toggle(event): void {
-    event.preventDefault();
     this.isOpen = !this.isOpen;
   }
 
@@ -157,7 +156,6 @@ export class SparkDropdownComponent {
   }
 
   choiceClick(event) {
-    event.preventDefault();
     this.clearActiveChoices();
     const choiceIndex = event.currentTarget.getAttribute(
       'data-sprk-dropdown-choice-index'


### PR DESCRIPTION
## What does this PR do?
Removes prevent.default() from the sprk-dropdown component to allow external links to work.

### Associated Issue 
Fix #1364 

### Code
 - [x] Build Component in Spark Angular
 - [ ] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)