### PR TITLE
removes usage of vanilla js from carousel

### DIFF
--- a/src/angular/projects/spark-angular/src/lib/components/sprk-carousel/sprk-carousel.component.ts
+++ b/src/angular/projects/spark-angular/src/lib/components/sprk-carousel/sprk-carousel.component.ts
@@ -1,5 +1,4 @@
 import { Component, Input, AfterViewInit, ElementRef } from '@angular/core';
-import { carousel } from '@sparkdesignsystem/spark';
 
 @Component({
   selector: 'sprk-carousel',
@@ -55,6 +54,10 @@ export class SprkCarouselComponent implements AfterViewInit {
 
   carouselInstance: object;
 
+  carousel(carouselElement): any {
+    // TODO: implement
+  }
+
   getClasses(): string {
     const classArray: string[] = ['sprk-c-Carousel'];
 
@@ -69,6 +72,6 @@ export class SprkCarouselComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     const carouselElement = this.ref.nativeElement;
-    this.carouselInstance = carousel(carouselElement);
+    this.carouselInstance = this.carousel(carouselElement);
   }
 }


### PR DESCRIPTION
## What does this PR do?
removes vanilla js from angular carousel

### Code
 - [x] Build Component in Spark Angular
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)