### PR TITLE
Exclude test files from NPM packages

### DIFF
--- a/packages/spark/.npmignore
+++ b/packages/spark/.npmignore
@@ -1,1 +1,3 @@
 .nyc_output/
+tests/
+*.test.js


### PR DESCRIPTION
## What does this PR do?
Update .npmignore files to keep test files out of the NPM bundle. In the spirit of https://gist.github.com/greim/e8e1bd3b1ed08a7505ce

### Associated Issue 
Fixes (Issue Number that this PR is closing out)

### Design Review
 - [ ] Design reviewed and approved

