### PR TITLE
Add highlight board components

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -284,7 +284,6 @@ export const fourUp = () => ({
          media="img"
          idString="card-four-up-1"
          imgSrc="https://spark-assets.netlify.com/desktop.jpg"
-         imgSrc="https://spark-assets.netlify.com/desktop.jpg"
          body="This Lorem ipsum dolor sit amet, doctus invenire vix te.
            Facilisi perpetua an pri, errem commune mea at, mei prima
            tantas signiferumque at. Numquam."

--- a/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
@@ -1,0 +1,81 @@
+import { storyWrapper } from '../../../../../../.storybook/helpers/storyWrapper';
+import { SprkHighlightBoardModule } from './sprk-highlight-board.module';
+import { SprkHighlightBoardComponent } from './sprk-highlight-board.component';
+import { RouterModule } from '@angular/router';
+import { APP_BASE_HREF } from '@angular/common';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+
+export default {
+  title: 'Components|Highlight Board',
+  component: SprkHighlightBoardModule,
+  decorators: [
+    storyWrapper(
+      storyContent => (
+        `<div class="sprk-o-Box">${ storyContent }<div>`
+      )
+    )
+  ]
+};
+
+const modules = {
+  imports: [
+    SprkHighlightBoardModule,
+    RouterModule.forRoot([{
+      path: 'iframe.html',
+      component: SprkHighlightBoardComponent,
+    }]),
+    BrowserAnimationsModule,
+  ],
+  providers: [{ provide: APP_BASE_HREF, useValue: '/' }]
+};
+
+export const defaultStory = () => ({
+  moduleMetadata: modules,
+  template: `
+    <sprk-highlight-board
+      heading="Hello, Welcome To Spark Design System"
+      ctaText="Designers"
+      ctaHref="https://sparkdesignsystem.com/"
+      ctaText2="Developers"
+      ctaHref2="https://sparkdesignsystem.com/"
+      imgSrc="https://spark-assets.netlify.com/desktop.jpg"
+      imgAlt="placeholder"
+      idString="highlightboard-1"
+    >
+    </sprk-highlight-board>
+  `,
+});
+
+defaultStory.story = {
+  name: 'Default'
+};
+
+export const noImage = () => ({
+  moduleMetadata: modules,
+  template: `
+    <sprk-highlight-board
+      heading="Highlight Board Heading Example"
+      ctaText="Learn More"
+      ctaText2="Learn More"
+      type="noImage"
+      idString="highlightboard-3"
+    >
+    </sprk-highlight-board>
+  `,
+});
+
+export const stacked = () => ({
+  moduleMetadata: modules,
+  template: `
+    <sprk-highlight-board
+      heading="Highlight Board Heading Example"
+      ctaText="Learn More"
+      type="stacked"
+      imgSrc="https://staging.sparkdesignsystem.com/assets/toolkit/images/desktop.jpg"
+      imgAlt="placeholder"
+      idString="highlightboard-4"
+    >
+    </sprk-highlight-board>
+  `,
+});
+

--- a/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
@@ -3,7 +3,6 @@ import { SprkHighlightBoardModule } from './sprk-highlight-board.module';
 import { SprkHighlightBoardComponent } from './sprk-highlight-board.component';
 import { RouterModule } from '@angular/router';
 import { APP_BASE_HREF } from '@angular/common';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 export default {
   title: 'Components|Highlight Board',
@@ -24,7 +23,6 @@ const modules = {
       path: 'iframe.html',
       component: SprkHighlightBoardComponent,
     }]),
-    BrowserAnimationsModule,
   ],
   providers: [{ provide: APP_BASE_HREF, useValue: '/' }]
 };
@@ -71,7 +69,7 @@ export const stacked = () => ({
       heading="Highlight Board Heading Example"
       ctaText="Learn More"
       type="stacked"
-      imgSrc="https://staging.sparkdesignsystem.com/assets/toolkit/images/desktop.jpg"
+      imgSrc="https://spark-assets.netlify.com/desktop.jpg"
       imgAlt="placeholder"
       idString="highlightboard-4"
     >


### PR DESCRIPTION
## What does this PR do?
Adds highlight board for sb
fixes duplicate imgSrc in card
![image](https://user-images.githubusercontent.com/4342363/67882244-54159c00-fb18-11e9-994f-520124d9dee5.png)

### Associated Issue 
Fixes #1872 

### Code
 - [x] Build Component in Spark Angular
 - [x] Unit Testing in Spark Angular with `gulp test-angular` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)