### PR TITLE
Create react text input huge

### DIFF
--- a/src/patterns/components/inputs/react/code/text-input-huge-disabled.hbs
+++ b/src/patterns/components/inputs/react/code/text-input-huge-disabled.hbs
@@ -1,0 +1,7 @@
+<SprkTextInput
+    type="hugeTextInput"
+    label="Text Input Label"
+    name="text-input-label"
+    disabled
+/>
+

--- a/src/patterns/components/inputs/react/code/text-input-huge-error.hbs
+++ b/src/patterns/components/inputs/react/code/text-input-huge-error.hbs
@@ -1,0 +1,7 @@
+<SprkTextInput
+    type="hugeTextInput"
+    label="Text Input Label"
+    name="text-input-label"
+    valid={false}
+    errorMessage="There is an error on this field."
+/>

--- a/src/patterns/components/inputs/react/code/text-input-huge.hbs
+++ b/src/patterns/components/inputs/react/code/text-input-huge.hbs
@@ -1,0 +1,5 @@
+<SprkTextInput
+    type="hugeTextInput"
+    label="Text Input Label"
+    name="text-input-label"
+/>

--- a/src/patterns/components/inputs/react/global-info.hbs
+++ b/src/patterns/components/inputs/react/global-info.hbs
@@ -111,8 +111,20 @@
     <tr>
       <td><strong>type</strong></td>
       <td>string</td>
-      <td>Will assign its value to the type attribute of the input element. If it is set to 'textarea', will render a
-        textarea instead of an input.</td>
+      <td>
+        Will assign its value to the type attribute of the input element.
+        <p class="sprk-u-mbs">
+          Expects only the following items:
+        </p>
+        <ul class="sprk-u-mlm">
+          <li>
+            'textarea' - will render a text area instead of a text input
+          </li>
+          <li>
+            'hugeTextInput' - will render a text input larger than the base input
+          </li>
+        </ul>
+      </td>
     </tr>
     <tr>
       <td><strong>value</strong></td>

--- a/src/patterns/components/inputs/text-input-huge-disabled.hbs
+++ b/src/patterns/components/inputs/text-input-huge-disabled.hbs
@@ -13,7 +13,7 @@ links:
 order: 2
 invisible: true
 hasAngularCode: false
-hasReactCode: false
+hasReactCode: true
 ---
 
 {{#embed "patterns.components.inputs.text-input-huge"

--- a/src/patterns/components/inputs/text-input-huge-error.hbs
+++ b/src/patterns/components/inputs/text-input-huge-error.hbs
@@ -13,7 +13,7 @@ links:
 order: 2
 invisible: true
 hasAngularCode: false
-hasReactCode: false
+hasReactCode: true
 ---
 {{#embed "patterns.components.inputs.text-input-huge"
          idattr="text-input-huge-error"

--- a/src/patterns/components/inputs/text-input-huge.hbs
+++ b/src/patterns/components/inputs/text-input-huge.hbs
@@ -13,7 +13,7 @@ links:
 order: 2
 invisible: false
 hasAngularCode: false
-hasReactCode: false
+hasReactCode: true
 ---
 
 {{#embed "patterns.components.inputs.text-input"

--- a/src/react/projects/spark-react/src/SprkInput/SprkTextInput/SprkTextInput.js
+++ b/src/react/projects/spark-react/src/SprkInput/SprkTextInput/SprkTextInput.js
@@ -36,18 +36,23 @@ class SprkTextInput extends Component {
     const { id, errorContainerId } = this.state;
 
     return (
-      <div className={classNames('sprk-b-InputContainer', additionalClasses)}>
+      <div
+        className={classNames('sprk-b-InputContainer', additionalClasses, {
+          'sprk-b-InputContainer--huge': type === 'hugeTextInput',
+        })}
+      >
         <div
           className={classNames({
             'sprk-b-TextInputIconContainer': leadingIcon.length > 0 || textIcon,
             'sprk-b-TextInputIconContainer--has-text-icon': textIcon,
-            'sprk-b-InputContainer--huge': type === 'hugeTextInput',
           })}
         >
           {leadingIcon.length > 0 && (
             <SprkIcon
               iconName={leadingIcon}
-              additionalClasses="sprk-c-Icon--m sprk-c-Icon--stroke-current-color"
+              additionalClasses="
+                sprk-c-Icon--m sprk-c-Icon--stroke-current-color
+              "
             />
           )}
           <label

--- a/src/react/projects/spark-react/src/SprkInput/SprkTextInput/SprkTextInput.js
+++ b/src/react/projects/spark-react/src/SprkInput/SprkTextInput/SprkTextInput.js
@@ -38,12 +38,11 @@ class SprkTextInput extends Component {
     return (
       <div className={classNames('sprk-b-InputContainer', additionalClasses)}>
         <div
-          className={classNames(
-            {
-              'sprk-b-TextInputIconContainer': leadingIcon.length > 0 || textIcon,
-            },
-            { 'sprk-b-TextInputIconContainer--has-text-icon': textIcon },
-          )}
+          className={classNames({
+            'sprk-b-TextInputIconContainer': leadingIcon.length > 0 || textIcon,
+            'sprk-b-TextInputIconContainer--has-text-icon': textIcon,
+            'sprk-b-InputContainer--huge': type === 'hugeTextInput',
+          })}
         >
           {leadingIcon.length > 0 && (
             <SprkIcon
@@ -53,11 +52,11 @@ class SprkTextInput extends Component {
           )}
           <label
             htmlFor={id}
-            className={classNames(
-              'sprk-b-Label',
-              { 'sprk-b-Label--with-icon': leadingIcon.length > 0 },
-              { 'sprk-u-ScreenReaderText': hiddenLabel },
-            )}
+            className={classNames('sprk-b-Label', {
+              'sprk-b-Label--with-icon': leadingIcon.length > 0,
+              'sprk-u-ScreenReaderText': hiddenLabel,
+              'sprk-b-Label--huge': type === 'hugeTextInput',
+            })}
           >
             {label}
           </label>
@@ -76,12 +75,12 @@ class SprkTextInput extends Component {
           )}
           {type !== 'textarea' && (
             <input
-              className={classNames(
-                'sprk-b-TextInput sprk-u-Width-100',
-                { 'sprk-b-TextInput--error': !valid },
-                { 'sprk-b-TextInput--has-svg-icon': leadingIcon.length > 0 },
-                { 'sprk-b-TextInput--has-text-icon': textIcon },
-              )}
+              className={classNames('sprk-b-TextInput sprk-u-Width-100', {
+                'sprk-b-TextInput--error': !valid,
+                'sprk-b-TextInput--has-svg-icon': leadingIcon.length > 0,
+                'sprk-b-TextInput--has-text-icon': textIcon,
+                'sprk-b-TextInput--huge': type === 'hugeTextInput',
+              })}
               id={id}
               data-analytics={analyticsString}
               data-id={idString}
@@ -95,8 +94,12 @@ class SprkTextInput extends Component {
           )}
         </div>
         {children}
-        {helperText.length > 0 && <div className="sprk-b-HelperText">{helperText}</div>}
-        {!valid && <SprkErrorContainer id={errorContainerId} message={errorMessage} />}
+        {helperText.length > 0 && (
+          <div className="sprk-b-HelperText">{helperText}</div>
+        )}
+        {!valid && (
+          <SprkErrorContainer id={errorContainerId} message={errorMessage} />
+        )}
       </div>
     );
   }

--- a/src/react/projects/spark-react/src/SprkInput/SprkTextInput/SprkTextInput.test.js
+++ b/src/react/projects/spark-react/src/SprkInput/SprkTextInput/SprkTextInput.test.js
@@ -11,6 +11,21 @@ it('should render an element with the correct class', () => {
   expect(wrapper.find('.sprk-b-InputContainer').length).toBe(1);
 });
 
+it('should render a huge text input with the correct class', () => {
+  const wrapper = mount(<SprkTextInput type="hugeTextInput" />);
+  expect(
+    wrapper
+      .find('.sprk-b-InputContainer')
+      .hasClass('sprk-b-InputContainer--huge'),
+  ).toBe(true);
+  expect(wrapper.find('.sprk-b-Label').hasClass('sprk-b-Label--huge')).toBe(
+    true,
+  );
+  expect(
+    wrapper.find('.sprk-b-TextInput').hasClass('sprk-b-TextInput--huge'),
+  ).toBe(true);
+});
+
 it('should add classes when additionalClasses has a value', () => {
   const wrapper = mount(<SprkTextInput additionalClasses="sprk-u-man" />);
   expect(wrapper.find('.sprk-b-InputContainer.sprk-u-man').length).toBe(1);
@@ -39,7 +54,9 @@ it('should render a textarea is type is set to textarea', () => {
 it('should run the supplied formatter', () => {
   const formatter = jest.fn(() => true);
   const onChangeMock = jest.fn();
-  mount(<SprkTextInput type="text" formatter={formatter} onChange={onChangeMock} />);
+  mount(
+    <SprkTextInput type="text" formatter={formatter} onChange={onChangeMock} />,
+  );
   expect(formatter.mock.calls.length).toBe(2);
 });
 
@@ -52,7 +69,13 @@ it('should not run the formatter if the field is invalid', () => {
 it('should run the supplied formatter (textarea)', () => {
   const formatter = jest.fn(() => true);
   const onChangeMock = jest.fn();
-  mount(<SprkTextInput type="textarea" formatter={formatter} onChange={onChangeMock} />);
+  mount(
+    <SprkTextInput
+      type="textarea"
+      formatter={formatter}
+      onChange={onChangeMock}
+    />,
+  );
   expect(formatter.mock.calls.length).toBe(2);
 });
 

--- a/src/react/src/routes/SprkInputDocs/SprkTextInputDocs/SprkTextInputDocs.js
+++ b/src/react/src/routes/SprkInputDocs/SprkTextInputDocs/SprkTextInputDocs.js
@@ -47,6 +47,14 @@ class SprkTextInputDocs extends React.Component {
             placeholder="Enter your first name"
           />
         </ExampleContainer>
+        <ExampleContainer heading="Text Huge">
+          <SprkTextInput
+            label="Name"
+            name="Name"
+            placeholder="Enter your first name"
+            type="hugeTextInput"
+          />
+        </ExampleContainer>
         <ExampleContainer heading="Text with Helper">
           <SprkTextInput
             label="Name"


### PR DESCRIPTION
## What does this PR do?
Create a react version of input text huge

### Associated Issue 
Fixes #1227 

### Documentation
 - [x] Update Spark Docs React

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Build Component in Spark Angular
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
