### PR TITLE
add missing vendor prefixes to select

### DIFF
--- a/packages/spark/base/inputs/_select.scss
+++ b/packages/spark/base/inputs/_select.scss
@@ -1,7 +1,7 @@
 .sprk-b-Select {
-  appearance: $sprk-select-appearance;
   -webkit-appearance: $sprk-select-appearance;
   -moz-appearance: $sprk-select-appearance;
+  appearance: $sprk-select-appearance;
   border: $sprk-select-border;
   border-radius: $sprk-select-border-radius;
   box-shadow: $sprk-select-box-shadow;

--- a/packages/spark/base/inputs/_select.scss
+++ b/packages/spark/base/inputs/_select.scss
@@ -1,5 +1,7 @@
 .sprk-b-Select {
   appearance: $sprk-select-appearance;
+  -webkit-appearance: $sprk-select-appearance;
+  -moz-appearance: $sprk-select-appearance;
   border: $sprk-select-border;
   border-radius: $sprk-select-border-radius;
   box-shadow: $sprk-select-box-shadow;


### PR DESCRIPTION
## What does this PR do?
Adds in missing vendor prefixes to select.

### Associated Issue 
Fixes #2098

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - no docs needed

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Manual Testing Plan
   - none needed

### Design Review
 - none needed
### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
