### PR TITLE
fix spark-react test errors by adding react component proptype

### DIFF
--- a/react/src/base/links/SprkLink.js
+++ b/react/src/base/links/SprkLink.js
@@ -90,7 +90,11 @@ SprkLink.propTypes = {
   /** The href value for the link. */
   href: PropTypes.string,
   /** The element that will be rendered. */
-  element: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  element: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.elementType
+  ]),
   /** The event that will fire when the element is clicked. */
   onClick: PropTypes.func,
 };

--- a/react/src/components/card/components/SprkCardTeaser/SprkCardTeaser.js
+++ b/react/src/components/card/components/SprkCardTeaser/SprkCardTeaser.js
@@ -207,7 +207,11 @@ SprkCardTeaser.propTypes = {
       additionalCtaIconClasses: PropTypes.string,
       ctaAnalytics: PropTypes.string,
       ctaIcon: PropTypes.string,
-      ctaLinkElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      ctaLinkElement: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.elementType
+      ]),
       ctaVariant: PropTypes.oneOf(['link', 'button']),
       href: PropTypes.string,
       text: PropTypes.string,
@@ -215,7 +219,11 @@ SprkCardTeaser.propTypes = {
     media: PropTypes.shape({
       additionalMediaIconClasses: PropTypes.string,
       href: PropTypes.string,
-      mediaLinkElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+      mediaLinkElement: PropTypes.oneOfType([
+        PropTypes.string,
+        PropTypes.func,
+        PropTypes.elementType
+      ]),
       iconName: PropTypes.string,
       imgAlt: PropTypes.string,
       imgSrc: PropTypes.string,

--- a/react/src/components/masthead/SprkMasthead.js
+++ b/react/src/components/masthead/SprkMasthead.js
@@ -323,7 +323,11 @@ SprkMasthead.propTypes = {
   /** The href to render for the logo link. */
   logoLink: PropTypes.string,
   /** The element link element to render for the logo. */
-  logoLinkElement: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+  logoLinkElement: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.func,
+    PropTypes.elementType
+  ]),
   /** Expects a component to render the nav link. */
   navLink: PropTypes.node,
 };


### PR DESCRIPTION
## What does this PR do?
We have been getting react test errors/warnings since the new docs site started. See below screenshot. I fixed this by researching and discovering a newer proptype that we should use going forward when we have a prop that can be of type react component. I left the old proptype values and added the new one. Leaving the old ones for now ensures that we don't have a breaking change. see: …https://github.com/facebook/prop-types/pull/211 for more info
![Screen Shot 2019-10-28 at 8 27 55 AM](https://user-images.githubusercontent.com/2117593/67678495-20424700-f95d-11e9-80ff-eaf6d071ea01.png)


### Associated Issue 
Fixes #2238
This involves our react package and will be good to update that in the release notes when we launch that we added an additional proptype option of PropTypes.elementType to SprkLinks (element), SprkCardTeaser (ctaLinkElement, mediaLinkElement) and SprkMasthead (logoLinkElement).

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] No documentation changes needed because proptype documentation in react is autogenerated in the SB apart of NDS and these changes are apart of that.

### Code
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)