### PR TITLE
address z-index issue for monetary input

### DIFF
--- a/packages/spark/base/inputs/_svg-icon-input.scss
+++ b/packages/spark/base/inputs/_svg-icon-input.scss
@@ -1,6 +1,7 @@
 .sprk-b-TextInputIconContainer,
 .sprk-b-InputContainer__icon-container {
   position: relative;
+  z-index: -1;
 }
 
 .sprk-b-InputContainer__icon-container--narrow {

--- a/packages/spark/base/inputs/_svg-icon-input.scss
+++ b/packages/spark/base/inputs/_svg-icon-input.scss
@@ -1,7 +1,6 @@
 .sprk-b-TextInputIconContainer,
 .sprk-b-InputContainer__icon-container {
   position: relative;
-  z-index: -1;
 }
 
 .sprk-b-InputContainer__icon-container--narrow {

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -11,13 +11,17 @@ import * as _ from 'lodash';
 
 @Component({
   selector: 'sprk-masthead',
-  styles: [`:host {
-            position: sticky;
-            position: -webkit-sticky;
-            top: 0;
-            display: block;
-          }`
-        ],
+  styles: [
+    `
+      :host {
+        position: sticky;
+        position: -webkit-sticky;
+        top: 0;
+        display: block;
+        z-index: 2000;
+      }
+    `
+  ],
   template: `
     <header [ngClass]="getClasses()" role="banner" [attr.data-id]="idString">
       <div

--- a/src/angular/src/app/spark-docs/masthead-docs/masthead-docs.component.ts
+++ b/src/angular/src/app/spark-docs/masthead-docs/masthead-docs.component.ts
@@ -218,6 +218,103 @@ import { Component } from '@angular/core';
           This is an info Spark alert!
         </sprk-alert>
         <h2 class="drizzle-b-h2">Masthead</h2>
+        <sprk-icon-input-container
+          iconContainerClasses="sprk-b-TextInputIconContainer--has-text-icon"
+        >
+          <label class="sprk-b-Label--monetary" sprkLabel> Payment </label>
+          <input
+            class="sprk-b-TextInput--has-text-icon"
+            name="monetary_input"
+            type="text"
+            pattern="(^$?(d+|d{1,3}(,d{3})*)(.d+)?$)|^$"
+            [(ngModel)]="monetary_input"
+            #monetaryInput="ngModel"
+            sprkFormatterMonetary
+            sprkInput
+          />
+          <div
+            [hidden]="monetaryInput.valid || monetaryInput.pristine"
+            sprkFieldError
+          >
+            <sprk-icon
+              iconType="exclamation-filled-small"
+              additionalClasses="sprk-b-ErrorIcon"
+            ></sprk-icon>
+            <div class="sprk-b-ErrorText">Invalid amount.</div>
+          </div>
+        </sprk-icon-input-container>
+        <sprk-icon-input-container>
+          <label
+            class="sprk-b-Label--with-icon sprk-u-ScreenReaderText"
+            sprkLabel
+          >
+            Search
+          </label>
+          <sprk-icon
+            iconType="search"
+            additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--stroke-current-color"
+            sprk-input-icon
+          ></sprk-icon>
+          <input
+            name="inline_search_input"
+            class="sprk-b-TextInput--has-svg-icon"
+            type="text"
+            placeholder="Search"
+            [(ngModel)]="inline_search_input"
+            #inlineSearchInput="ngModel"
+            data-id="input-search-1"
+            sprkInput
+          />
+        </sprk-icon-input-container>
+        <sprk-icon-input-container
+          iconContainerClasses="sprk-b-InputContainer__icon-container--narrow"
+        >
+          <label sprkLabel>Percentage</label>
+          <sprk-icon
+            iconType="percent"
+            additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
+            sprk-input-icon
+          ></sprk-icon>
+          <input
+            class="sprk-b-InputContainer__input--has-icon-right"
+            name="percentage"
+            type="tel"
+            sprkInput
+          />
+        </sprk-icon-input-container>
+        <sprk-icon-input-container>
+          <label class="sprk-b-Label--with-icon" sprkLabel>
+            Date Input (picker)
+          </label>
+          <sprk-icon
+            iconType="calendar"
+            additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-DatePicker__icon"
+            sprk-input-icon
+          ></sprk-icon>
+          <input
+            name="datepicker_input"
+            class="sprk-b-TextInput--has-svg-icon"
+            type="text"
+            pattern="^(((0[13578]|1[02])([/-]?)(0[1-9]|[12]d|3[01])|(0[469]|11)([/-]?)(0[1-9]|[12]d|30)|02([/-]?)((0[1-9])|[12]d))(4|7|9)[12]d{3})?$"
+            placeholder="MM/DD/YYYY"
+            [(ngModel)]="datepicker_input"
+            #datepickerInput="ngModel"
+            sprkFormatterDate
+            [sprkDatePickerConfig]="dpConfig"
+            sprkDatepicker
+            sprkInput
+          />
+          <div
+            [hidden]="datepickerInput.valid || datepickerInput.pristine"
+            sprkFieldError
+          >
+            <sprk-icon
+              iconType="exclamation-filled-small"
+              additionalClasses="sprk-b-ErrorIcon"
+            ></sprk-icon>
+            <div class="sprk-b-ErrorText">Invalid date.</div>
+          </div>
+        </sprk-icon-input-container>
         <p>
           Lorem Ipsum is simply dummy text of the printing and typesetting
           industry. Lorem Ipsum has been the industry's standard dummy text ever


### PR DESCRIPTION
## What does this PR do?
Updates the monetary input css to not scroll on top of the masthead

### Associated Issue 
Fixes #2089 

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots
Before: 
![image](https://user-images.githubusercontent.com/15703773/66080576-5940f480-e534-11e9-9bd3-7aa8b868115a.png)

After: 
![image](https://user-images.githubusercontent.com/15703773/66080606-6b229780-e534-11e9-8016-41973892e819.png)
