### PR TITLE
Clarifying documentation on masthead component.

### DIFF
--- a/src/patterns/components/masthead/default.hbs
+++ b/src/patterns/components/masthead/default.hbs
@@ -12,7 +12,7 @@ information:
 restrictions:
 - You must set the variable $sprk-masthead-narrow-height so that the navigation displays properly on small screens.
   You should put your logo in the Masthead and then grab the total height of the Masthead with your logo in it. Set
-  $mobile-masthead-height to that height.
+  $sprk-masthead-narrow-height to that height, in pixels (e.g. $sprk-masthead-narrow-height":" 55px).
 order: 1
 hasAngularCode: true
 hasAngularCodeInfo: true


### PR DESCRIPTION
After speaking with @afebbraro, she confirmed that `$mobile-masthead-height` was a typo, and that the unit of measurement should be in pixels.