### PR TITLE
Add dropdowns to vanilla SB

### DIFF
--- a/spark/components/dropdown/vanilla/dropdown.stories.js
+++ b/spark/components/dropdown/vanilla/dropdown.stories.js
@@ -1,3 +1,141 @@
+import { useEffect } from '@storybook/client-api';
+import { dropdowns } from './dropdown';
+
 export default {
   title: 'Components|Dropdown',
+};
+
+export const defaultDropdown = () => {
+  useEffect(() => {
+    dropdowns();
+  }, []);
+
+  return `
+    <a
+      class="sprk-b-Link sprk-b-Link--plain"
+      href="#nogo"
+      data-sprk-dropdown-trigger="dropdown01"
+      aria-haspopup="true"
+      role="combobox"
+    >
+      <svg class="sprk-c-Icon sprk-u-mls" viewBox="0 0 100 100">
+        <use xlink:href="#settings" />
+      </svg>
+    </a>
+
+    <div
+      class="sprk-c-Dropdown sprk-u-Display--none"
+      data-sprk-dropdown="dropdown01"
+      data-id="dropdown-1"
+    >
+      <div class="sprk-c-Dropdown__header">
+        <h2 class="sprk-c-Dropdown__title">My Choices</h2>
+      </div>
+
+      <ul class="sprk-c-Dropdown__links">
+        <li
+          class="sprk-c-Dropdown__item"
+          role="option"
+        >
+          <a class="sprk-c-Dropdown__link" href="#nogo">
+            Choice 1
+          </a>
+        </li>
+
+        <li
+          class="sprk-c-Dropdown__item"
+          role="option"
+        >
+          <a class="sprk-c-Dropdown__link" href="#nogo">
+            Choice 2
+          </a>
+        </li>
+      </ul>
+    </div>
+  `;
+};
+
+defaultDropdown.story = {
+  name: 'Default',
+};
+
+export const informationalDropdown = () => {
+  useEffect(() => {
+    dropdowns();
+  }, []);
+
+  return `
+    <a
+      class="sprk-b-Link sprk-b-Link--plain sprk-u-mrs"
+      href="#nogo"
+      data-sprk-dropdown-trigger="dropdown02"
+      aria-haspopup="true"
+      data-analytics="object.action.event">
+        <span
+          data-sprk-dropdown-trigger-text-container=""
+          role="combobox">Make a selection...</span>
+        <svg
+          class="sprk-c-Icon sprk-c-Icon--stroke-current-color sprk-u-mls"
+          viewBox="0 0 100 100">
+          <use xlink:href="#chevron-down" />
+        </svg>
+    </a>
+
+    <div
+      class="sprk-c-Dropdown sprk-u-Display--none"
+      data-sprk-dropdown="dropdown02"
+      data-id="dropdown-2"
+    >
+      <div class="sprk-c-Dropdown__header">
+        <h2 class="sprk-c-Dropdown__title sprk-b-TypeBodyTwo">
+          My Choices
+        </h2>
+      </div>
+
+      <ul class="sprk-c-Dropdown__links">
+        <li class="sprk-c-Dropdown__item">
+          <a
+            class="sprk-c-Dropdown__link"
+            href="#nogo" data-sprk-dropdown-choice="Choice Title 1"
+            role="option"
+          >
+            <p class="sprk-b-TypeBodyOne">
+              Choice Title
+            </p>
+
+            <p class="sprk-b-TypeBodyTwo">
+              Information about this choice
+            </p>
+
+            <p class="sprk-b-TypeBodyTwo">
+              More information
+            </p>
+          </a>
+        </li>
+
+        <li
+          class="sprk-c-Dropdown__item"
+          data-sprk-dropdown-choice="Choice Title 2"
+        >
+          <a class="sprk-c-Dropdown__link" href="#nogo" role="option">
+            <p class="sprk-b-TypeBodyOne">Choice Title</p>
+            <p class="sprk-b-TypeBodyTwo">Information about this choice</p>
+            <p class="sprk-b-TypeBodyTwo">More information</p>
+          </a>
+        </li>
+      </ul>
+
+      <div
+        class="sprk-c-Dropdown__footer sprk-u-TextAlign--center"
+      >
+        <a class="sprk-c-Button sprk-c-Button--tertiary" href="#nogo">
+          Go Elsewhere
+        </a>
+      </div>
+    </div>
+  `;
+};
+
+informationalDropdown.story = {
+  name: 'Informational',
 };


### PR DESCRIPTION
## What does this PR do?
Adds the dropdowns to vanilla SB. While doing this, I may have found a bug in the dropdowns.js for vanilla and I logged it here: https://github.com/sparkdesignsystem/spark-design-system/issues/2158 - The bug was caught because in SB Vanilla, when you click on the dropdown trigger, it opens a new page. So dropdowns in SB Vanilla will do that until we discuss the bug #2158 and implement a preventDefault in there or we do something extra for vanilla SB.

### Associated Issue 
Fixes #1799 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Code
 - [x] Build Component in Spark Vanilla SB (Sass, HTML, JS)
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)

### Accessibility
- [ ] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)
 --- I didn't make any HTML changes to the component but in putting it into SB I noticed that the accessibility checks had 5 - 6 violations for this. I logged a bug so that we can look into this: https://github.com/sparkdesignsystem/spark-design-system/issues/2159

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)