### PR TITLE
removed sprk-accordion-border-open variable

### DIFF
--- a/src/patterns/components/accordions/collection.yaml
+++ b/src/patterns/components/accordions/collection.yaml
@@ -17,9 +17,6 @@ variableTable:
   $sprk-accordion-border:
     default: 1px solid $sprk-black-tint-25
     description: Sets the border used in the accordion.
-  $sprk-accordion-border-open:
-    default: 1px solid $sprk-black
-    description: Sets the border used in the accordion items when they are open.
   $sprk-accordion-summary-color:
     default: $sprk-black
     description: Sets the font color of the item summary.


### PR DESCRIPTION
## What does this PR do?
Removes `$sprk-accordion-border-open` variable from the accordion docs

### Associated Issue 
Fixes #2233 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Component Sass Var/Class Modifier table