### PR TITLE
add masthead override for examples

### DIFF
--- a/src/assets/toolkit/styles/toolkit.scss
+++ b/src/assets/toolkit/styles/toolkit.scss
@@ -17,6 +17,9 @@ $sprk-webfonts:
 // Override breakpoint for masthead because of Drizzle layout containment
 $masthead-breakpoint: 74rem;
 
+//Override masthead translate to avoid Masthead examples animating on narrow viewports
+$sprk-masthead-translateY: translateY(0);
+
 @import '../../../../packages/spark/spark.scss';
 
 //


### PR DESCRIPTION
## What does this PR do?
Overwrites the $sprk-masthead-translateY SASS variable to avoid animating the Masthead examples.

### Documentation
 - [x] Update Drizzle Styles

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
