### PR TITLE
Fix Huge Text Input Default Value on IE/Edge - React

### DIFF
--- a/react/src/base/inputs/SprkInput.stories.js
+++ b/react/src/base/inputs/SprkInput.stories.js
@@ -55,6 +55,27 @@ hugeTextInput.story = {
   },
 };
 
+export const hugeTextInputWithDefaultValue = () => (
+  <SprkTextInput
+    type="hugeTextInput"
+    label={text('label', 'Text Input Label')}
+    name="text-input-label"
+    valid={boolean('valid', true)}
+    disabled={boolean('disabled', false)}
+    placeholder="Huge Text Placeholder"
+    errorMessage="There is an error on this field."
+    defaultValue="Default Value"
+  />
+);
+
+hugeTextInputWithDefaultValue.story = {
+  parameters: {
+    jest: [
+      'SprkTextInput',
+    ]
+  },
+};
+
 export const checkbox = () => (
   <SprkSelectionInput
     groupLabel="Checkbox Input"

--- a/react/src/base/inputs/SprkTextInput/SprkTextInput.js
+++ b/react/src/base/inputs/SprkTextInput/SprkTextInput.js
@@ -5,7 +5,7 @@ import uniqueId from 'lodash/uniqueId';
 import SprkErrorContainer from '../SprkErrorContainer/SprkErrorContainer';
 import SprkInputIconCheck from '../components/SprkInputIconCheck/SprkInputIconCheck';
 import SprkLabelLocationCheck from '../components/SprkLabelLocationCheck/SprkLabelLocationCheck';
-import SprkTextAreaCheck from '../components/SprkTextareaCheck/SprkTextareaCheck';
+import SprkInputElement from '../components/SprkInputElement/SprkInputElement';
 
 class SprkTextInput extends Component {
   constructor(props) {
@@ -60,7 +60,7 @@ class SprkTextInput extends Component {
             id={id}
             disabled={disabled}
           >
-            <SprkTextAreaCheck
+            <SprkInputElement
               id={id}
               analyticsString={analyticsString}
               idString={idString}

--- a/react/src/base/inputs/SprkTextInput/SprkTextInput.test.js
+++ b/react/src/base/inputs/SprkTextInput/SprkTextInput.test.js
@@ -63,6 +63,20 @@ it('should add floating label class to huge text when there is value', () => {
   ).toBe(true);
 });
 
+it('should add floating label class to huge text when there is defaultValue', () => {
+  const wrapper = mount(
+    <SprkTextInput
+      defaultValue="default Value"
+      type="hugeTextInput"
+    />,
+  );
+  expect(
+    wrapper
+      .find('.sprk-b-TextInput')
+      .hasClass('sprk-b-Input--has-floating-label'),
+  ).toBe(true);
+});
+
 it('should add classes when additionalClasses has a value', () => {
   const wrapper = mount(<SprkTextInput additionalClasses="sprk-u-man" />);
   expect(wrapper.find('.sprk-b-InputContainer.sprk-u-man').length).toBe(1);

--- a/react/src/base/inputs/components/SprkInputElement/SprkInputElement.js
+++ b/react/src/base/inputs/components/SprkInputElement/SprkInputElement.js
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import classNames from 'classnames';
 import propTypes from 'prop-types';
 
-class SprkTextareaCheck extends Component {
+class SprkInputElement extends Component {
   constructor(props) {
     const { value } = props;
     const { defaultValue } = props;
@@ -84,7 +84,7 @@ class SprkTextareaCheck extends Component {
   }
 }
 
-SprkTextareaCheck.propTypes = {
+SprkInputElement.propTypes = {
   analyticsString: propTypes.string,
   errorContainerId: propTypes.string,
   formatter: propTypes.func,
@@ -97,4 +97,4 @@ SprkTextareaCheck.propTypes = {
   valid: propTypes.bool,
 };
 
-export default SprkTextareaCheck;
+export default SprkInputElement;

--- a/react/src/base/inputs/components/SprkTextareaCheck/SprkTextareaCheck.js
+++ b/react/src/base/inputs/components/SprkTextareaCheck/SprkTextareaCheck.js
@@ -5,11 +5,14 @@ import propTypes from 'prop-types';
 class SprkTextareaCheck extends Component {
   constructor(props) {
     const { value } = props;
+    const { defaultValue } = props;
     super(props);
 
-    this.state = {
-      hasValue: value,
-    };
+    if( value || defaultValue ) {
+      this.state = {
+        hasValue: true,
+      };
+    }
   }
 
   render() {

--- a/react/src/base/inputs/components/SprkTextareaCheck/SprkTextareaCheck.js
+++ b/react/src/base/inputs/components/SprkTextareaCheck/SprkTextareaCheck.js
@@ -12,6 +12,10 @@ class SprkTextareaCheck extends Component {
       this.state = {
         hasValue: true,
       };
+    } else {
+      this.state = {
+        hasValue: false,
+      };
     }
   }
 


### PR DESCRIPTION
## What does this PR do?
Adds logic to manage the hasValue state to add the necessary class when there is a default value provided in the Huge Text Input component - React

Discussion about whether this should happen in the SprkTextareaCheck or not occurred after Bob worked on this PR - 
https://github.com/sparkdesignsystem/spark-design-system/pull/2099

If I remember correctly, needs to be managed in SprkTextareaCheck because there is already a ref being passed by the SprkTextInput and couldn't create another one.

### Associated Issue 
Fixes #2096 

### Documentation
 - [x] Update Spark Docs React

### Code
 - [x] Build Component in Spark React
 - [x] Unit Testing in Spark React with `gulp test-react` (100% coverage, 100% passing)
![image](https://user-images.githubusercontent.com/15703773/68028882-54cf3f00-fc8c-11e9-9c6c-14dd31367822.png)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots
![image](https://user-images.githubusercontent.com/15703773/67977930-657da780-fbef-11e9-923a-623fc23a179c.png)
