### PR TITLE
Alias Typos and Component Exports

### DIFF
--- a/packages/spark/settings/_settings.scss
+++ b/packages/spark/settings/_settings.scss
@@ -719,8 +719,8 @@ $sprk-accordion-active-background-color: $sprk-gray !default;
 //
 // Toggle
 ///
-$sprk-toggle-transistion-timing: $sprk-toggle-transition-timing;
 $sprk-toggle-transition-timing: 0.3s ease !default;
+$sprk-toggle-transistion-timing: $sprk-toggle-transition-timing;
 
 //
 // Dropdown
@@ -861,8 +861,8 @@ $sprk-stepper-icon-color-hover: $sprk-black-tint-50 !default;
 $sprk-stepper-icon-color-selected: $sprk-white !default;
 $sprk-stepper-dark-icon-color: $sprk-blue !default;
 $sprk-stepper-dark-icon-color-selected: $sprk-white !default;
-$sprk-stepper-dark-icon-color-hoverg: $sprk-stepper-dark-icon-color-hover;
 $sprk-stepper-dark-icon-color-hover: $sprk-white !default;
+$sprk-stepper-dark-icon-color-hoverg: $sprk-stepper-dark-icon-color-hover;
 $sprk-stepper-icon-transition: 0.3s all ease-in-out !default;
 $sprk-stepper-icon-z-index: $sprk-layer-height-xs !default;
 $sprk-stepper-icon-box-shadow-selected-spread: 8px !default;

--- a/packages/spark/settings/_settings.scss
+++ b/packages/spark/settings/_settings.scss
@@ -719,6 +719,7 @@ $sprk-accordion-active-background-color: $sprk-gray !default;
 //
 // Toggle
 ///
+$sprk-toggle-transistion-timing: $sprk-toggle-transition-timing;
 $sprk-toggle-transition-timing: 0.3s ease !default;
 
 //
@@ -860,6 +861,7 @@ $sprk-stepper-icon-color-hover: $sprk-black-tint-50 !default;
 $sprk-stepper-icon-color-selected: $sprk-white !default;
 $sprk-stepper-dark-icon-color: $sprk-blue !default;
 $sprk-stepper-dark-icon-color-selected: $sprk-white !default;
+$sprk-stepper-dark-icon-color-hoverg: $sprk-stepper-dark-icon-color-hover;
 $sprk-stepper-dark-icon-color-hover: $sprk-white !default;
 $sprk-stepper-icon-transition: 0.3s all ease-in-out !default;
 $sprk-stepper-icon-z-index: $sprk-layer-height-xs !default;

--- a/src/angular/projects/spark-angular/src/public_api.ts
+++ b/src/angular/projects/spark-angular/src/public_api.ts
@@ -288,3 +288,297 @@ export {
 export {
   SprkTabbedNavigationTabModule
 } from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-tab/sprk-tabbed-navigation-tab.module';
+export {
+  SprkIconInputContainerComponent as ɵbu
+} from './lib/components/inputs/sprk-icon-input-container/sprk-icon-input-container.component';
+export {
+  SprkIconInputContainerModule as ɵbt
+} from './lib/components/inputs/sprk-icon-input-container/sprk-icon-input-container.module';
+export {
+  SparkInputContainerComponent as ɵbn
+} from './lib/components/inputs/sprk-input-container/sprk-input-container.component';
+export {
+  SparkInputContainerModule as ɵbm
+} from './lib/components/inputs/sprk-input-container/sprk-input-container.module';
+export {
+  SprkSelectionContainerComponent as ɵbw
+} from './lib/components/inputs/sprk-selection-container/sprk-selection-container.component';
+export {
+  SprkSelectionContainerModule as ɵbv
+} from './lib/components/inputs/sprk-selection-container/sprk-selection-container.module';
+export {
+  SprkSelectionItemContainerComponent as ɵbx
+} from './lib/components/inputs/sprk-selection-item-container/sprk-selection-item-container.component';
+export {
+  SprkSelectionItemContainerModule as ɵca
+} from './lib/components/inputs/sprk-selection-item-container/sprk-selection-item-container.module';
+export {
+  SprkTextareaContainerComponent as ɵbs
+} from './lib/components/inputs/sprk-textarea-container/sprk-textarea-container.component';
+export {
+  SprkTextareaContainerModule as ɵbr
+} from './lib/components/inputs/sprk-textarea-container/sprk-textarea-container.module';
+export {
+  SprkAccordionItemComponent as ɵj
+} from './lib/components/sprk-accordion-item/sprk-accordion-item.component';
+export {
+  SprkAccordionItemModule as ɵi
+} from './lib/components/sprk-accordion-item/sprk-accordion-item.module';
+export {
+  SprkAccordionComponent as ɵh
+} from './lib/components/sprk-accordion/sprk-accordion.component';
+export {
+  SprkAccordionModule as ɵe
+} from './lib/components/sprk-accordion/sprk-accordion.module';
+export {
+  SprkAlertComponent as ɵd
+} from './lib/components/sprk-alert/sprk-alert.component';
+export {
+  SprkAlertModule as ɵa
+} from './lib/components/sprk-alert/sprk-alert.module';
+export {
+  SprkAwardComponent as ɵr
+} from './lib/components/sprk-award/sprk-award.component';
+export {
+  SprkAwardModule as ɵk
+} from './lib/components/sprk-award/sprk-award.module';
+export {
+  SprkCardComponent as ɵv
+} from './lib/components/sprk-card/sprk-card.component';
+export {
+  SprkCardModule as ɵu
+} from './lib/components/sprk-card/sprk-card.module';
+export {
+  SprkDictionaryComponent as ɵx
+} from './lib/components/sprk-dictionary/sprk-dictionary.component';
+export {
+  SprkDictionaryModule as ɵw
+} from './lib/components/sprk-dictionary/sprk-dictionary.module';
+export {
+  SprkDividerComponent as ɵz
+} from './lib/components/sprk-divider/sprk-divider.component';
+export {
+  SprkDividerModule as ɵy
+} from './lib/components/sprk-divider/sprk-divider.module';
+export {
+  SprkDropdownComponent as ɵbb
+} from './lib/components/sprk-dropdown/sprk-dropdown.component';
+export {
+  SprkDropdownModule as ɵba
+} from './lib/components/sprk-dropdown/sprk-dropdown.module';
+export {
+  SprkFooterComponent as ɵdr
+} from './lib/components/sprk-footer/sprk-footer.component';
+export {
+  SprkFooterModule as ɵdq
+} from './lib/components/sprk-footer/sprk-footer.module';
+export {
+  SprkHighlightBoardComponent as ɵbd
+} from './lib/components/sprk-highlight-board/sprk-highlight-board.component';
+export {
+  SprkHighlightBoardModule as ɵbc
+} from './lib/components/sprk-highlight-board/sprk-highlight-board.module';
+export {
+  SprkIconComponent as ɵc
+} from './lib/components/sprk-icon/sprk-icon.component';
+export {
+  SprkIconModule as ɵb
+} from './lib/components/sprk-icon/sprk-icon.module';
+export {
+  SprkLinkComponent as ɵg
+} from './lib/components/sprk-link/sprk-link.component';
+export {
+  SprkLinkModule as ɵf
+} from './lib/components/sprk-link/sprk-link.module';
+export {
+  SprkListItemComponent as ɵbl
+} from './lib/components/sprk-list-item/sprk-list-item.component';
+export {
+  SprkListItemModule as ɵbk
+} from './lib/components/sprk-list-item/sprk-list-item.module';
+export {
+  SprkMastheadAccordionItemComponent as ɵcf
+} from './lib/components/sprk-masthead/sprk-masthead-accordion-item/sprk-masthead-accordion-item.component';
+export {
+  SprkMastheadAccordionItemModule as ɵce
+} from './lib/components/sprk-masthead/sprk-masthead-accordion-item/sprk-masthead-accordion-item.module';
+export {
+  SprkMastheadAccordionComponent as ɵcd
+} from './lib/components/sprk-masthead/sprk-masthead-accordion/sprk-masthead-accordion.component';
+export {
+  SprkMastheadAccordionModule as ɵcc
+} from './lib/components/sprk-masthead/sprk-masthead-accordion/sprk-masthead-accordion.module';
+export {
+  SprkMastheadComponent as ɵcg
+} from './lib/components/sprk-masthead/sprk-masthead.component';
+export {
+  SprkMastheadModule as ɵcb
+} from './lib/components/sprk-masthead/sprk-masthead.module';
+export {
+  SprkModalComponent as ɵbf
+} from './lib/components/sprk-modal/sprk-modal.component';
+export {
+  SprkModalModule as ɵbe
+} from './lib/components/sprk-modal/sprk-modal.module';
+export {
+  SprkOrderedListComponent as ɵbh
+} from './lib/components/sprk-ordered-list/sprk-ordered-list.component';
+export {
+  SprkOrderedListModule as ɵbg
+} from './lib/components/sprk-ordered-list/sprk-ordered-list.module';
+export {
+  SprkPaginationComponent as ɵdp
+} from './lib/components/sprk-pagination/sprk-pagination.component';
+export {
+  SprkPaginationModule as ɵdo
+} from './lib/components/sprk-pagination/sprk-pagination.module';
+export {
+  SprkPromoComponent as ɵcz
+} from './lib/components/sprk-promo/sprk-promo.component';
+export {
+  SprkPromoModule as ɵcy
+} from './lib/components/sprk-promo/sprk-promo.module';
+export {
+  SprkStackComponent as ɵm
+} from './lib/components/sprk-stack/sprk-stack.component';
+export {
+  SprkStackModule as ɵl
+} from './lib/components/sprk-stack/sprk-stack.module';
+export {
+  SprkTabbedNavigationComponent as ɵdt
+} from './lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.component';
+export {
+  SprkTabbedNavigationModule as ɵds
+} from './lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.module';
+export {
+  SprkTableComponent as ɵdb
+} from './lib/components/sprk-table/sprk-table.component';
+export {
+  SprkTableModule as ɵda
+} from './lib/components/sprk-table/sprk-table.module';
+export {
+  SprkToggleComponent as ɵq
+} from './lib/components/sprk-toggle/sprk-toggle.component';
+export {
+  SprkToggleModule as ɵp
+} from './lib/components/sprk-toggle/sprk-toggle.module';
+export {
+  SprkUnorderedListComponent as ɵbj
+} from './lib/components/sprk-unordered-list/sprk-unordered-list.component';
+export {
+  SprkUnorderedListModule as ɵbi
+} from './lib/components/sprk-unordered-list/sprk-unordered-list.module';
+export {
+  SprkFormatterDateDirective as ɵcr
+} from './lib/directives/inputs/formatters/sprk-formatter-date/sprk-formatter-date.directive';
+export {
+  SprkFormatterDateModule as ɵcq
+} from './lib/directives/inputs/formatters/sprk-formatter-date/sprk-formatter-date.module';
+export {
+  SprkFormatterMonetaryDirective as ɵct
+} from './lib/directives/inputs/formatters/sprk-formatter-monetary/sprk-formatter-monetary.directive';
+export {
+  SprkFormatterMonetaryModule as ɵcs
+} from './lib/directives/inputs/formatters/sprk-formatter-monetary/sprk-formatter-monetary.module';
+export {
+  SprkFormatterPhoneNumberDirective as ɵcp
+} from './lib/directives/inputs/formatters/sprk-formatter-phone-number/sprk-formatter-phone-number.directive';
+export {
+  SprkFormatterPhoneNumberModule as ɵco
+} from './lib/directives/inputs/formatters/sprk-formatter-phone-number/sprk-formatter-phone-number.module';
+export {
+  SprkFormatterSsnDirective as ɵcv
+} from './lib/directives/inputs/formatters/sprk-formatter-ssn/sprk-formatter-ssn.directive';
+export {
+  SprkFormatterSsnModule as ɵcu
+} from './lib/directives/inputs/formatters/sprk-formatter-ssn/sprk-formatter-ssn.module';
+export {
+  SprkButtonDirective as ɵt
+} from './lib/directives/inputs/sprk-button/sprk-button.directive';
+export {
+  SprkButtonModule as ɵs
+} from './lib/directives/inputs/sprk-button/sprk-button.module';
+export {
+  SprkDatepickerDirective as ɵcx
+} from './lib/directives/inputs/sprk-datepicker/sprk-datepicker.directive';
+export {
+  SprkDatepickerModule as ɵcw
+} from './lib/directives/inputs/sprk-datepicker/sprk-datepicker.module';
+export {
+  SprkFieldErrorDirective as ɵbq
+} from './lib/directives/inputs/sprk-field-error/sprk-field-error.directive';
+export {
+  SprkFieldErrorModule as ɵcn
+} from './lib/directives/inputs/sprk-field-error/sprk-field-error.module';
+export {
+  SprkHelperTextDirective as ɵck
+} from './lib/directives/inputs/sprk-helper-text/sprk-helper-text.directive';
+export {
+  SprkHelperTextModule as ɵcj
+} from './lib/directives/inputs/sprk-helper-text/sprk-helper-text.module';
+export {
+  SprkInputDirective as ɵbp
+} from './lib/directives/inputs/sprk-input/sprk-input.directive';
+export {
+  SprkInputModule as ɵch
+} from './lib/directives/inputs/sprk-input/sprk-input.module';
+export {
+  SprkLabelDirective as ɵbo
+} from './lib/directives/inputs/sprk-label/sprk-label.directive';
+export {
+  SprkLabelModule as ɵcl
+} from './lib/directives/inputs/sprk-label/sprk-label.module';
+export {
+  SprkSelectionInputDirective as ɵbz
+} from './lib/directives/inputs/sprk-selection-input/sprk-selection-input.directive';
+export {
+  SprkSelectionInputModule as ɵci
+} from './lib/directives/inputs/sprk-selection-input/sprk-selection-input.module';
+export {
+  SprkSelectionLabelDirective as ɵby
+} from './lib/directives/inputs/sprk-selection-label/sprk-selection-label.directive';
+export {
+  SprkSelectionLabelModule as ɵcm
+} from './lib/directives/inputs/sprk-selection-label/sprk-selection-label.module';
+export {
+  SprkStackItemDirective as ɵo
+} from './lib/directives/sprk-stack-item/sprk-stack-item.directive';
+export {
+  SprkStackItemModule as ɵn
+} from './lib/directives/sprk-stack-item/sprk-stack-item.module';
+export {
+  SprkTableEmptyHeadingDirective as ɵdh
+} from './lib/directives/sprk-table-empty-heading/sprk-table-empty-heading.directive';
+export {
+  SprkTableEmptyHeadingModule as ɵdg
+} from './lib/directives/sprk-table-empty-heading/sprk-table-empty-heading.module';
+export {
+  SprkTableGroupedColumnDirective as ɵdf
+} from './lib/directives/sprk-table-grouped-column/sprk-table-grouped-column.directive';
+export {
+  SprkTableGroupedColumnModule as ɵde
+} from './lib/directives/sprk-table-grouped-column/sprk-table-grouped-column.module';
+export {
+  SprkTableHeadDirective as ɵdd
+} from './lib/directives/sprk-table-head/sprk-table-head.directive';
+export {
+  SprkTableHeadModule as ɵdc
+} from './lib/directives/sprk-table-head/sprk-table-head.module';
+export {
+  SprkTableRowHeadingDirective as ɵdj
+} from './lib/directives/sprk-table-row-heading/sprk-table-row-heading.directive';
+export {
+  SprkTableRowHeadingModule as ɵdi
+} from './lib/directives/sprk-table-row-heading/sprk-table-row-heading.module';
+export {
+  SprkTabbedNavigationPanelDirective as ɵdn
+} from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-panel/sprk-tabbed-navigation-panel.directive';
+export {
+  SprkTabbedNavigationPanelModule as ɵdm
+} from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-panel/sprk-tabbed-navigation-panel.module';
+export {
+  SprkTabbedNavigationTabDirective as ɵdl
+} from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-tab/sprk-tabbed-navigation-tab.directive';
+export {
+  SprkTabbedNavigationTabModule as ɵdk
+} from './lib/directives/tabbed-navigation/sprk-tabbed-navigation-tab/sprk-tabbed-navigation-tab.module';


### PR DESCRIPTION
## What does this PR do?
Add alias for typos that have been fixed and exports to avoid breaking changes.

### Associated Issue 
Fixes #1692 