### PR TITLE
add spinning to sprk-button.directive

### DIFF
--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
@@ -6,6 +6,7 @@ import { SprkButtonDirective } from './sprk-button.directive';
   selector: 'sprk-test',
   template: `
     <button sprkButton></button>
+    <button sprkButton [isSpinning]="true"></button>
   `
 })
 class TestComponent {}
@@ -14,6 +15,7 @@ describe('Spark Button Directive', () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
   let button1Element: HTMLElement;
+  let button2Element: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -25,9 +27,14 @@ describe('Spark Button Directive', () => {
 
     fixture.detectChanges();
     button1Element = fixture.nativeElement.querySelectorAll('button')[0];
+    button2Element = fixture.nativeElement.querySelectorAll('button')[1];
   }));
 
   it('should create itself', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should contain a spinner if isSpinning is true', () => {
+    expect(button2Element.querySelectorAll('.sprk-c-Spinner').length).toBe(1);
   });
 });

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.ts
@@ -1,10 +1,12 @@
-import { Directive, ElementRef, OnInit } from '@angular/core';
+import { Directive, ElementRef, OnInit, Input } from '@angular/core';
 
 @Directive({
   selector: '[sprkButton]'
 })
 export class SprkButtonDirective implements OnInit {
   constructor(public ref: ElementRef) {}
+
+  @Input() isSpinning = false;
 
   getClasses(): string[] {
     const classArray: string[] = [];
@@ -16,5 +18,17 @@ export class SprkButtonDirective implements OnInit {
     this.getClasses().forEach(item => {
       this.ref.nativeElement.classList.add(item);
     });
+    if (this.isSpinning) {
+      this.setSpinning(this.ref.nativeElement);
+    }
+  }
+
+  setSpinning = (element) => {
+    const el = element;
+    const width = element.offsetWidth;
+    el.setAttribute('data-sprk-spinner-text', el.textContent);
+    el.innerHTML = `<div class="sprk-c-Spinner sprk-c-Spinner--circle"></div>`;
+    el.setAttribute('data-sprk-has-spinner', 'true');
+    el.setAttribute('style', `width: ${width}px`);
   }
 }

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
@@ -17,3 +17,16 @@ export const primary = () => ({
     </button>
   `,
 });
+
+export const spinning = () => ({
+  moduleMetadata: modules,
+  template: `
+    <button
+      data-id="button-1"
+      sprkButton
+      [isSpinning]="true"
+    >
+      Button
+    </button>
+  `,
+});


### PR DESCRIPTION
## What does this PR do?
Adds isSpinning to the sprk-button directive, when true, uses a ref to inject 
a sprk spinner into the element.

### Associated Issue 
#2197 

### Code
 - [x] Build Component in Spark Angular
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)