### PR TITLE
Add Vanilla Buttons to Story Book

### DIFF
--- a/spark/components/buttons/vanilla/button.stories.js
+++ b/spark/components/buttons/vanilla/button.stories.js
@@ -12,15 +12,27 @@ export const primary = () => (
 );
 
 export const secondary = () => (
-  '<button class="sprk-c-Button sprk-c-Button--secondary" type="button" data-id="button-1">Button</button>'
+  `
+    <button class="sprk-c-Button sprk-c-Button--secondary" type="button" data-id="button-1">
+    Button
+    </button>
+  `
 );
 
 export const tertiary = () => (
-  '<button class="sprk-c-Button sprk-c-Button--tertiary" data-id="button-1">Button</button>'
+  `
+    <button class="sprk-c-Button sprk-c-Button--tertiary" type="button" data-id="button-1">
+    Button
+    </button>
+  `
 );
 
 export const disabled = () => (
-  '<button class="sprk-c-Button sprk-is-Disabled" data-id="button-1" disabled>Button</button>'
+  `
+  <button class="sprk-c-Button sprk-is-Disabled" data-id="button-1" disabled>
+    Button
+  </button>
+  `
 );
 
 export const spinner = () => (
@@ -34,15 +46,24 @@ spinner.story = {
   name: 'Spinner',
 };
 
-export const fullWidthAtSmallViewport = () =>
-  '<button class="sprk-c-Button sprk-c-Button--full@s" type="button" data-id="button-1">Button</button>';
+export const fullWidthAtSmallViewport = () => (
+  `
+  <button class="sprk-c-Button sprk-c-Button--full@s" type="button" data-id="button-1">
+    Button
+  </button>
+  `
+);
 fullWidthAtSmallViewport.story = {
   name: 'Full Width at Small Viewport',
 };
 
-export const fullWidthAtExtraSmallViewport = () =>
-  '<button class="sprk-c-Button sprk-c-Button--full@xs" type="button" data-id="button-90">Button</button>';
-
+export const fullWidthAtExtraSmallViewport = () => (
+  `
+  <button class="sprk-c-Button sprk-c-Button--full@xs" type="button" data-id="button-90">
+    Button
+  </button>
+  `
+);
 fullWidthAtExtraSmallViewport.story = {
   name: 'Full Width at Extra Small Viewport',
 };

--- a/spark/components/buttons/vanilla/button.stories.js
+++ b/spark/components/buttons/vanilla/button.stories.js
@@ -23,24 +23,26 @@ export const disabled = () => (
   '<button class="sprk-c-Button sprk-is-Disabled" data-id="button-1" disabled>Button</button>'
 );
 
-const withSpinner = () => (
-  '<button class="sprk-c-Button" data-sprk-spinner="click" data-id="button-spinner-1">Submit</button>'
+export const spinner = () => (
+  `
+  <button class="sprk-c-Button" data-sprk-spinner="click" data-id="button-spinner-1">
+    <div class="sprk-c-Spinner sprk-c-Spinner--circle"></div>
+  </button>
+  `
 );
-
-withSpinner.story = {
-  name: 'with spinner',
+spinner.story = {
+  name: 'Spinner',
 };
 
 export const fullWidthAtSmallViewport = () =>
   '<button class="sprk-c-Button sprk-c-Button--full@s" type="button" data-id="button-1">Button</button>';
-
 fullWidthAtSmallViewport.story = {
-  name: 'full width at small viewport',
+  name: 'Full Width at Small Viewport',
 };
 
 export const fullWidthAtExtraSmallViewport = () =>
   '<button class="sprk-c-Button sprk-c-Button--full@xs" type="button" data-id="button-90">Button</button>';
 
 fullWidthAtExtraSmallViewport.story = {
-  name: 'full width at extra small viewport',
+  name: 'Full Width at Extra Small Viewport',
 };

--- a/spark/components/buttons/vanilla/button.stories.js
+++ b/spark/components/buttons/vanilla/button.stories.js
@@ -1,14 +1,12 @@
-import { withKnobs, text } from '@storybook/addon-knobs';
 
 export default {
   title: 'Components|Buttons',
-  decorators: [withKnobs],
 };
 
 export const primary = () => (
   `
     <button class="sprk-c-Button" data-id="button-1">
-      ${text('button text', 'Button')}
+      Button
     </button>
   `
 );

--- a/spark/components/buttons/vanilla/button.stories.js
+++ b/spark/components/buttons/vanilla/button.stories.js
@@ -21,7 +21,7 @@ export const secondary = () => (
 
 export const tertiary = () => (
   `
-    <button class="sprk-c-Button sprk-c-Button--tertiary" type="button" data-id="button-1">
+    <button class="sprk-c-Button sprk-c-Button--tertiary" type="button" data-id="button-2">
     Button
     </button>
   `

--- a/spark/components/buttons/vanilla/button.stories.js
+++ b/spark/components/buttons/vanilla/button.stories.js
@@ -5,7 +5,7 @@ export default {
 
 export const primary = () => (
   `
-    <button class="sprk-c-Button" data-id="button-1">
+    <button class="sprk-c-Button" data-id="button-primary">
       Button
     </button>
   `
@@ -13,7 +13,7 @@ export const primary = () => (
 
 export const secondary = () => (
   `
-    <button class="sprk-c-Button sprk-c-Button--secondary" type="button" data-id="button-1">
+    <button class="sprk-c-Button sprk-c-Button--secondary" type="button" data-id="button-secondary">
     Button
     </button>
   `
@@ -21,7 +21,7 @@ export const secondary = () => (
 
 export const tertiary = () => (
   `
-    <button class="sprk-c-Button sprk-c-Button--tertiary" type="button" data-id="button-2">
+    <button class="sprk-c-Button sprk-c-Button--tertiary" type="button" data-id="button-tertiary">
     Button
     </button>
   `
@@ -29,7 +29,7 @@ export const tertiary = () => (
 
 export const disabled = () => (
   `
-  <button class="sprk-c-Button sprk-is-Disabled" data-id="button-1" disabled>
+  <button class="sprk-c-Button sprk-is-Disabled" data-id="button-disabled" disabled>
     Button
   </button>
   `
@@ -37,7 +37,7 @@ export const disabled = () => (
 
 export const spinner = () => (
   `
-  <button class="sprk-c-Button" data-sprk-spinner="click" data-id="button-spinner-1">
+  <button class="sprk-c-Button" data-sprk-spinner="click" data-id="button-spinner">
     <div class="sprk-c-Spinner sprk-c-Spinner--circle"></div>
   </button>
   `
@@ -48,7 +48,7 @@ spinner.story = {
 
 export const fullWidthAtSmallViewport = () => (
   `
-  <button class="sprk-c-Button sprk-c-Button--full@s" type="button" data-id="button-1">
+  <button class="sprk-c-Button sprk-c-Button--full@s" type="button" data-id="button-full-smv">
     Button
   </button>
   `
@@ -59,7 +59,7 @@ fullWidthAtSmallViewport.story = {
 
 export const fullWidthAtExtraSmallViewport = () => (
   `
-  <button class="sprk-c-Button sprk-c-Button--full@xs" type="button" data-id="button-90">
+  <button class="sprk-c-Button sprk-c-Button--full@xs" type="button" data-id="button-full-xsmv">
     Button
   </button>
   `


### PR DESCRIPTION
## What does this PR do?
Make sure button renders in vanilla
![buttons](https://user-images.githubusercontent.com/4342363/66424446-a95c0300-e9db-11e9-967e-2d679754f03c.gif)


### Associated Issue 
Fixes #1795 

### Browser Testing (current version and 1 prior)
Netlify vanilla builds are not set up yet.
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
