### PR TITLE
Remove accordion component centering

### DIFF
--- a/packages/spark/components/_accordions.scss
+++ b/packages/spark/components/_accordions.scss
@@ -3,7 +3,6 @@
 // ==================================================================
 .sprk-c-Accordion {
   border-top: $sprk-accordion-border;
-  margin: 0 auto;
   max-width: $sprk-accordion-max-width;
   width: 100%;
 }


### PR DESCRIPTION
## What does this PR do?
Removes the margin: 0 auto; to no longer center the component on the page.

### Associated Issue 
Fixes #1375

### Code
 - [x] Update component Sass
