### PR TITLE
select placeholder elements by extra decorator class for layout placeholder styles

### DIFF
--- a/html/components/centered-column.stories.js
+++ b/html/components/centered-column.stories.js
@@ -7,7 +7,9 @@ export default {
   ],
 };
 
-export const defaultStory = () => ('<div class="sprk-o-CenteredColumn"></div>');
+export const defaultStory = () => (
+  '<div class="sprk-o-CenteredColumn" data-id="centered-column"></div>'
+);
 
 defaultStory.story = {
   name: 'Default',

--- a/html/components/centered-column.stories.js
+++ b/html/components/centered-column.stories.js
@@ -2,13 +2,13 @@ export default {
   title: 'Components|Centered Column',
   decorators: [
     story => `
-      <div class="sprk-o-Box">${story()}</div>
+      <div class="sprk-o-Box sb-decorate">${story()}</div>
     `,
   ],
 };
 
 export const defaultStory = () => (
-  '<div class="sprk-o-CenteredColumn" data-id="centered-column"></div>'
+  '<div class="sprk-o-CenteredColumn"></div>'
 );
 
 defaultStory.story = {

--- a/storybook-theming/_docs.scss
+++ b/storybook-theming/_docs.scss
@@ -109,7 +109,7 @@ body {
   margin-bottom: $sprk-space-m;
 }
 
-.sb-show-main .sprk-o-CenteredColumn {
+.sb-show-main [data-id="centered-column"] {
   background-color: $sprk-gray-dark;
   height: 4rem;
 }

--- a/storybook-theming/_docs.scss
+++ b/storybook-theming/_docs.scss
@@ -109,7 +109,8 @@ body {
   margin-bottom: $sprk-space-m;
 }
 
-.sb-show-main [data-id="centered-column"] {
+.sb-show-main .sb-decorate .sprk-o-CenteredColumn,
+.sb-show-main .sb-decorate .sprk-o-Box {
   background-color: $sprk-gray-dark;
   height: 4rem;
 }


### PR DESCRIPTION
## What does this PR do?
Select placeholder elements by extra decorator class for layout placeholder styles This is better because the old method causes unexpected placeholder styles on any components that use the spark layout classes.

### Associated Issue 
no issue, this is a follow up to the previous pr for adding the centered column layout

## Please check off completed items as you work.

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)
### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
