### PR TITLE
Update angular to allow individual module imports

### DIFF
--- a/src/angular/projects/spark-angular/src/public_api.ts
+++ b/src/angular/projects/spark-angular/src/public_api.ts
@@ -3,3 +3,285 @@
  */
 
 export * from './lib/spark-angular.module';
+export {
+  SprkHugeInputContainerComponent
+} from './lib/components/inputs/sprk-huge-input-container/sprk-huge-input-container.component';
+export {
+  SprkHugeInputContainerModule
+} from './lib/components/inputs/sprk-huge-input-container/sprk-huge-input-container.module';
+export {
+  SprkIconInputContainerComponent
+} from './lib/components/inputs/sprk-icon-input-container/sprk-icon-input-container.component';
+export {
+  SprkIconInputContainerModule
+} from './lib/components/inputs/sprk-icon-input-container/sprk-icon-input-container.module';
+export {
+  SparkInputContainerComponent
+} from './lib/components/inputs/sprk-input-container/sprk-input-container.component';
+export {
+  SparkInputContainerModule
+} from './lib/components/inputs/sprk-input-container/sprk-input-container.module';
+export {
+  SprkSelectionContainerComponent
+} from './lib/components/inputs/sprk-selection-container/sprk-selection-container.component';
+export {
+  SprkSelectionContainerModule
+} from './lib/components/inputs/sprk-selection-container/sprk-selection-container.module';
+export {
+  SprkSelectionItemContainerComponent
+} from './lib/components/inputs/sprk-selection-item-container/sprk-selection-item-container.component';
+export {
+  SprkSelectionItemContainerModule
+} from './lib/components/inputs/sprk-selection-item-container/sprk-selection-item-container.module';
+export {
+  SprkTextareaContainerComponent
+} from './lib/components/inputs/sprk-textarea-container/sprk-textarea-container.component';
+export {
+  SprkTextareaContainerModule
+} from './lib/components/inputs/sprk-textarea-container/sprk-textarea-container.module';
+export {
+  SprkAccordionItemComponent
+} from './lib/components/sprk-accordion-item/sprk-accordion-item.component';
+export {
+  SprkAccordionItemModule
+} from './lib/components/sprk-accordion-item/sprk-accordion-item.module';
+export {
+  SprkAccordionComponent
+} from './lib/components/sprk-accordion/sprk-accordion.component';
+export {
+  SprkAccordionModule
+} from './lib/components/sprk-accordion/sprk-accordion.module';
+export {
+  SprkAlertComponent
+} from './lib/components/sprk-alert/sprk-alert.component';
+export { SprkAlertModule } from './lib/components/sprk-alert/sprk-alert.module';
+export {
+  SprkAwardComponent
+} from './lib/components/sprk-award/sprk-award.component';
+export { SprkAwardModule } from './lib/components/sprk-award/sprk-award.module';
+export {
+  SprkCardComponent
+} from './lib/components/sprk-card/sprk-card.component';
+export { SprkCardModule } from './lib/components/sprk-card/sprk-card.module';
+export {
+  SprkDictionaryComponent
+} from './lib/components/sprk-dictionary/sprk-dictionary.component';
+export {
+  SprkDictionaryModule
+} from './lib/components/sprk-dictionary/sprk-dictionary.module';
+export {
+  SprkDividerComponent
+} from './lib/components/sprk-divider/sprk-divider.component';
+export {
+  SprkDividerModule
+} from './lib/components/sprk-divider/sprk-divider.module';
+export {
+  SprkDropdownComponent
+} from './lib/components/sprk-dropdown/sprk-dropdown.component';
+export {
+  SprkDropdownModule
+} from './lib/components/sprk-dropdown/sprk-dropdown.module';
+export {
+  SprkFooterComponent
+} from './lib/components/sprk-footer/sprk-footer.component';
+export {
+  SprkFooterModule
+} from './lib/components/sprk-footer/sprk-footer.module';
+export {
+  SprkHighlightBoardComponent
+} from './lib/components/sprk-highlight-board/sprk-highlight-board.component';
+export {
+  SprkHighlightBoardModule
+} from './lib/components/sprk-highlight-board/sprk-highlight-board.module';
+export {
+  SprkIconComponent
+} from './lib/components/sprk-icon/sprk-icon.component';
+export { SprkIconModule } from './lib/components/sprk-icon/sprk-icon.module';
+export {
+  SprkLinkComponent
+} from './lib/components/sprk-link/sprk-link.component';
+export { SprkLinkModule } from './lib/components/sprk-link/sprk-link.module';
+export {
+  SprkListItemComponent
+} from './lib/components/sprk-list-item/sprk-list-item.component';
+export {
+  SprkListItemModule
+} from './lib/components/sprk-list-item/sprk-list-item.module';
+export {
+  SprkMastheadAccordionItemComponent
+} from './lib/components/sprk-masthead/sprk-masthead-accordion-item/sprk-masthead-accordion-item.component';
+export {
+  SprkMastheadAccordionItemModule
+} from './lib/components/sprk-masthead/sprk-masthead-accordion-item/sprk-masthead-accordion-item.module';
+export {
+  SprkMastheadAccordionComponent
+} from './lib/components/sprk-masthead/sprk-masthead-accordion/sprk-masthead-accordion.component';
+export {
+  SprkMastheadAccordionModule
+} from './lib/components/sprk-masthead/sprk-masthead-accordion/sprk-masthead-accordion.module';
+export {
+  SprkMastheadComponent
+} from './lib/components/sprk-masthead/sprk-masthead.component';
+export {
+  SprkMastheadModule
+} from './lib/components/sprk-masthead/sprk-masthead.module';
+export {
+  SprkModalComponent
+} from './lib/components/sprk-modal/sprk-modal.component';
+export { SprkModalModule } from './lib/components/sprk-modal/sprk-modal.module';
+export {
+  SprkOrderedListComponent
+} from './lib/components/sprk-ordered-list/sprk-ordered-list.component';
+export {
+  SprkOrderedListModule
+} from './lib/components/sprk-ordered-list/sprk-ordered-list.module';
+export {
+  SprkPaginationComponent
+} from './lib/components/sprk-pagination/sprk-pagination.component';
+export {
+  SprkPaginationModule
+} from './lib/components/sprk-pagination/sprk-pagination.module';
+export {
+  SprkPromoComponent
+} from './lib/components/sprk-promo/sprk-promo.component';
+export { SprkPromoModule } from './lib/components/sprk-promo/sprk-promo.module';
+export {
+  SprkStackComponent
+} from './lib/components/sprk-stack/sprk-stack.component';
+export { SprkStackModule } from './lib/components/sprk-stack/sprk-stack.module';
+export {
+  SprkTabbedNavigationComponent
+} from './lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.component';
+export {
+  SprkTabbedNavigationModule
+} from './lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.module';
+export {
+  SprkTableComponent
+} from './lib/components/sprk-table/sprk-table.component';
+export { SprkTableModule } from './lib/components/sprk-table/sprk-table.module';
+export {
+  SprkToggleComponent
+} from './lib/components/sprk-toggle/sprk-toggle.component';
+export {
+  SprkToggleModule
+} from './lib/components/sprk-toggle/sprk-toggle.module';
+export {
+  SprkUnorderedListComponent
+} from './lib/components/sprk-unordered-list/sprk-unordered-list.component';
+export {
+  SprkUnorderedListModule
+} from './lib/components/sprk-unordered-list/sprk-unordered-list.module';
+export {
+  SprkFormatterDateDirective
+} from './lib/directives/inputs/formatters/sprk-formatter-date/sprk-formatter-date.directive';
+export {
+  SprkFormatterDateModule
+} from './lib/directives/inputs/formatters/sprk-formatter-date/sprk-formatter-date.module';
+export {
+  SprkFormatterMonetaryDirective
+} from './lib/directives/inputs/formatters/sprk-formatter-monetary/sprk-formatter-monetary.directive';
+export {
+  SprkFormatterMonetaryModule
+} from './lib/directives/inputs/formatters/sprk-formatter-monetary/sprk-formatter-monetary.module';
+export {
+  SprkFormatterPhoneNumberDirective
+} from './lib/directives/inputs/formatters/sprk-formatter-phone-number/sprk-formatter-phone-number.directive';
+export {
+  SprkFormatterPhoneNumberModule
+} from './lib/directives/inputs/formatters/sprk-formatter-phone-number/sprk-formatter-phone-number.module';
+export {
+  SprkFormatterSsnDirective
+} from './lib/directives/inputs/formatters/sprk-formatter-ssn/sprk-formatter-ssn.directive';
+export {
+  SprkFormatterSsnModule
+} from './lib/directives/inputs/formatters/sprk-formatter-ssn/sprk-formatter-ssn.module';
+export {
+  SprkButtonDirective
+} from './lib/directives/inputs/sprk-button/sprk-button.directive';
+export {
+  SprkButtonModule
+} from './lib/directives/inputs/sprk-button/sprk-button.module';
+export {
+  SprkDatepickerDirective
+} from './lib/directives/inputs/sprk-datepicker/sprk-datepicker.directive';
+export {
+  SprkDatepickerModule
+} from './lib/directives/inputs/sprk-datepicker/sprk-datepicker.module';
+export {
+  SprkFieldErrorDirective
+} from './lib/directives/inputs/sprk-field-error/sprk-field-error.directive';
+export {
+  SprkFieldErrorModule
+} from './lib/directives/inputs/sprk-field-error/sprk-field-error.module';
+export {
+  SprkHelperTextDirective
+} from './lib/directives/inputs/sprk-helper-text/sprk-helper-text.directive';
+export {
+  SprkHelperTextModule
+} from './lib/directives/inputs/sprk-helper-text/sprk-helper-text.module';
+export {
+  SprkInputDirective
+} from './lib/directives/inputs/sprk-input/sprk-input.directive';
+export {
+  SprkInputModule
+} from './lib/directives/inputs/sprk-input/sprk-input.module';
+export {
+  SprkLabelDirective
+} from './lib/directives/inputs/sprk-label/sprk-label.directive';
+export {
+  SprkLabelModule
+} from './lib/directives/inputs/sprk-label/sprk-label.module';
+export {
+  SprkSelectionInputDirective
+} from './lib/directives/inputs/sprk-selection-input/sprk-selection-input.directive';
+export {
+  SprkSelectionInputModule
+} from './lib/directives/inputs/sprk-selection-input/sprk-selection-input.module';
+export {
+  SprkSelectionLabelDirective
+} from './lib/directives/inputs/sprk-selection-label/sprk-selection-label.directive';
+export {
+  SprkSelectionLabelModule
+} from './lib/directives/inputs/sprk-selection-label/sprk-selection-label.module';
+export {
+  SprkStackItemDirective
+} from './lib/directives/sprk-stack-item/sprk-stack-item.directive';
+export {
+  SprkStackItemModule
+} from './lib/directives/sprk-stack-item/sprk-stack-item.module';
+export {
+  SprkTableEmptyHeadingDirective
+} from './lib/directives/sprk-table-empty-heading/sprk-table-empty-heading.directive';
+export {
+  SprkTableEmptyHeadingModule
+} from './lib/directives/sprk-table-empty-heading/sprk-table-empty-heading.module';
+export {
+  SprkTableGroupedColumnDirective
+} from './lib/directives/sprk-table-grouped-column/sprk-table-grouped-column.directive';
+export {
+  SprkTableGroupedColumnModule
+} from './lib/directives/sprk-table-grouped-column/sprk-table-grouped-column.module';
+export {
+  SprkTableHeadDirective
+} from './lib/directives/sprk-table-head/sprk-table-head.directive';
+export {
+  SprkTableHeadModule
+} from './lib/directives/sprk-table-head/sprk-table-head.module';
+export {
+  SprkTableRowHeadingDirective
+} from './lib/directives/sprk-table-row-heading/sprk-table-row-heading.directive';
+export {
+  SprkTableRowHeadingModule
+} from './lib/directives/sprk-table-row-heading/sprk-table-row-heading.module';
+export {
+  SprkTabbedNavigationPanelDirective
+} from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-panel/sprk-tabbed-navigation-panel.directive';
+export {
+  SprkTabbedNavigationPanelModule
+} from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-panel/sprk-tabbed-navigation-panel.module';
+export {
+  SprkTabbedNavigationTabDirective
+} from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-tab/sprk-tabbed-navigation-tab.directive';
+export {
+  SprkTabbedNavigationTabModule
+} from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-tab/sprk-tabbed-navigation-tab.module';


### PR DESCRIPTION
## What does this PR do?
Explicitly export modules and components in the public_api.ts file. Prevents the angular compiler from aliasing the exports, allowing for individual import and use.

### Associated Issue 
Fixes #1402 
