### PR TITLE
Masthead scrolling fix for docs site

### DIFF
--- a/src/assets/drizzle/styles/utility/_toolkit-overrides.scss
+++ b/src/assets/drizzle/styles/utility/_toolkit-overrides.scss
@@ -21,6 +21,12 @@
   position: static;
 }
 
+//Override masthead translate to avoid Masthead examples animating on narrow viewports
+.#{$app-namespace}-c-Preview .sprk-c-Masthead.sprk-c-Masthead--hidden {
+  transform: translateY(0);
+}
+
+
 [data-template-id^='masthead-with-extended-navigation'] .#{$app-namespace}-c-Preview__example {
   position: relative;
 }

--- a/src/assets/toolkit/styles/toolkit.scss
+++ b/src/assets/toolkit/styles/toolkit.scss
@@ -17,9 +17,6 @@ $sprk-webfonts:
 // Override breakpoint for masthead because of Drizzle layout containment
 $masthead-breakpoint: 74rem;
 
-//Override masthead translate to avoid Masthead examples animating on narrow viewports
-$sprk-masthead-translateY: translateY(0);
-
 @import '../../../../packages/spark/spark.scss';
 
 //


### PR DESCRIPTION
## What does this PR do?
Updates the styles for the tests pages for Masthead and the preview examples.

### Associated Issue 
-- No issue created for this.  

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [ ] Build Component in Spark Angular (Not Applicable)
 - [ ] Build Component in Spark React (Not Applicable)
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
 - [ ] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing) (Not Applicable)
 - [ ] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing) (Not Applicable)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Design Review
 -- Not needed for this.
