### PR TITLE
Update Mobile Masthead - React

### DIFF
--- a/src/patterns/components/masthead/react/code/default.hbs
+++ b/src/patterns/components/masthead/react/code/default.hbs
@@ -3,6 +3,9 @@
     narrowNavLinks={links.concat(addedNarrowNavLinks)}
     siteLogo={<SiteLogo />}
     utilityContents={utilityItems}
+    navLinkContent="Sign In"
+    navLinkElement="a"
+    navLink="#nogo"
 />
 <script>
   const links = [

--- a/src/patterns/components/masthead/react/code/default.hbs
+++ b/src/patterns/components/masthead/react/code/default.hbs
@@ -3,9 +3,7 @@
     narrowNavLinks={links.concat(addedNarrowNavLinks)}
     siteLogo={<SiteLogo />}
     utilityContents={utilityItems}
-    navLinkContent="Sign In"
-    navLinkElement="a"
-    navLink="#nogo"
+    navLink={<SprkLink variant="simple" href="#nogo" additionalClasses="sprk-c-Masthead__link">Sign In</SprkLink>}
 />
 <script>
   const links = [

--- a/src/patterns/components/masthead/react/code/extended.hbs
+++ b/src/patterns/components/masthead/react/code/extended.hbs
@@ -6,6 +6,9 @@
     siteLogo={<SiteLogo />}
     utilityContents={utilityItems}
     variant="extended"
+    navLinkContent="Sign In"
+    navLinkElement="a"
+    navLink="#nogo"
 />
 <script>
   const links = [

--- a/src/patterns/components/masthead/react/code/extended.hbs
+++ b/src/patterns/components/masthead/react/code/extended.hbs
@@ -6,9 +6,7 @@
     siteLogo={<SiteLogo />}
     utilityContents={utilityItems}
     variant="extended"
-    navLinkContent="Sign In"
-    navLinkElement="a"
-    navLink="#nogo"
+    navLink={<SprkLink variant="simple" href="#nogo" additionalClasses="sprk-c-Masthead__link">Sign In</SprkLink>}
 />
 <script>
   const links = [

--- a/src/patterns/components/masthead/react/code/extended.hbs
+++ b/src/patterns/components/masthead/react/code/extended.hbs
@@ -62,12 +62,6 @@
       to: '/link',
     },
     {
-      element: Link,
-      leadingIcon: 'settings',
-      text: 'Settings',
-      to: '/button',
-    },
-    {
       leadingIcon: 'user',
       text: 'My Account',
       subNavLinks: [

--- a/src/patterns/components/masthead/react/info/default.hbs
+++ b/src/patterns/components/masthead/react/info/default.hbs
@@ -77,6 +77,21 @@
       <td>string</td>
       <td>Can be 'default' or 'extended'. Determines which variant to render.</td>
     </tr>
+        <tr>
+      <td class="sprk-u-FontWeight--bold">navLink</td>
+      <td>string</td>
+      <td>Expects a string that will render as the href for the nav link.</td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">navLinkElement</td>
+      <td>string, function</td>
+      <td>Expects an 'a' or react route link that will determine what element is rendered for the nav link.</td>
+    </tr>
+    <tr>
+      <td class="sprk-u-FontWeight--bold">navLinkContent</td>
+      <td>string</td>
+      <td>The text that will be rendered in the nav link element.</td>
+    </tr>
   </tbody>
 </table>
 

--- a/src/patterns/components/masthead/react/info/default.hbs
+++ b/src/patterns/components/masthead/react/info/default.hbs
@@ -79,18 +79,8 @@
     </tr>
         <tr>
       <td class="sprk-u-FontWeight--bold">navLink</td>
-      <td>string</td>
-      <td>Expects a string that will render as the href for the nav link.</td>
-    </tr>
-    <tr>
-      <td class="sprk-u-FontWeight--bold">navLinkElement</td>
-      <td>string, function</td>
-      <td>Expects an 'a' or react route link that will determine what element is rendered for the nav link.</td>
-    </tr>
-    <tr>
-      <td class="sprk-u-FontWeight--bold">navLinkContent</td>
-      <td>string</td>
-      <td>The text that will be rendered in the nav link element.</td>
+      <td>node</td>
+      <td>Expects a component to render in the nav-item area of the Masthead on narrow viewports.</td>
     </tr>
   </tbody>
 </table>

--- a/src/patterns/components/masthead/react/info/default.hbs
+++ b/src/patterns/components/masthead/react/info/default.hbs
@@ -77,7 +77,7 @@
       <td>string</td>
       <td>Can be 'default' or 'extended'. Determines which variant to render.</td>
     </tr>
-        <tr>
+    <tr>
       <td class="sprk-u-FontWeight--bold">navLink</td>
       <td>node</td>
       <td>Expects a component to render in the nav-item area of the Masthead on narrow viewports.</td>

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -63,6 +63,9 @@ class SprkMasthead extends Component {
       variant,
       logoLink,
       logoLinkElement,
+      navLink,
+      navLinkElement,
+      navLinkContent,
     } = this.props;
     const { isScrolled, narrowNavOpen } = this.state;
 
@@ -101,6 +104,28 @@ class SprkMasthead extends Component {
                 element={logoLinkElement}
               >
                 {siteLogo}
+              </SprkLink>
+            )}
+          </div>
+
+          <div className="sprk-c-Masthead__nav-item sprk-o-Stack__item sprk-o-Stack__item--center-column@xxs">
+            {navLinkElement !== 'a' ? (
+              <SprkLink
+                additionalClasses="sprk-c-Masthead__link"
+                variant="simple"
+                to={navLink}
+                element={navLinkElement}
+              >
+                {navLinkContent}
+              </SprkLink>
+            ) : (
+              <SprkLink
+                additionalClasses="sprk-c-Masthead__link"
+                variant="simple"
+                href={navLink}
+                element={navLinkElement}
+              >
+                {navLinkContent}
               </SprkLink>
             )}
           </div>
@@ -211,6 +236,12 @@ SprkMasthead.propTypes = {
   logoLink: PropTypes.string,
   // the element link element to render for the logo
   logoLinkElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  // the href to render for the nav link
+  navLink: PropTypes.string,
+  // the element link element to render for the nav item link
+  navLinkElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  // the content to render
+  navLinkContent: PropTypes.string,
 };
 
 SprkMasthead.defaultProps = {

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -64,8 +64,6 @@ class SprkMasthead extends Component {
       logoLink,
       logoLinkElement,
       navLink,
-      navLinkElement,
-      navLinkContent,
     } = this.props;
     const { isScrolled, narrowNavOpen } = this.state;
 
@@ -109,25 +107,7 @@ class SprkMasthead extends Component {
           </div>
 
           <div className="sprk-c-Masthead__nav-item sprk-o-Stack__item sprk-o-Stack__item--center-column@xxs">
-            {navLinkElement !== 'a' ? (
-              <SprkLink
-                additionalClasses="sprk-c-Masthead__link"
-                variant="simple"
-                to={navLink}
-                element={navLinkElement}
-              >
-                {navLinkContent}
-              </SprkLink>
-            ) : (
-              <SprkLink
-                additionalClasses="sprk-c-Masthead__link"
-                variant="simple"
-                href={navLink}
-                element={navLinkElement}
-              >
-                {navLinkContent}
-              </SprkLink>
-            )}
+            {navLink}
           </div>
 
           {(littleNavLinks.length > 0 || utilityContents.length > 0) && (
@@ -236,12 +216,8 @@ SprkMasthead.propTypes = {
   logoLink: PropTypes.string,
   // the element link element to render for the logo
   logoLinkElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  // the href to render for the nav link
-  navLink: PropTypes.string,
-  // the element link element to render for the nav item link
-  navLinkElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-  // the content to render
-  navLinkContent: PropTypes.string,
+  // expects a component to render the nav link
+  navLink: PropTypes.node,
 };
 
 SprkMasthead.defaultProps = {

--- a/src/react/src/routes/SprkMastheadDefaultDocs/SprkMastheadDefaultDocs.js
+++ b/src/react/src/routes/SprkMastheadDefaultDocs/SprkMastheadDefaultDocs.js
@@ -75,6 +75,9 @@ function SprkMastheadDefaultDocs() {
         narrowNavLinks={links.concat(addedNarrowNavLinks)}
         siteLogo={<SiteLogo />}
         utilityContents={utilityItems}
+        navLinkContent="Sign In"
+        navLinkElement="a"
+        navLink="#nogo"
       />
       <div className="sprk-u-mal">
         <p>Lorem Ipsum</p>

--- a/src/react/src/routes/SprkMastheadDefaultDocs/SprkMastheadDefaultDocs.js
+++ b/src/react/src/routes/SprkMastheadDefaultDocs/SprkMastheadDefaultDocs.js
@@ -75,9 +75,7 @@ function SprkMastheadDefaultDocs() {
         narrowNavLinks={links.concat(addedNarrowNavLinks)}
         siteLogo={<SiteLogo />}
         utilityContents={utilityItems}
-        navLinkContent="Sign In"
-        navLinkElement="a"
-        navLink="#nogo"
+        navLink={<SprkLink variant="simple" href="#nogo" additionalClasses="sprk-c-Masthead__link">Sign In</SprkLink>}
       />
       <div className="sprk-u-mal">
         <p>Lorem Ipsum</p>

--- a/src/react/src/routes/SprkMastheadExtendedDocs/SprkMastheadExtendedDocs.js
+++ b/src/react/src/routes/SprkMastheadExtendedDocs/SprkMastheadExtendedDocs.js
@@ -172,9 +172,7 @@ function SprkMastheadExtendedDocs() {
         siteLogo={<SiteLogo />}
         utilityContents={utilityItems}
         variant="extended"
-        navLinkContent="Sign In"
-        navLinkElement="a"
-        navLink="#nogo"
+        navLink={<SprkLink variant="simple" href="#nogo" additionalClasses="sprk-c-Masthead__link">Sign In</SprkLink>}
       />
       <div className="sprk-u-mal">
         <p>Lorem Ipsum</p>

--- a/src/react/src/routes/SprkMastheadExtendedDocs/SprkMastheadExtendedDocs.js
+++ b/src/react/src/routes/SprkMastheadExtendedDocs/SprkMastheadExtendedDocs.js
@@ -65,6 +65,12 @@ function SprkMastheadExtendedDocs() {
       to: '/link',
     },
     {
+      element: Link,
+      leadingIcon: 'settings',
+      text: 'Settings',
+      to: '/button',
+    },
+    {
       leadingIcon: 'user',
       text: 'My Account',
       subNavLinks: [
@@ -147,16 +153,6 @@ function SprkMastheadExtendedDocs() {
     >
       Talk To Us
     </SprkLink>,
-    <SprkLink
-      href="#nogo"
-      variant="plain"
-      additionalClasses="sprk-c-Masthead__link"
-    >
-      <SprkIcon
-        iconName="settings"
-        additionalClasses="sprk-c-Icon--stroke-current-color sprk-c-Icon--l"
-      />
-    </SprkLink>,
     <SprkDropdown
       additionalClasses="sprk-u-Right--zero sprk-u-mrm"
       additionalIconClasses="sprk-c-Icon--l"
@@ -176,6 +172,9 @@ function SprkMastheadExtendedDocs() {
         siteLogo={<SiteLogo />}
         utilityContents={utilityItems}
         variant="extended"
+        navLinkContent="Sign In"
+        navLinkElement="a"
+        navLink="#nogo"
       />
       <div className="sprk-u-mal">
         <p>Lorem Ipsum</p>

--- a/src/react/src/routes/SprkMastheadExtendedDocs/SprkMastheadExtendedDocs.js
+++ b/src/react/src/routes/SprkMastheadExtendedDocs/SprkMastheadExtendedDocs.js
@@ -65,12 +65,6 @@ function SprkMastheadExtendedDocs() {
       to: '/link',
     },
     {
-      element: Link,
-      leadingIcon: 'settings',
-      text: 'Settings',
-      to: '/button',
-    },
-    {
       leadingIcon: 'user',
       text: 'My Account',
       subNavLinks: [


### PR DESCRIPTION
## What does this PR do?
Adds a spot in the react masthead to accommodate the new mobile navigation link.

### Associated Issue 
Fixes #1461 

### Documentation
 - [x] Update Spark Docs React

### Code
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
