### PR TITLE
Add missing vanilla polyfills to components that need them in SB

### DIFF
--- a/spark/components/accordions/vanilla/accordions.stories.js
+++ b/spark/components/accordions/vanilla/accordions.stories.js
@@ -1,5 +1,6 @@
 import { useEffect } from '@storybook/client-api';
 import { toggle } from '../../toggle/vanilla/toggle';
+import '../../../utilities/polyfills/vanilla/classListSVG';
 
 export default {
   title: 'Components|Accordion',

--- a/spark/components/footer/vanilla/footer.stories.js
+++ b/spark/components/footer/vanilla/footer.stories.js
@@ -1,5 +1,6 @@
 import { useEffect } from '@storybook/client-api';
 import { toggle } from '../../toggle/vanilla/toggle';
+import '../../../utilities/polyfills/vanilla/classListSVG';
 
 export default {
   title: 'Components|Footer',


### PR DESCRIPTION
## What does this PR do?
Add missing vanilla polyfill imports to components that need them in SB.

### Associated Issue 
There isn't an issue, doing to this to fix issues that were created from merging in Footer.

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.
### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)