### PR TITLE
uses visible state of alert instead of class to hide dismissed alerts

### DIFF
--- a/src/angular/projects/spark-angular/src/lib/components/sprk-alert/sprk-alert.component.spec.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-alert/sprk-alert.component.spec.ts
@@ -108,9 +108,7 @@ describe('SprkAlertComponent', () => {
     fixture.detectChanges();
     alertElement.querySelector('button').click();
     fixture.detectChanges();
-    expect(
-      alertElement.classList.contains('sprk-u-Display--none')
-    ).toBeTruthy();
+    expect(component.visible).toBe(false);
   });
 
   it('should add data-id when idString has a value', () => {

--- a/src/angular/projects/spark-angular/src/lib/components/sprk-alert/sprk-alert.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-alert/sprk-alert.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input } from '@angular/core';
-import { dismissAlert } from '@sparkdesignsystem/spark';
 
 @Component({
   selector: 'sprk-alert',
@@ -82,6 +81,6 @@ export class SprkAlertComponent {
   }
 
   alertDismiss(event): void {
-    dismissAlert(event.currentTarget.parentElement);
+    this.visible = false;
   }
 }


### PR DESCRIPTION
## What does this PR do?
Uses local state instead of vanilla js and a class to hide dismissed alerts.

### Code
 - [x] Build Component in Spark Angular
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing