### PR TITLE
Fix Overflow Issue in Navigation

### DIFF
--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -105,7 +105,7 @@ import * as _ from 'lodash';
                 <sprk-dropdown
                   [choices]="link.subNav"
                   additionalTriggerClasses="sprk-b-Link--plain sprk-c-Masthead__link sprk-c-Masthead__link--big-nav"
-                  additionalClasses="sprk-u-Width-100 sprk-u-TextAlign--left"
+                  additionalClasses="sprk-u-TextAlign--left"
                   triggerIconType="chevron-down"
                   [triggerText]="link.text"
                 ></sprk-dropdown>


### PR DESCRIPTION
## What does this PR do?
Removes the sprk-u-Width-100 class to prevent character overflow issues.

### Associated Issue 
Fixes #1061 

### Code
 - [x] Update Component in Spark Angular
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)