### PR TITLE
Fix Huge Text Input Default Value bug

### DIFF
--- a/src/react/projects/spark-react/src/SprkInput/components/SprkTextareaCheck.js
+++ b/src/react/projects/spark-react/src/SprkInput/components/SprkTextareaCheck.js
@@ -9,6 +9,22 @@ class SprkTextareaCheck extends Component {
     this.state = {
       hasValue: this.props.value,
     };
+
+    this.inputRef = React.createRef();
+  }
+
+  componentDidMount() {
+    /*
+     * Check if Huge Select has a value when it first mounts.
+     * Set presence of value in state.
+     */
+    if (this.props.variant === 'hugeTextInput') {
+      if (this.inputRef.current.value !== '') {
+        this.setState({
+          hasValue: true,
+        });
+      }
+    }
   }
 
   render() {
@@ -68,6 +84,7 @@ class SprkTextareaCheck extends Component {
         aria-describedby={errorContainerId}
         value={valid && formatter(value) ? formatter(value) : value}
         onBlur={e => handleOnBlur(e)}
+        ref={this.inputRef}
         {...rest}
       >
         {children}

--- a/src/react/projects/spark-react/src/SprkInput/components/SprkTextareaCheck.js
+++ b/src/react/projects/spark-react/src/SprkInput/components/SprkTextareaCheck.js
@@ -9,13 +9,11 @@ class SprkTextareaCheck extends Component {
     this.state = {
       hasValue: this.props.value,
     };
-
-    this.inputRef = React.createRef();
   }
 
   componentDidMount() {
-    if (this.props.variant === 'hugeTextInput') {
-      if (this.props.value != '') {
+    if (this.props.type === 'hugeTextInput') {
+      if (this.props.value !== '') {
         this.setState({
           hasValue: true,
         });
@@ -80,7 +78,6 @@ class SprkTextareaCheck extends Component {
         aria-describedby={errorContainerId}
         value={valid && formatter(value) ? formatter(value) : value}
         onBlur={e => handleOnBlur(e)}
-        ref={this.inputRef}
         {...rest}
       >
         {children}

--- a/src/react/projects/spark-react/src/SprkInput/components/SprkTextareaCheck.js
+++ b/src/react/projects/spark-react/src/SprkInput/components/SprkTextareaCheck.js
@@ -14,12 +14,8 @@ class SprkTextareaCheck extends Component {
   }
 
   componentDidMount() {
-    /*
-     * Check if Huge Select has a value when it first mounts.
-     * Set presence of value in state.
-     */
     if (this.props.variant === 'hugeTextInput') {
-      if (this.inputRef.current.value !== '') {
+      if (this.props.value != '') {
         this.setState({
           hasValue: true,
         });


### PR DESCRIPTION
In IE11, huge text inputs with a default value should render correctly on page load.


https://github.com/sparkdesignsystem/spark-design-system/issues/2096