### PR TITLE
move masthead styles to spark ng style file

### DIFF
--- a/packages/spark/_spark-angular.scss
+++ b/packages/spark/_spark-angular.scss
@@ -6,3 +6,10 @@
 }
 
 /* stylelint-enable selector-class-pattern */
+sprk-masthead {
+  position: sticky;
+  position: -webkit-sticky;
+  top: 0;
+  display: block;
+  z-index: $sprk-layer-height-m;
+}

--- a/src/angular/projects/spark-angular/src/environment/environment.ts
+++ b/src/angular/projects/spark-angular/src/environment/environment.ts
@@ -1,3 +1,3 @@
 export const environment = {
-  version: '9.3.0-beta.1'
+  version: '9.3.0'
 };

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -11,17 +11,6 @@ import * as _ from 'lodash';
 
 @Component({
   selector: 'sprk-masthead',
-  styles: [
-    `
-      :host {
-        position: sticky;
-        position: -webkit-sticky;
-        top: 0;
-        display: block;
-        z-index: 2000;
-      }
-    `
-  ],
   template: `
     <header [ngClass]="getClasses()" role="banner" [attr.data-id]="idString">
       <div


### PR DESCRIPTION
## What does this PR do?
move masthead styles to spark ng style file
### Associated Issue 
no issue
## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [ ] Update Spark Docs React
 - [ ] Update Spark Docs Angular
 - [ ] Update Spark Docs Vanilla
 - [ ] Update Component Sass Var/Class Modifier table

### Code
 - [ ] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Build Component in Spark Angular
 - [ ] Build Component in Spark React
 - [ ] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
 - [ ] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)
 - [ ] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Accessibility
- [ ] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Manual Testing Plan
  - [ ] Update excel sheet with component changes

### Design Review
 - [ ] Design reviewed and approved

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
