### PR TITLE
Add vanilla divider storybook

### DIFF
--- a/spark/components/dividers/react/SprkDivider.stories.js
+++ b/spark/components/dividers/react/SprkDivider.stories.js
@@ -9,11 +9,11 @@ export default {
 export const asASpanElement = () => <SprkDivider idString="divider-1" element="span" />;
 
 asASpanElement.story = {
-  name: 'As A Span Element',
+  name: 'As a <span>',
 };
 
 export const asAHrElement = () => <SprkDivider idString="divider-2" element="hr" />;
 
 asAHrElement.story = {
-  name: 'As A HR Element',
+  name: 'As an <hr>',
 };

--- a/spark/components/dividers/vanilla/dividers.stories.js
+++ b/spark/components/dividers/vanilla/dividers.stories.js
@@ -17,7 +17,7 @@ export const asAHrElement = () => (
   `
     <hr
       class="sprk-c-Divider"
-      data-id="divider-1"
+      data-id="divider-2"
     >
   `
 );

--- a/spark/components/dividers/vanilla/dividers.stories.js
+++ b/spark/components/dividers/vanilla/dividers.stories.js
@@ -1,3 +1,28 @@
 export default {
   title: 'Components|Dividers',
 };
+
+export const asASpanElement = () =>(`
+  <span
+    class="sprk-c-Divider"
+    data-id="divider-1"
+  ></span>
+`);
+
+asASpanElement.story = {
+  name: 'As a <span>',
+};
+
+export const asAHrElement = () => (
+  `
+    <hr
+      class="sprk-c-Divider"
+      data-id="divider-1"
+    >
+  `
+);
+
+asAHrElement.story = {
+  name: 'As an <hr>',
+};
+


### PR DESCRIPTION
## What does this PR do?
- Improve titles of stories
- Add vanilla stories for dividers
![image](https://user-images.githubusercontent.com/4342363/66574537-6a948d00-eb42-11e9-86ff-7d303909e384.png)

### Associated Issue 
Fixes #1797 

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  