### PR TITLE
Add Huge Select - Angular

### DIFF
--- a/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.spec.ts
+++ b/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.spec.ts
@@ -1,11 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { SprkInputDirective } from './sprk-input.directive';
 
 @Component({
   selector: 'sprk-test',
   template: `
-    <input sprkInput />
+    <input sprkInput value='Initial Value'/>
   `
 })
 class TestComponent {}
@@ -13,7 +14,7 @@ class TestComponent {}
 describe('Spark Input Directive', () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
-  let inputElement: HTMLInputElement;
+  let inputElement: DebugElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -24,10 +25,29 @@ describe('Spark Input Directive', () => {
     component = fixture.componentInstance;
 
     fixture.detectChanges();
-    inputElement = fixture.nativeElement.querySelector('input');
+    inputElement = fixture.debugElement.query(By.css('input'));
   }));
 
   it('should create itself', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should add the has-floating-label class on change if the input value is not empty', () => {
+    inputElement.nativeElement.value = 'Test Value!';
+    inputElement.nativeElement.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    expect(inputElement.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(true);
+  });
+
+  it('should not add the has-floating-label class on change if the input value is empty', () => {
+    inputElement.nativeElement.value = '';
+    inputElement.nativeElement.dispatchEvent(new Event('change'));
+    fixture.detectChanges();
+    expect(inputElement.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(false);
+  });
+
+  it('should add the has-floating-label class on load if the input value is not empty', () => {
+    expect(inputElement.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(true);
+  });
+
 });

--- a/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.spec.ts
+++ b/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.spec.ts
@@ -6,7 +6,10 @@ import { SprkInputDirective } from './sprk-input.directive';
 @Component({
   selector: 'sprk-test',
   template: `
-    <input sprkInput value='Initial Value'/>
+    <input sprkInput id="with-value" value='Initial Value'/>
+    <input sprkInput id="no-value"/>
+    <select sprkInput id="select"></select>
+    <textarea sprkInput id="textarea"></textarea>
   `
 })
 class TestComponent {}
@@ -14,7 +17,11 @@ class TestComponent {}
 describe('Spark Input Directive', () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
-  let inputElement: DebugElement;
+  let inputElementWithValue: DebugElement;
+  let inputElementNoValue: DebugElement;
+  let selectElement: DebugElement;
+  let textareaElement: DebugElement;
+
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -25,7 +32,10 @@ describe('Spark Input Directive', () => {
     component = fixture.componentInstance;
 
     fixture.detectChanges();
-    inputElement = fixture.debugElement.query(By.css('input'));
+    inputElementWithValue = fixture.debugElement.query(By.css('#with-value'));
+    inputElementNoValue = fixture.debugElement.query(By.css('#no-value'));
+    selectElement = fixture.debugElement.query(By.css('#select'));
+    textareaElement = fixture.debugElement.query(By.css('#textarea'));
   }));
 
   it('should create itself', () => {
@@ -33,21 +43,37 @@ describe('Spark Input Directive', () => {
   });
 
   it('should add the has-floating-label class on change if the input value is not empty', () => {
-    inputElement.nativeElement.value = 'Test Value!';
-    inputElement.nativeElement.dispatchEvent(new Event('change'));
+    inputElementWithValue.nativeElement.value = 'Test Value!';
+    inputElementWithValue.nativeElement.dispatchEvent(new Event('change'));
     fixture.detectChanges();
-    expect(inputElement.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(true);
+    expect(inputElementWithValue.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(true);
   });
 
   it('should not add the has-floating-label class on change if the input value is empty', () => {
-    inputElement.nativeElement.value = '';
-    inputElement.nativeElement.dispatchEvent(new Event('change'));
+    inputElementWithValue.nativeElement.value = '';
+    inputElementWithValue.nativeElement.dispatchEvent(new Event('change'));
     fixture.detectChanges();
-    expect(inputElement.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(false);
+    expect(inputElementWithValue.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(false);
   });
 
   it('should add the has-floating-label class on load if the input value is not empty', () => {
-    expect(inputElement.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(true);
+    expect(inputElementWithValue.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(true);
+  });
+
+  it('should not add the has-floating-label class on load if the input value is empty', () => {
+    expect(inputElementNoValue.nativeElement.classList.contains('sprk-b-Input--has-floating-label')).toEqual(false);
+  });
+
+  it('should add the sprk-b-Select class on load if the input is a SELECT', () => {
+    expect(selectElement.nativeElement.classList.contains('sprk-b-Select')).toEqual(true);
+  });
+
+  it('should add the sprk-b-TextInput class on load if the input is a TEXTAREA', () => {
+    expect(textareaElement.nativeElement.classList.contains('sprk-b-TextInput')).toEqual(true);
+  });
+
+  it('should add the sprk-b-TextArea class on load if the input is a TEXTAREA', () => {
+    expect(textareaElement.nativeElement.classList.contains('sprk-b-TextArea')).toEqual(true);
   });
 
 });

--- a/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.ts
+++ b/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.ts
@@ -16,9 +16,9 @@ export class SprkInputDirective implements OnInit {
   OnChange($event) {
     const value = (this.ref.nativeElement as HTMLInputElement).value;
     if (value.length > 0) {
-      this.ref.nativeElement.classList.add('sprk-b-TextInput--float-label');
+      this.ref.nativeElement.classList.add('sprk-b-Input--has-floating-label');
     } else {
-      this.ref.nativeElement.classList.remove('sprk-b-TextInput--float-label');
+      this.ref.nativeElement.classList.remove('sprk-b-Input--has-floating-label');
     }
   }
 

--- a/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.ts
+++ b/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.ts
@@ -32,6 +32,9 @@ export class SprkInputDirective implements OnInit {
       this.ref.nativeElement.classList.add('sprk-b-TextInput');
     }
 
+    if ((this.ref.nativeElement as HTMLInputElement).value.length > 0 ) {
+      this.ref.nativeElement.classList.add('sprk-b-Input--has-floating-label');
+    }
     this.ref.nativeElement.classList.add('sprk-u-Width-100');
   }
 }

--- a/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.ts
+++ b/src/angular/projects/spark-angular/src/lib/directives/inputs/sprk-input/sprk-input.directive.ts
@@ -13,7 +13,7 @@ export class SprkInputDirective implements OnInit {
   constructor(public ref: ElementRef) {}
 
   @HostListener('change')
-  OnChange($event) {
+  OnChange() {
     const value = (this.ref.nativeElement as HTMLInputElement).value;
     if (value.length > 0) {
       this.ref.nativeElement.classList.add('sprk-b-Input--has-floating-label');

--- a/src/angular/src/app/spark-docs/input-docs/input-docs.component.ts
+++ b/src/angular/src/app/spark-docs/input-docs/input-docs.component.ts
@@ -252,6 +252,36 @@ import { Component } from '@angular/core';
           ></sprk-icon>
           <label sprkLabel>Select Box Label</label>
         </sprk-input-container>
+        <sprk-huge-input-container>
+          <select
+            id="select-huge"
+            data-id="select-huge"
+            aria-describedby="select-huge--error-container"
+            data-sprk-input="huge"
+            sprkInput
+          >
+            <option
+              value=""
+              disabled
+              selected
+              hidden
+            ></option>
+            <option value="1">Option 1</option>
+            <option value="2">Option 2</option>
+            <option value="3">Option 3</option>
+            <optgroup label="Grouped Options">
+              <option value="g1">Grouped Option 1</option>
+              <option value="g2">Grouped Option 2</option>
+              <option value="g3">Grouped Option 3</option>
+            </optgroup>
+          </select>
+          <sprk-icon
+            iconType="chevron-down"
+            additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
+            sprk-select-icon
+          ></sprk-icon>
+          <label sprkLabel for="select-huge">Select Box Label</label>
+        </sprk-huge-input-container>
         <sprk-textarea-container>
           <label sprkLabel>Textarea Input</label>
           <textarea

--- a/src/patterns/components/inputs/angular/code/select-huge-disabled.hbs
+++ b/src/patterns/components/inputs/angular/code/select-huge-disabled.hbs
@@ -1,0 +1,30 @@
+<sprk-huge-input-container>
+  <select
+    id="select-normal"
+    aria-describedby="select-normal--error-container"
+    data-id="select-huge-disabled-1"
+    data-sprk-input="huge"
+    sprkInput
+    disabled>
+    <option
+     value=""
+     disabled
+     selected
+     hidden
+    ></option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <optgroup label="Grouped Options">
+      <option value="g1">Grouped Option 1</option>
+      <option value="g2">Grouped Option 2</option>
+      <option value="g3">Grouped Option 3</option>
+    </optgroup>
+  </select>
+  <label sprkLabel>Select Box Label</label>
+  <sprk-icon
+    iconType="chevron-down"
+    additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
+    sprk-select-icon
+  ></sprk-icon>
+</sprk-huge-input-container>

--- a/src/patterns/components/inputs/angular/code/select-huge-error.hbs
+++ b/src/patterns/components/inputs/angular/code/select-huge-error.hbs
@@ -3,6 +3,7 @@
     id="select-normal"
     aria-describedby="select-normal--error-container"
     data-id="select-huge-error-1"
+    data-sprk-input="huge"
     sprkInput
   >
     <option

--- a/src/patterns/components/inputs/angular/code/select-huge-error.hbs
+++ b/src/patterns/components/inputs/angular/code/select-huge-error.hbs
@@ -1,0 +1,29 @@
+<sprk-huge-input-container>
+  <select
+    id="select-normal"
+    aria-describedby="select-normal--error-container"
+    data-id="select-huge-error-1"
+    sprkInput
+  >
+    <option
+     value=""
+     disabled
+     selected
+     hidden
+    ></option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <optgroup label="Grouped Options">
+      <option value="g1">Grouped Option 1</option>
+      <option value="g2">Grouped Option 2</option>
+      <option value="g3">Grouped Option 3</option>
+    </optgroup>
+  </select>
+  <label sprkLabel>Select Box Label</label>
+  <sprk-icon
+    iconType="chevron-down"
+    additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
+    sprk-select-icon
+  ></sprk-icon>
+</sprk-huge-input-container>

--- a/src/patterns/components/inputs/angular/code/select-huge.hbs
+++ b/src/patterns/components/inputs/angular/code/select-huge.hbs
@@ -1,0 +1,30 @@
+<sprk-huge-input-container>
+  <select
+    id="select-normal"
+    aria-describedby="select-normal--error-container"
+    data-id="select-huge-1"
+    data-sprk-input="huge"
+    sprkInput
+  >
+    <option
+     value=""
+     disabled
+     selected
+     hidden
+    ></option>
+    <option value="1">Option 1</option>
+    <option value="2">Option 2</option>
+    <option value="3">Option 3</option>
+    <optgroup label="Grouped Options">
+      <option value="g1">Grouped Option 1</option>
+      <option value="g2">Grouped Option 2</option>
+      <option value="g3">Grouped Option 3</option>
+    </optgroup>
+  </select>
+  <label sprkLabel>Select Box Label</label>
+  <sprk-icon
+    iconType="chevron-down"
+    additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
+    sprk-select-icon
+  ></sprk-icon>
+</sprk-huge-input-container>

--- a/src/patterns/components/inputs/select-huge-disabled.hbs
+++ b/src/patterns/components/inputs/select-huge-disabled.hbs
@@ -1,5 +1,6 @@
 ---
 name: Select Box Huge - Disabled State
+description:
   This select input is larger than the default select input and it's design is consistent with the huge text input.
   The label is centered inside the select until focused. On focus, the label transitions to the top of the select.
 information:

--- a/src/patterns/components/inputs/select-huge-disabled.hbs
+++ b/src/patterns/components/inputs/select-huge-disabled.hbs
@@ -14,7 +14,7 @@ restrictions:
   - Labels cannot be long in length as they must fit inside the select. They should not wrap onto a second line.
 invisible: true
 order: 10
-hasAngularCode: false
+hasAngularCode: true
 hasReactCode: false
 ---
 

--- a/src/patterns/components/inputs/select-huge-error.hbs
+++ b/src/patterns/components/inputs/select-huge-error.hbs
@@ -14,7 +14,7 @@ restrictions:
   - Labels cannot be long in length as they must fit inside the select. They should not wrap onto a second line.
 invisible: true
 order: 10
-hasAngularCode: false
+hasAngularCode: true
 hasReactCode: false
 ---
 

--- a/src/patterns/components/inputs/select-huge-error.hbs
+++ b/src/patterns/components/inputs/select-huge-error.hbs
@@ -1,5 +1,6 @@
 ---
 name: Select Box Huge - Error State
+description:
   This select input is larger than the default select input and it's design is consistent with the huge text input.
   The label is centered inside the select until focused. On focus, the label transitions to the top of the select.
 information:

--- a/src/patterns/components/inputs/select-huge.hbs
+++ b/src/patterns/components/inputs/select-huge.hbs
@@ -14,7 +14,7 @@ restrictions:
   - The select element must come before the label element.
   - Labels cannot be long in length as they must fit inside the select. They should not wrap onto a second line.
 order: 10
-hasAngularCode: false
+hasAngularCode: true
 hasReactCode: false
 ---
 


### PR DESCRIPTION
## What does this PR do?
Adds the ability to use the Huge Select input in Angular.

### Associated Issue 
Fixes #1643 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs Angular

### Code
 - [x] Build Component in Spark Angular
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)
![image](https://user-images.githubusercontent.com/15703773/65165934-beadc500-da0d-11e9-9478-2709e84e1d81.png)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)