### PR TITLE
remove subHeading from highlight board docs

### DIFF
--- a/src/patterns/components/highlight-board/angular/code/no-image.hbs
+++ b/src/patterns/components/highlight-board/angular/code/no-image.hbs
@@ -1,6 +1,5 @@
 <sprk-highlight-board
   heading="Lift the burden of getting a home loan"
-  subHeading="Fast, Powerful and Completely Online"
   ctaText="Learn More"
   type="noImage"
   idString="highlightboard-3">

--- a/src/patterns/components/highlight-board/angular/code/stacked.hbs
+++ b/src/patterns/components/highlight-board/angular/code/stacked.hbs
@@ -1,6 +1,5 @@
 <sprk-highlight-board
   heading="Lift the burden of getting a home loan"
-  subHeading="Fast, Powerful and Completely Online"
   ctaText="Learn More"
   type="stacked"
   imgSrc="https://staging.sparkdesignsystem.com/assets/toolkit/images/desktop.jpg"

--- a/src/patterns/components/highlight-board/angular/info/default.hbs
+++ b/src/patterns/components/highlight-board/angular/info/default.hbs
@@ -47,21 +47,6 @@
 
     <tr>
       <td class="sprk-u-FontWeight--bold">
-        subHeading
-      </td>
-
-      <td>
-        string
-      </td>
-
-      <td>
-        The value supplied will be rendered
-        as the sub-heading.
-      </td>
-    </tr>
-
-    <tr>
-      <td class="sprk-u-FontWeight--bold">
         analyticsStringCta
       </td>
 


### PR DESCRIPTION
## What does this PR do?
Removed "subHeading" from the Angular docs for Highlight Board.

### Associated Issue 
Fixes #1742 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs Angular
 - [x] Update Component Sass Var/Class Modifier table