### PR TITLE
Update Default Value of Inputs Error Line Height

### DIFF
--- a/packages/spark/settings/_settings.scss
+++ b/packages/spark/settings/_settings.scss
@@ -501,7 +501,7 @@ $sprk-input-error-text-color: $sprk-black !default;
 $sprk-input-error-text-font-family: $sprk-font-family-body-two !default;
 $sprk-input-error-text-font-weight: 400 !default;
 $sprk-input-error-text-font-size: 0.8125rem !default;
-$sprk-input-error-text-line-height: 1.5 !default;
+$sprk-input-error-text-line-height: 1.2 !default;
 $sprk-input-error-text-margin: 0 0 0 6px !default;
 $sprk-error-container-margin: $sprk-space-s 0 0 0 !default;
 $sprk-error-icon-size: 1.25rem !default;

--- a/packages/spark/settings/_settings.scss
+++ b/packages/spark/settings/_settings.scss
@@ -501,7 +501,7 @@ $sprk-input-error-text-color: $sprk-black !default;
 $sprk-input-error-text-font-family: $sprk-font-family-body-two !default;
 $sprk-input-error-text-font-weight: 400 !default;
 $sprk-input-error-text-font-size: 0.8125rem !default;
-$sprk-input-error-text-line-height: 1.2 !default;
+$sprk-input-error-text-line-height: 1.4 !default;
 $sprk-input-error-text-margin: 0 0 0 6px !default;
 $sprk-error-container-margin: $sprk-space-s 0 0 0 !default;
 $sprk-error-icon-size: 1.25rem !default;

--- a/packages/spark/settings/_settings.scss
+++ b/packages/spark/settings/_settings.scss
@@ -501,7 +501,7 @@ $sprk-input-error-text-color: $sprk-black !default;
 $sprk-input-error-text-font-family: $sprk-font-family-body-two !default;
 $sprk-input-error-text-font-weight: 400 !default;
 $sprk-input-error-text-font-size: 0.8125rem !default;
-$sprk-input-error-text-line-height: 1 !default;
+$sprk-input-error-text-line-height: 1.5 !default;
 $sprk-input-error-text-margin: 0 0 0 6px !default;
 $sprk-error-container-margin: $sprk-space-s 0 0 0 !default;
 $sprk-error-icon-size: 1.25rem !default;

--- a/src/patterns/components/inputs/collection.yaml
+++ b/src/patterns/components/inputs/collection.yaml
@@ -219,7 +219,7 @@ variableTable:
     default: 0.8125rem
     description: The font size used for input error text.
   $sprk-input-error-text-line-height:
-    default: 1.2
+    default: 1.4
     description: The line-height used for input error text.
   $sprk-input-error-text-margin:
     default: 0 0 0 6px


### PR DESCRIPTION
## What does this PR do?
Updates the $sprk-input-error-text-line-height line height from 1 to 1.4 to add spacing when the error message wraps to a second line.

### Associated Issue 
Fixes #1394 

### Documentation
 - [x] Update Component Sass Var/Class Modifier table

### Code
 - [x] Update Sass Variable

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Design Review
 - [x] Design reviewed and approved

### Screenshots
New line height - 1.4 per Ashley Morgan

![image](https://user-images.githubusercontent.com/15703773/59116770-4b7aba00-891a-11e9-9122-743fa23ad69e.png)
