### PR TITLE
Angular Masthead Enhanced Scrolling Functionality

### DIFF
--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.spec.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.spec.ts
@@ -39,6 +39,7 @@ describe('SprkMastheadComponent', () => {
     component.scrollDirection = 'up';
     component.isHidden = false;
     component.isNarrowLayout = false;
+    component.isNarrowOnResize = false;
     window.document.body.style.minHeight = '800px';
     window.document.body.style.minWidth = '1024px';
   });
@@ -174,19 +175,21 @@ describe('SprkMastheadComponent', () => {
     expect(component.scrollDirection).toBe('down');
   });
 
-  // it('should update narrowLayout and isHidden on resize', () => {
-  //   component.isHidden = true;
-  //   fixture.detectChanges();
+  it('should show masthead when going from small to large screen', () => {
+    component.isNarrowOnResize = false;
+    component.isNarrowLayout = true;
+    fixture.detectChanges();
+    component.throttledUpdateLayoutState();
 
-  //   console.log(component.isHidden, 'isHidden');
-  //   const resizeEvent = document.createEvent('CustomEvent');
-  //   resizeEvent.initCustomEvent('resize', false, false, null);
+    expect(component.isHidden).toBe(false);
+    expect(component.isNarrowLayout).toBe(false);
+  });
 
-  //   window.resizeTo(1500, 800);
-  //   window.dispatchEvent(resizeEvent);
-  //   fixture.detectChanges();
-  //   console.log(component.isHidden, 'after isHidden');
-
-  //   expect(component.isHidden).toBe(false);
-  // });
+  it('should call throttledUpdateLayoutState to be called on resize', () => {
+    const spyOnResize = spyOn(component, 'throttledUpdateLayoutState');
+    const resizeEvent = document.createEvent('CustomEvent');
+    resizeEvent.initCustomEvent('resize', false, false, null);
+    window.dispatchEvent(resizeEvent);
+    expect(spyOnResize).toHaveBeenCalled();
+  });
 });

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.spec.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.spec.ts
@@ -6,7 +6,6 @@ import { SprkMastheadAccordionComponent } from './sprk-masthead-accordion/sprk-m
 import { SprkMastheadAccordionItemComponent } from './sprk-masthead-accordion-item/sprk-masthead-accordion-item.component';
 import { SprkMastheadComponent } from './sprk-masthead.component';
 import { SprkDropdownComponent } from '../sprk-dropdown/sprk-dropdown.component';
-
 describe('SprkMastheadComponent', () => {
   let component: SprkMastheadComponent;
   let fixture: ComponentFixture<SprkMastheadComponent>;
@@ -34,6 +33,14 @@ describe('SprkMastheadComponent', () => {
     component = fixture.componentInstance;
     mastheadElement = fixture.nativeElement.querySelector('header');
     hamburgerIcon = mastheadElement.querySelector('.sprk-c-Menu');
+  });
+
+  afterEach(() => {
+    component.scrollDirection = 'up';
+    component.isHidden = false;
+    component.isNarrowLayout = false;
+    window.document.body.style.minHeight = '800px';
+    window.document.body.style.minWidth = '1024px';
   });
 
   it('should create itself', () => {
@@ -136,4 +143,50 @@ describe('SprkMastheadComponent', () => {
       'sprk-c-Masthead__big-nav-items sprk-o-Stack sprk-o-Stack--misc-a sprk-o-Stack--center-row sprk-o-Stack--split@xxs sprk-b-List sprk-b-List--bare'
     );
   });
+
+  it('should add the scroll class when state isScrolled is true', () => {
+    component.isScrolled = true;
+    fixture.detectChanges();
+    expect(mastheadElement.classList.contains('sprk-c-Masthead--scroll')).toEqual(true);
+  });
+
+  it('should add the hidden class when state isHidden is true', () => {
+    component.isHidden = true;
+    fixture.detectChanges();
+    expect(mastheadElement.classList.contains('sprk-c-Masthead--hidden')).toEqual(true);
+  });
+
+  it('should update state isHidden to true when scrollDirection is equal to down', () => {
+
+    // Scroll down the page
+    const scrollEvent = document.createEvent('CustomEvent');
+    scrollEvent.initCustomEvent('scroll', false, false, null);
+    const expectedLeft = 0;
+    const expectedTop = 456;
+    window.document.body.style.minHeight = '9000px';
+    window.document.body.style.minWidth = '200px';
+    fixture.detectChanges();
+    window.scrollTo(expectedLeft, expectedTop);
+    window.dispatchEvent(scrollEvent);
+
+
+    expect(component.isHidden).toBe(true);
+    expect(component.scrollDirection).toBe('down');
+  });
+
+  // it('should update narrowLayout and isHidden on resize', () => {
+  //   component.isHidden = true;
+  //   fixture.detectChanges();
+
+  //   console.log(component.isHidden, 'isHidden');
+  //   const resizeEvent = document.createEvent('CustomEvent');
+  //   resizeEvent.initCustomEvent('resize', false, false, null);
+
+  //   window.resizeTo(1500, 800);
+  //   window.dispatchEvent(resizeEvent);
+  //   fixture.detectChanges();
+  //   console.log(component.isHidden, 'after isHidden');
+
+  //   expect(component.isHidden).toBe(false);
+  // });
 });

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -11,6 +11,13 @@ import * as _ from 'lodash';
 
 @Component({
   selector: 'sprk-masthead',
+  styles: [`:host {
+            position: sticky;
+            position: -webkit-sticky;
+            top: 0;
+            display: block;
+          }`
+        ],
   template: `
     <header [ngClass]="getClasses()" role="banner" [attr.data-id]="idString">
       <div

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -304,7 +304,6 @@ export class SprkMastheadComponent implements AfterContentInit {
   }
 
   checkScrollDirection() {
-    console.log('scroll:', window.scrollY);
     const newDirection = scrollYDirection();
     if (this.scrollDirection !== newDirection) {
       this.scrollDirection = newDirection;

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -293,12 +293,11 @@ export class SprkMastheadComponent implements AfterContentInit {
   // Handles when viewport size changes to large while narrow nav is hidden
   @HostListener('window:resize', ['$event'])
   onResize(event): void {
+    this.isNarrowOnResize = isElementVisible('.sprk-c-Masthead__menu');
     this.throttledUpdateLayoutState();
   }
 
   updateLayoutState() {
-    this.isNarrowOnResize = isElementVisible('.sprk-c-Masthead__menu');
-
     if (this.isNarrowLayout !== this.isNarrowOnResize) {
       this.isNarrowLayout = this.isNarrowOnResize;
 

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -272,10 +272,10 @@ export class SprkMastheadComponent implements AfterContentInit {
   isNarrowLayout = false;
   scrollDirection = 'up';
   isHidden = false;
-  currentLayout = false;
+  isNarrowOnResize = false;
 
   throttledCheckScrollDirection = _.throttle(this.checkScrollDirection, 500);
-  throttledCheckIfNarrowLayout = _.throttle(this.checkIfNarrowLayout, 500);
+  throttledUpdateLayoutState = _.throttle(this.updateLayoutState, 500);
 
   @HostListener('window:orientationchange')
   handleResizeEvent() {
@@ -293,13 +293,16 @@ export class SprkMastheadComponent implements AfterContentInit {
   // Handles when viewport size changes to large while narrow nav is hidden
   @HostListener('window:resize', ['$event'])
   onResize(event): void {
-    this.throttledCheckIfNarrowLayout();
+    this.throttledUpdateLayoutState();
   }
 
-  checkIfNarrowLayout() {
-    this.currentLayout = isElementVisible('.sprk-c-Masthead__menu');
-    if (this.isNarrowLayout !== this.currentLayout) {
-      this.isNarrowLayout = this.currentLayout;
+  updateLayoutState() {
+    this.isNarrowOnResize = isElementVisible('.sprk-c-Masthead__menu');
+
+    if (this.isNarrowLayout !== this.isNarrowOnResize) {
+      this.isNarrowLayout = this.isNarrowOnResize;
+
+      // If is not narrow on resize update, make sure it's visible
       if (!this.isNarrowLayout) {
         this.isHidden = false;
       }

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -1,5 +1,13 @@
-import { Component, HostListener, Input, Renderer2 } from '@angular/core';
+import {
+  Component,
+  HostListener,
+  Input,
+  Renderer2,
+  AfterContentInit,
+  OnDestroy
+} from '@angular/core';
 import { Router, Event, NavigationEnd } from '@angular/router';
+import { isElementVisible, scrollYDirection } from '@sparkdesignsystem/spark';
 import * as _ from 'lodash';
 
 @Component({
@@ -221,7 +229,7 @@ import * as _ from 'lodash';
     </header>
   `
 })
-export class SprkMastheadComponent {
+export class SprkMastheadComponent implements AfterContentInit, OnDestroy {
   constructor(private renderer: Renderer2, router: Router) {
     router.events.subscribe((event: Event) => {
       if (event instanceof NavigationEnd) {
@@ -255,6 +263,9 @@ export class SprkMastheadComponent {
   componentID = _.uniqueId();
   controls_id = `sprk-narrow-navigation-item__${this.componentID}`;
   isScrolled = false;
+  isNarrowLayout = false;
+  scrollDirection = 'up';
+  isHidden = false;
 
   @HostListener('window:orientationchange')
   handleResizeEvent() {
@@ -264,6 +275,36 @@ export class SprkMastheadComponent {
   @HostListener('window:scroll', ['$event'])
   onScroll(event): void {
     window.scrollY >= 10 ? (this.isScrolled = true) : (this.isScrolled = false);
+  }
+
+  ngAfterContentInit() {
+    this.isNarrowLayout = isElementVisible('.sprk-c-Masthead__menu');
+    this.toggleScrollEvent();
+  }
+
+  ngOnDestroy() {
+    window.removeEventListener('scroll', this.checkScrollDirection, false);
+  }
+
+  toggleMenu() {
+    this.scrollDirection === 'down' ? this.isHidden = true : this.isHidden = false;
+  }
+
+  checkScrollDirection() {
+    const newDirection = scrollYDirection();
+    if (this.scrollDirection !== newDirection) {
+      this.scrollDirection = newDirection;
+      this.scrollDirection === 'down' ? this.isHidden = true : this.isHidden = false;
+      console.log('isHidden', this.isHidden);
+    }
+  }
+
+  toggleScrollEvent() {
+    if (this.isNarrowLayout) {
+      window.addEventListener('scroll', this.checkScrollDirection);
+    } else {
+      window.removeEventListener('scroll', this.checkScrollDirection, false);
+    }
   }
 
   getClasses(): string {
@@ -281,6 +322,10 @@ export class SprkMastheadComponent {
 
     if (this.isScrolled) {
       classArray.push('sprk-c-Masthead--scroll');
+    }
+
+    if (this.isHidden) {
+      classArray.push('sprk-c-Masthead--hidden');
     }
 
     return classArray.join(' ');

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -3,7 +3,7 @@ import {
   HostListener,
   Input,
   Renderer2,
-  AfterContentInit,
+  AfterContentInit
 } from '@angular/core';
 import { Router, Event, NavigationEnd } from '@angular/router';
 import { isElementVisible, scrollYDirection } from '@sparkdesignsystem/spark';
@@ -265,6 +265,7 @@ export class SprkMastheadComponent implements AfterContentInit {
   isNarrowLayout = false;
   scrollDirection = 'up';
   isHidden = false;
+  currentLayout = false;
 
   @HostListener('window:orientationchange')
   handleResizeEvent() {
@@ -276,6 +277,18 @@ export class SprkMastheadComponent implements AfterContentInit {
     window.scrollY >= 10 ? (this.isScrolled = true) : (this.isScrolled = false);
     if (this.isNarrowLayout) {
       this.checkScrollDirection();
+    }
+  }
+
+  // Handles when viewport size changes to large while narrow nav is hidden
+  @HostListener('window:resize', ['$event'])
+  onResize(event): void {
+    this.currentLayout = isElementVisible('.sprk-c-Masthead__menu');
+    if (this.isNarrowLayout !== this.currentLayout) {
+      this.isNarrowLayout = this.currentLayout;
+      if (!this.isNarrowLayout) {
+        this.isHidden = false;
+      }
     }
   }
 

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -267,6 +267,9 @@ export class SprkMastheadComponent implements AfterContentInit {
   isHidden = false;
   currentLayout = false;
 
+  throttledCheckScrollDirection = _.throttle(this.checkScrollDirection, 500);
+  throttledCheckIfNarrowLayout = _.throttle(this.checkIfNarrowLayout, 500);
+
   @HostListener('window:orientationchange')
   handleResizeEvent() {
     this.closeNarrowNav();
@@ -276,13 +279,17 @@ export class SprkMastheadComponent implements AfterContentInit {
   onScroll(event): void {
     window.scrollY >= 10 ? (this.isScrolled = true) : (this.isScrolled = false);
     if (this.isNarrowLayout) {
-      this.checkScrollDirection();
+      this.throttledCheckScrollDirection();
     }
   }
 
   // Handles when viewport size changes to large while narrow nav is hidden
   @HostListener('window:resize', ['$event'])
   onResize(event): void {
+    this.throttledCheckIfNarrowLayout();
+  }
+
+  checkIfNarrowLayout() {
     this.currentLayout = isElementVisible('.sprk-c-Masthead__menu');
     if (this.isNarrowLayout !== this.currentLayout) {
       this.isNarrowLayout = this.currentLayout;
@@ -297,6 +304,7 @@ export class SprkMastheadComponent implements AfterContentInit {
   }
 
   checkScrollDirection() {
+    console.log('scroll:', window.scrollY);
     const newDirection = scrollYDirection();
     if (this.scrollDirection !== newDirection) {
       this.scrollDirection = newDirection;

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -4,7 +4,6 @@ import {
   Input,
   Renderer2,
   AfterContentInit,
-  OnDestroy
 } from '@angular/core';
 import { Router, Event, NavigationEnd } from '@angular/router';
 import { isElementVisible, scrollYDirection } from '@sparkdesignsystem/spark';
@@ -229,7 +228,7 @@ import * as _ from 'lodash';
     </header>
   `
 })
-export class SprkMastheadComponent implements AfterContentInit, OnDestroy {
+export class SprkMastheadComponent implements AfterContentInit {
   constructor(private renderer: Renderer2, router: Router) {
     router.events.subscribe((event: Event) => {
       if (event instanceof NavigationEnd) {
@@ -275,35 +274,22 @@ export class SprkMastheadComponent implements AfterContentInit, OnDestroy {
   @HostListener('window:scroll', ['$event'])
   onScroll(event): void {
     window.scrollY >= 10 ? (this.isScrolled = true) : (this.isScrolled = false);
+    if (this.isNarrowLayout) {
+      this.checkScrollDirection();
+    }
   }
 
   ngAfterContentInit() {
     this.isNarrowLayout = isElementVisible('.sprk-c-Masthead__menu');
-    this.toggleScrollEvent();
-  }
-
-  ngOnDestroy() {
-    window.removeEventListener('scroll', this.checkScrollDirection, false);
-  }
-
-  toggleMenu() {
-    this.scrollDirection === 'down' ? this.isHidden = true : this.isHidden = false;
   }
 
   checkScrollDirection() {
     const newDirection = scrollYDirection();
     if (this.scrollDirection !== newDirection) {
       this.scrollDirection = newDirection;
-      this.scrollDirection === 'down' ? this.isHidden = true : this.isHidden = false;
-      console.log('isHidden', this.isHidden);
-    }
-  }
-
-  toggleScrollEvent() {
-    if (this.isNarrowLayout) {
-      window.addEventListener('scroll', this.checkScrollDirection);
-    } else {
-      window.removeEventListener('scroll', this.checkScrollDirection, false);
+      this.scrollDirection === 'down'
+        ? (this.isHidden = true)
+        : (this.isHidden = false);
     }
   }
 

--- a/src/patterns/components/masthead/collection.yaml
+++ b/src/patterns/components/masthead/collection.yaml
@@ -3,7 +3,7 @@ description:
 information:
   - There are three custom configurations that you must do in order for the Masthead's narrow navigation to work properly (see below restrictions).
   - The Masthead is "sticky" and content will flow under it.
-  - Vanilla & React Implementations Only - On narrow viewports when a user scrolls down the page, the masthead will become hidden. When the user scrolls back up towards the top of the page, the masthead will come back into view.
+  - On narrow viewports when a user scrolls down the page, the masthead will become hidden. When the user scrolls back up towards the top of the page, the masthead will come back into view.
   - All content used here is placeholder content. Please use your own logo, content, and hrefs.
   - Make sure you leave the 'data-sprk-masthead' attribute on the main Masthead element as it functions as a Spark JS hook. It's already included in the provided code.
 restrictions:


### PR DESCRIPTION
## What does this PR do?
Enhances the scrolling functionality of the masthead in Angular. When the user scrolls down the page on a narrow viewport, the masthead animates off the page to create more space for content. When the user scrolls back up towards the top of the page, the masthead animates back in to give easy access to the navigation.
![64639640-3ceae580-d3d6-11e9-8d46-dcbe57b5a679](https://user-images.githubusercontent.com/4342363/64809277-f082df80-d566-11e9-96f6-4154dd31419a.gif)

#### Improvements needed in the future:
- Router event: Instead of using this router, make run this on every menu link instead
- `.sprk-c-Masthead--hidden` modifier: apply it only on breakpoints so we can reduce polling for resize events (more detail in comments of masthead scss)

### Associated Issue 
Fixes #1640, Fixes #1768

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs Angular

### Code
 - [x] Build Component in Spark Angular
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (~100%~ coverage, 100% passing)

#### Line 240 -246 of `sprk-masthead.component.ts`
- Skipping testing because the function inside of it is being tested already, and there's no need to test angular to see if it's doing it's job.
- this will be replaced by improvements mentioned above.

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE) -- expected functionality for it not to stick
  - [x] Microsoft Edge
  - [x] Apple Safari - found an issue where sticky doesn't work correctly
  - [x] Apple Safari (Mobile)
 
