### PR TITLE
React Masthead Enhanced Scrolling Functionality

### DIFF
--- a/src/patterns/components/masthead/collection.yaml
+++ b/src/patterns/components/masthead/collection.yaml
@@ -3,7 +3,7 @@ description:
 information:
   - There are three custom configurations that you must do in order for the Masthead's narrow navigation to work properly (see below restrictions).
   - The Masthead is "sticky" and content will flow under it.
-  - Vanilla Implementation Only - On narrow viewports when a user scrolls down the page, the masthead will become hidden. When the user scrolls back up towards the top of the page, the masthead will come back into view.
+  - Vanilla & React Implementations Only - On narrow viewports when a user scrolls down the page, the masthead will become hidden. When the user scrolls back up towards the top of the page, the masthead will come back into view.
   - All content used here is placeholder content. Please use your own logo, content, and hrefs.
   - Make sure you leave the 'data-sprk-masthead' attribute on the main Masthead element as it functions as a Spark JS hook. It's already included in the provided code.
 restrictions:

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -86,7 +86,7 @@ class SprkMasthead extends Component {
     if (this.state.isNarrowLayout !== this.state.currentLayout) {
       this.setState({ isNarrowLayout : this.state.currentLayout });
       this.toggleScrollEvent();
-      if(!this.state.isNarrowLayout) {
+      if (!this.state.isNarrowLayout) {
         this.setState({ isHidden : false });
       }
     }
@@ -98,7 +98,7 @@ class SprkMasthead extends Component {
   }
 
   toggleMenu() {
-    if(this.state.scrollDirection === 'down') {
+    if (this.state.scrollDirection === 'down') {
       this.setState({ isHidden : true });
     } else {
       this.setState({ isHidden : false });
@@ -107,14 +107,14 @@ class SprkMasthead extends Component {
 
   checkScrollDirection() {
     const newDirection = scrollYDirection();
-    if(this.state.scrollDirection !== newDirection) {
+    if (this.state.scrollDirection !== newDirection) {
       this.setState({ scrollDirection : newDirection });
       this.toggleMenu();
     }
   }
 
   toggleScrollEvent() {
-    if(this.state.isNarrowLayout) {
+    if (this.state.isNarrowLayout) {
       window.addEventListener('scroll', this.throttledCheckScrollDirection);
     } else {
       window.removeEventListener('scroll', this.throttledCheckScrollDirection, false);

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -19,6 +19,7 @@ class SprkMasthead extends Component {
       isHidden: false,
       isNarrowLayout: false,
       scrollDirection: 'up',
+      currentLayout: false,
     };
     this.toggleNarrowNav = this.toggleNarrowNav.bind(this);
     this.toggleScrollEvent = this.toggleScrollEvent.bind(this);
@@ -26,9 +27,11 @@ class SprkMasthead extends Component {
     this.throttledCheckScrollDirection = throttle(this.checkScrollDirection, 500);
     this.toggleMenu = this.toggleMenu.bind(this);
     this.checkIfNarrowLayout = this.checkIfNarrowLayout.bind(this);
-    this.throttledCheckIfNarrowLayout = throttle(this.checkIfNarrowLayout, 500);
+    this.checkLayoutOnResize = this.checkLayoutOnResize.bind(this);
+    this.throttledCheckLayoutOnResize = throttle(this.checkLayoutOnResize, 500);
     this.closeNarrowNavMenu = this.closeNarrowNavMenu.bind(this);
     this.setIsScrolled = this.setIsScrolled.bind(this);
+    this.getCurrentLayout = this.getCurrentLayout.bind(this);
   }
 
   componentDidMount() {
@@ -36,7 +39,7 @@ class SprkMasthead extends Component {
 
     window.addEventListener('scroll', this.setIsScrolled);
     window.addEventListener('orientationchange', this.closeNarrowNavMenu);
-    window.addEventListener('resize', this.throttledCheckIfNarrowLayout);
+    window.addEventListener('resize', this.throttledCheckLayoutOnResize);
   }
 
   componentWillUnmount() {
@@ -75,15 +78,23 @@ class SprkMasthead extends Component {
     }
   }
 
+  getCurrentLayout() {
+    this.setState({ currentLayout : isElementVisible('.sprk-c-Masthead__menu')});
+  }
+
   checkIfNarrowLayout() {
-    const newMenuVisibility = isElementVisible('.sprk-c-Masthead__menu');
-    if (this.state.isNarrowLayout !== newMenuVisibility) {
-      this.setState({ isNarrowLayout : newMenuVisibility });
+    if (this.state.isNarrowLayout !== this.state.currentLayout) {
+      this.setState({ isNarrowLayout : this.state.currentLayout });
       this.toggleScrollEvent();
       if(!this.state.isNarrowLayout) {
         this.setState({ isHidden : false });
       }
     }
+  }
+
+  checkLayoutOnResize() {
+    this.getCurrentLayout();
+    this.checkIfNarrowLayout();
   }
 
   toggleMenu() {

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -7,7 +7,7 @@ import SprkMastheadLittleNav from './components/SprkMastheadLittleNav/SprkMasthe
 import SprkMastheadNarrowNav from './components/SprkMastheadNarrowNav/SprkMastheadNarrowNav';
 import SprkMastheadBigNav from './components/SprkMastheadBigNav/SprkMastheadBigNav';
 import SprkLink from '../SprkLink/SprkLink';
-import { isElementVisible } from '@sparkdesignsystem/spark';
+import { isElementVisible, scrollYDirection } from '@sparkdesignsystem/spark';
 import throttle from 'lodash/throttle';
 
 class SprkMasthead extends Component {
@@ -18,10 +18,13 @@ class SprkMasthead extends Component {
       isScrolled: false,
       isHidden: false,
       isNarrowLayout: false,
+      scrollDirection: 'up',
     };
     this.toggleNarrowNav = this.toggleNarrowNav.bind(this);
     this.toggleScrollEvent = this.toggleScrollEvent.bind(this);
     this.checkScrollDirection = this.checkScrollDirection.bind(this);
+    this.throttledCheckScrollDirection = throttle(this.checkScrollDirection, 500);
+    this.toggleMenu = this.toggleMenu.bind(this);
   }
 
   componentDidMount() {
@@ -74,15 +77,23 @@ class SprkMasthead extends Component {
     }
   }
 
-  checkScrollDirection() {
+  toggleMenu() {
     console.log(window.scrollY);
+  }
+
+  checkScrollDirection() {
+    const newDirection = scrollYDirection();
+    if(this.state.scrollDirection !== newDirection) {
+      this.setState({ scrollDirection : newDirection });
+      this.toggleMenu();
+    }
   }
 
   toggleScrollEvent() {
     if(this.state.isNarrowLayout) {
-      window.addEventListener('scroll', this.checkScrollDirection);
+      window.addEventListener('scroll', this.throttledCheckScrollDirection);
     } else {
-      window.removeEventListener('scroll', this.checkScrollDirection, false);
+      window.removeEventListener('scroll', this.throttledCheckScrollDirection, false);
     }
   }
 

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -7,6 +7,7 @@ import SprkMastheadLittleNav from './components/SprkMastheadLittleNav/SprkMasthe
 import SprkMastheadNarrowNav from './components/SprkMastheadNarrowNav/SprkMastheadNarrowNav';
 import SprkMastheadBigNav from './components/SprkMastheadBigNav/SprkMastheadBigNav';
 import SprkLink from '../SprkLink/SprkLink';
+import { isElementVisible } from '@sparkdesignsystem/spark';
 
 class SprkMasthead extends Component {
   constructor() {
@@ -14,6 +15,7 @@ class SprkMasthead extends Component {
     this.state = {
       narrowNavOpen: false,
       isScrolled: false,
+      isHidden: false,
     };
     this.toggleNarrowNav = this.toggleNarrowNav.bind(this);
   }
@@ -29,6 +31,9 @@ class SprkMasthead extends Component {
     window.addEventListener('orientationchange', () => {
       this.setState({ narrowNavOpen: false });
     });
+
+    let isMenuVisible = isElementVisible('.sprk-c-Masthead__menu');
+    console.log(isMenuVisible);
   }
 
   toggleNarrowNav() {
@@ -65,7 +70,7 @@ class SprkMasthead extends Component {
       logoLinkElement,
       navLink,
     } = this.props;
-    const { isScrolled, narrowNavOpen } = this.state;
+    const { isScrolled, narrowNavOpen, isHidden } = this.state;
 
     return (
       <header
@@ -74,6 +79,7 @@ class SprkMasthead extends Component {
           'sprk-o-Stack',
           { 'sprk-c-Masthead--open': narrowNavOpen },
           { 'sprk-c-Masthead--scroll': isScrolled },
+          { 'sprk-c-Masthead--hidden': isHidden },
           additionalClasses,
         )}
         role="banner"

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -8,6 +8,7 @@ import SprkMastheadNarrowNav from './components/SprkMastheadNarrowNav/SprkMasthe
 import SprkMastheadBigNav from './components/SprkMastheadBigNav/SprkMastheadBigNav';
 import SprkLink from '../SprkLink/SprkLink';
 import { isElementVisible } from '@sparkdesignsystem/spark';
+import throttle from 'lodash/throttle';
 
 class SprkMasthead extends Component {
   constructor() {
@@ -16,6 +17,7 @@ class SprkMasthead extends Component {
       narrowNavOpen: false,
       isScrolled: false,
       isHidden: false,
+      isNarrowLayout: false,
     };
     this.toggleNarrowNav = this.toggleNarrowNav.bind(this);
   }
@@ -31,9 +33,23 @@ class SprkMasthead extends Component {
     window.addEventListener('orientationchange', () => {
       this.setState({ narrowNavOpen: false });
     });
+    this.setState({ isNarrowLayout : isElementVisible('.sprk-c-Masthead__menu') });
+    
+    window.addEventListener(
+      'resize',
+      throttle(() => {
+        const newMenuVisibility = isElementVisible('.sprk-c-Masthead__menu');
+        if (this.state.isNarrowLayout !== newMenuVisibility) {
+          // toggleScrollEvent(newMenuVisibility);
+          this.setState({ isNarrowLayout : newMenuVisibility });
+        }
+      }, 500)
+    )
 
-    let isMenuVisible = isElementVisible('.sprk-c-Masthead__menu');
-    console.log(isMenuVisible);
+  }
+
+  componentWillUnmount() {
+    // REMOVE RESIZE AND SCROLL EVENTS
   }
 
   toggleNarrowNav() {
@@ -70,8 +86,7 @@ class SprkMasthead extends Component {
       logoLinkElement,
       navLink,
     } = this.props;
-    const { isScrolled, narrowNavOpen, isHidden } = this.state;
-
+    const { isScrolled, narrowNavOpen, isHidden, isNarrowLayout } = this.state;
     return (
       <header
         className={classNames(

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -44,6 +44,9 @@ class SprkMasthead extends Component {
         if (this.state.isNarrowLayout !== newMenuVisibility) {
           this.setState({ isNarrowLayout : newMenuVisibility });
           this.toggleScrollEvent();
+          if(!this.state.isNarrowLayout) {
+            this.setState({ isHidden : false });
+          }
         }
       }, 500)
     )
@@ -76,11 +79,10 @@ class SprkMasthead extends Component {
   }
 
   toggleScrollEvent() {
-    const checkScrollDirection = this.checkScrollDirection;
     if(this.state.isNarrowLayout) {
-      window.addEventListener('scroll', checkScrollDirection);
+      window.addEventListener('scroll', this.checkScrollDirection);
     } else {
-      window.removeEventListener('scroll', checkScrollDirection, false);
+      window.removeEventListener('scroll', this.checkScrollDirection, false);
     }
   }
 

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -25,39 +25,25 @@ class SprkMasthead extends Component {
     this.checkScrollDirection = this.checkScrollDirection.bind(this);
     this.throttledCheckScrollDirection = throttle(this.checkScrollDirection, 500);
     this.toggleMenu = this.toggleMenu.bind(this);
+    this.checkIfNarrowLayout = this.checkIfNarrowLayout.bind(this);
+    this.throttledCheckIfNarrowLayout = throttle(this.checkIfNarrowLayout, 500);
+    this.closeNarrowNavMenu = this.closeNarrowNavMenu.bind(this);
+    this.setIsScrolled = this.setIsScrolled.bind(this);
   }
 
   componentDidMount() {
-    window.addEventListener('scroll', () => {
-      if (window.scrollY >= 10) {
-        this.setState({ isScrolled: true });
-      } else {
-        this.setState({ isScrolled: false });
-      }
-    });
-    window.addEventListener('orientationchange', () => {
-      this.setState({ narrowNavOpen: false });
-    });
     this.setState({ isNarrowLayout : isElementVisible('.sprk-c-Masthead__menu') });
-    
-    window.addEventListener(
-      'resize',
-      throttle(() => {
-        const newMenuVisibility = isElementVisible('.sprk-c-Masthead__menu');
-        if (this.state.isNarrowLayout !== newMenuVisibility) {
-          this.setState({ isNarrowLayout : newMenuVisibility });
-          this.toggleScrollEvent();
-          if(!this.state.isNarrowLayout) {
-            this.setState({ isHidden : false });
-          }
-        }
-      }, 500)
-    )
 
+    window.addEventListener('scroll', this.setIsScrolled);
+    window.addEventListener('orientationchange', this.closeNarrowNavMenu);
+    window.addEventListener('resize', this.throttledCheckIfNarrowLayout);
   }
 
   componentWillUnmount() {
-    // REMOVE RESIZE AND SCROLL EVENTS
+    window.removeEventListener('scroll', this.setIsScrolled, false);
+    window.removeEventListener('scroll', this.throttledCheckScrollDirection, false);
+    window.removeEventListener('orientationchange', this.closeNarrowNavMenu, false);
+    window.removeEventListener('resize', this.throttledCheckIfNarrowLayout, false);
   }
 
   toggleNarrowNav() {
@@ -74,6 +60,29 @@ class SprkMasthead extends Component {
     }
     if (document.body.style.height !== '100%') {
       document.body.classList.toggle('sprk-u-Height--100');
+    }
+  }
+
+  closeNarrowNavMenu() {
+    this.setState({ narrowNavOpen: false });
+  }
+
+  setIsScrolled() {
+    if (window.scrollY >= 10) {
+      this.setState({ isScrolled: true });
+    } else {
+      this.setState({ isScrolled: false });
+    }
+  }
+
+  checkIfNarrowLayout() {
+    const newMenuVisibility = isElementVisible('.sprk-c-Masthead__menu');
+    if (this.state.isNarrowLayout !== newMenuVisibility) {
+      this.setState({ isNarrowLayout : newMenuVisibility });
+      this.toggleScrollEvent();
+      if(!this.state.isNarrowLayout) {
+        this.setState({ isHidden : false });
+      }
     }
   }
 
@@ -118,7 +127,7 @@ class SprkMasthead extends Component {
       logoLinkElement,
       navLink,
     } = this.props;
-    const { isScrolled, narrowNavOpen, isHidden, isNarrowLayout } = this.state;
+    const { isScrolled, narrowNavOpen, isHidden } = this.state;
 
     // On render check whether to add the scroll event
     this.toggleScrollEvent();

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -78,7 +78,11 @@ class SprkMasthead extends Component {
   }
 
   toggleMenu() {
-    console.log(window.scrollY);
+    if(this.state.scrollDirection === 'down') {
+      this.setState({ isHidden : true });
+    } else {
+      this.setState({ isHidden : false });
+    }
   }
 
   checkScrollDirection() {

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.js
@@ -20,6 +20,8 @@ class SprkMasthead extends Component {
       isNarrowLayout: false,
     };
     this.toggleNarrowNav = this.toggleNarrowNav.bind(this);
+    this.toggleScrollEvent = this.toggleScrollEvent.bind(this);
+    this.checkScrollDirection = this.checkScrollDirection.bind(this);
   }
 
   componentDidMount() {
@@ -40,8 +42,8 @@ class SprkMasthead extends Component {
       throttle(() => {
         const newMenuVisibility = isElementVisible('.sprk-c-Masthead__menu');
         if (this.state.isNarrowLayout !== newMenuVisibility) {
-          // toggleScrollEvent(newMenuVisibility);
           this.setState({ isNarrowLayout : newMenuVisibility });
+          this.toggleScrollEvent();
         }
       }, 500)
     )
@@ -69,6 +71,19 @@ class SprkMasthead extends Component {
     }
   }
 
+  checkScrollDirection() {
+    console.log(window.scrollY);
+  }
+
+  toggleScrollEvent() {
+    const checkScrollDirection = this.checkScrollDirection;
+    if(this.state.isNarrowLayout) {
+      window.addEventListener('scroll', checkScrollDirection);
+    } else {
+      window.removeEventListener('scroll', checkScrollDirection, false);
+    }
+  }
+
   render() {
     const {
       additionalClasses,
@@ -87,6 +102,9 @@ class SprkMasthead extends Component {
       navLink,
     } = this.props;
     const { isScrolled, narrowNavOpen, isHidden, isNarrowLayout } = this.state;
+
+    // On render check whether to add the scroll event
+    this.toggleScrollEvent();
     return (
       <header
         className={classNames(

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.test.js
@@ -4,6 +4,7 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import Enzyme, { shallow, mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
+import '../windowStubs';
 import SprkMasthead from './SprkMasthead';
 import SprkMastheadLittleNav from './components/SprkMastheadLittleNav/SprkMastheadLittleNav';
 import SprkMastheadBigNav from './components/SprkMastheadBigNav/SprkMastheadBigNav';
@@ -133,4 +134,19 @@ it('should render the correct logoLink if logoLinkElement is router link', () =>
   );
   expect(wrapper.find(SprkLink).props().to).toBe('/button');
   expect(wrapper.find(SprkLink).props().element).toBe(Link);
+});
+
+it('should add the hidden class when state isHidden is true', () => {
+  const wrapper = mount(<SprkMasthead/>);
+  wrapper.setState({ isHidden : true });
+  expect(wrapper.find('header.sprk-c-Masthead--hidden').length).toBe(1);
+});
+
+it('should update state isHidden to true when scrollDirection is equal to down', () => {
+  const wrapper = mount(<SprkMasthead/>);
+  const instance = wrapper.instance();
+  expect(wrapper.state('isHidden')).toEqual(false);
+  wrapper.setState({ scrollDirection : 'down' });
+  instance.toggleMenu();
+  expect(wrapper.state('isHidden')).toEqual(true);
 });

--- a/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.test.js
+++ b/src/react/projects/spark-react/src/SprkMasthead/SprkMasthead.test.js
@@ -150,3 +150,65 @@ it('should update state isHidden to true when scrollDirection is equal to down',
   instance.toggleMenu();
   expect(wrapper.state('isHidden')).toEqual(true);
 });
+
+it('should update state isHidden to false when scrollDirection is equal to up', () => {
+  const wrapper = mount(<SprkMasthead/>);
+  const instance = wrapper.instance();
+  wrapper.setState({ isHidden : true });
+  expect(wrapper.state('isHidden')).toEqual(true);
+  wrapper.setState({ scrollDirection : 'up' });
+  instance.toggleMenu();
+  expect(wrapper.state('isHidden')).toEqual(false);
+});
+
+it('should update narrowNavOpen to false when closeNarrowNavMenu is called', () => {
+  const wrapper = mount(<SprkMasthead/>);
+  const instance = wrapper.instance();
+  wrapper.setState({ narrowNavOpen : true });
+  expect(wrapper.state('narrowNavOpen')).toEqual(true);
+  instance.closeNarrowNavMenu();
+  expect(wrapper.state('narrowNavOpen')).toEqual(false);
+});
+
+it('should update state of isNarrowLayout if isNarrowLayout !== newMenuVisibility', () => {
+  const wrapper = mount(<SprkMasthead/>);
+  const instance = wrapper.instance();
+  wrapper.setState({ currentLayout : true });
+  wrapper.setState({ isNarrowLayout : false });
+  instance.checkIfNarrowLayout();
+  expect(wrapper.state('isNarrowLayout')).toEqual(true);
+});
+
+it('should update state of isHidden if isNarrowLayout is false', () => {
+  const wrapper = mount(<SprkMasthead/>);
+  const instance = wrapper.instance();
+  wrapper.setState({ currentLayout : false });
+  wrapper.setState({ isNarrowLayout : true });
+  wrapper.setState({ isHidden : true });
+  instance.checkIfNarrowLayout();
+  expect(wrapper.state('isHidden')).toEqual(false);
+});
+
+it('should call getCurrentLayout when checkLayoutOnResize is called', () => {
+  const wrapper = mount(<SprkMasthead/>);
+  const instance = wrapper.instance();
+  const spy  = jest.spyOn(wrapper.instance(), "getCurrentLayout");  
+  wrapper.update();
+  instance.checkLayoutOnResize();
+  expect(spy).toHaveBeenCalled();
+});
+
+it('should call checkIfNarrowLayout when checkLayoutOnResize is called', () => {
+  const wrapper = mount(<SprkMasthead/>);
+  const instance = wrapper.instance();
+  const spy  = jest.spyOn(wrapper.instance(), "checkIfNarrowLayout");  
+  wrapper.update();
+  instance.checkLayoutOnResize();
+  expect(spy).toHaveBeenCalled();
+});
+
+// NOT TESTING REMOVAL OF EVENTLISTENERS ON UNMOUNT
+// - There is no functionality in JS to detect the presence of eventlisteners
+// - The only way is to use state or variables like attached = true/false
+// - Unable to detect state after component has been unmounted
+// - Testing unmount function is testing native functionality of react and is redundant

--- a/src/react/src/routes/SprkMastheadDefaultDocs/SprkMastheadDefaultDocs.js
+++ b/src/react/src/routes/SprkMastheadDefaultDocs/SprkMastheadDefaultDocs.js
@@ -86,6 +86,60 @@ function SprkMastheadDefaultDocs() {
         <p>Lorem Ipsum</p>
         <p>Lorem Ipsum</p>
       </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
     </EmptyLayout>
   );
 }

--- a/src/react/src/routes/SprkMastheadExtendedDocs/SprkMastheadExtendedDocs.js
+++ b/src/react/src/routes/SprkMastheadExtendedDocs/SprkMastheadExtendedDocs.js
@@ -183,6 +183,60 @@ function SprkMastheadExtendedDocs() {
         <p>Lorem Ipsum</p>
         <p>Lorem Ipsum</p>
       </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
+      <div className="sprk-u-mal">
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+        <p>Lorem Ipsum</p>
+      </div>
     </EmptyLayout>
   );
 }


### PR DESCRIPTION
## What does this PR do?
Enhances the scrolling functionality of the masthead in React. When the user scrolls down the page on a narrow viewport, the masthead animates off the page to create more space for content. When the user scrolls back up towards the top of the page, the masthead animates back in to give easy access to the navigation.

![masthead design masthead](https://user-images.githubusercontent.com/4342363/64562463-0734f680-d31b-11e9-972e-00464b79c776.gif)

### Associated Issue 
Fixes #1294

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs React

### Code
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark React with `gulp test-react` (93% coverage, 100% passing)
NOT TESTING REMOVAL OF EVENTLISTENERS ON UNMOUNT
- There is no functionality in JS to detect the presence of eventlisteners
- The only way is to use state or variables like attached = true/false
- Unable to detect state after component has been unmounted
- Testing unmount function is testing native functionality of react and is redundant


### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
          - The masthead is not "stuck" in IE and is expected functionality
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Manual Testing Plan
  - [x] Update excel sheet with component changes
