### PR TITLE
Stepper - remove extraneous p tag

### DIFF
--- a/src/react/projects/spark-react/src/SprkStepper/components/SprkStepperStep/SprkStepperStep.js
+++ b/src/react/projects/spark-react/src/SprkStepper/components/SprkStepperStep/SprkStepperStep.js
@@ -81,16 +81,18 @@ class SprkStepperStep extends Component {
             </h3>
           </span>
 
-          <div
-            className={classnames(
-              "sprk-c-Stepper__step-description",
-              hasDescription && !isSelected ? 'sprk-u-Display--none' : 'sprk-u-Visibility--hidden',
-            )}
+          { hasDescription &&
+            <div
+              className={classnames(
+                "sprk-c-Stepper__step-description",
+                hasDescription && !isSelected ? 'sprk-u-Display--none' : 'sprk-u-Visibility--hidden',
+              )}
 
-          >
-            {/* desc is only ever displayed in the slider. This is just for spacing. */}
-            <p className="sprk-b-TypeBodyTwo">{children}</p>
-          </div>
+            >
+              {/* desc is only ever displayed in the slider. This is just for spacing. */}
+              <p className="sprk-b-TypeBodyTwo">{children}</p>
+            </div>
+          }
         </div>
       </li>
     );

--- a/src/react/projects/spark-react/src/SprkStepper/components/SprkStepperStep/SprkStepperStep.js
+++ b/src/react/projects/spark-react/src/SprkStepper/components/SprkStepperStep/SprkStepperStep.js
@@ -85,7 +85,7 @@ class SprkStepperStep extends Component {
             <div
               className={classnames(
                 "sprk-c-Stepper__step-description",
-                hasDescription && !isSelected ? 'sprk-u-Display--none' : 'sprk-u-Visibility--hidden',
+                isSelected ? 'sprk-u-Visibility--hidden' : 'sprk-u-Display--none',
               )}
 
             >

--- a/src/react/src/routes/SprkStepperDocs/SprkStepperDocs.js
+++ b/src/react/src/routes/SprkStepperDocs/SprkStepperDocs.js
@@ -111,7 +111,7 @@ class SprkStepperDocs extends Component {
                   <SprkStepperStep
                     title={item.title}
                     isSelected={item.isSelected}
-                    key={+new Date()}
+                    key={index}
                     id={item.id}
                     >
                       This is my content


### PR DESCRIPTION
## What does this PR do?
Removing an extra `<p>` tag when the step doesn't have a description.

### Associated Issue 
Fixes Issue https://github.com/sparkdesignsystem/spark-design-system/issues/1536

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
Before: 
![image](https://user-images.githubusercontent.com/1424560/60835829-1ddf9580-a192-11e9-900d-5c303b90dcfa.png)

After (slightly more compact):
![image](https://user-images.githubusercontent.com/1424560/60835854-2afc8480-a192-11e9-8ed4-0bb78f137994.png)

