### PR TITLE
tweak iframe heights in sb docs

### DIFF
--- a/angular/.storybook/config.js
+++ b/angular/.storybook/config.js
@@ -4,7 +4,7 @@ import sparkTheme from "../../storybook-theming/storybook-spark-theme";
 import '../src/polyfills';
 import '!style-loader!css-loader!sass-loader!../../storybook-theming/font-loader.scss';
 import '../../storybook-theming/icon-loader';
-import { setCompodocJson } from '@storybook/addon-docs/angular';
+import { setCompodocJson, extractComponentDescription, extractProps } from '@storybook/addon-docs/angular';
 import docJson from '../documentation.json';
 
 setCompodocJson(docJson);
@@ -25,6 +25,7 @@ addParameters({
       }
       return null;
     },
+    extractProps,
   },
 });
 

--- a/angular/.storybook/config.js
+++ b/angular/.storybook/config.js
@@ -4,7 +4,7 @@ import sparkTheme from "../../storybook-theming/storybook-spark-theme";
 import '../src/polyfills';
 import '!style-loader!css-loader!sass-loader!../../storybook-theming/font-loader.scss';
 import '../../storybook-theming/icon-loader';
-import { setCompodocJson, extractComponentDescription, extractProps } from '@storybook/addon-docs/angular';
+import { setCompodocJson, extractProps } from '@storybook/addon-docs/angular';
 import docJson from '../documentation.json';
 
 setCompodocJson(docJson);

--- a/angular/projects/spark-angular/src/lib/components/inputs/sprk-input.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/sprk-input.stories.ts
@@ -43,8 +43,9 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
-  },
-};
+    docs: { iframeHeight: 200 },
+  }
+}
 
 const modules = {
   imports: [
@@ -656,3 +657,9 @@ export const datePicker = () => ({
     </sprk-icon-input-container>
   `,
 });
+
+datePicker.story = {
+  parameters: {
+    docs: { iframeHeight: 400 },
+  }
+};

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
@@ -20,6 +20,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/accordion)
     `,
+    docs: { iframeHeight: 420 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-alert/sprk-alert.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-alert/sprk-alert.stories.ts
@@ -16,6 +16,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/alert)
     `,
+    docs: { iframeHeight: 120 },
   },
 };
 
@@ -62,6 +63,12 @@ export const fail = () => ({
     </sprk-alert>
   `
 });
+
+fail.story = {
+  parameters: {
+    docs: { iframeHeight: 235 },
+  },
+}
 
 export const withNoDismissButton = () => ({
   moduleMetadata: modules,

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.stories.ts
@@ -19,6 +19,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/award)
     `,
+    docs: { iframeHeight: 400 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -20,6 +20,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/card)
     `,
+    docs: { iframeHeight: 200 },
   },
 };
 
@@ -56,6 +57,9 @@ export const defaultStory = () => ({
 
 defaultStory.story = {
   name: 'Default',
+  parameters: {
+    docs: { iframeHeight: 150 },
+  },
 };
 
 export const standout = () => ({
@@ -122,7 +126,10 @@ export const highlightedHeader = () => ({
 });
 
 highlightedHeader.story = {
-  name: 'Highlighted Header'
+  name: 'Highlighted Header',
+  parameters: {
+    docs: { iframeHeight: 300 },
+  },
 };
 
 export const teaser = () => ({
@@ -148,6 +155,9 @@ export const teaser = () => ({
 
 teaser.story = {
   name: 'Teaser',
+  parameters: {
+    docs: { iframeHeight: 500 },
+  },
 };
 
 export const twoUp = () => ({
@@ -200,6 +210,9 @@ export const twoUp = () => ({
 
 twoUp.story = {
   name: 'Card Layout - Two Up',
+  parameters: {
+    docs: { iframeHeight: 600 },
+  },
 };
 
 export const threeUp = () => ({
@@ -269,7 +282,10 @@ export const threeUp = () => ({
 });
 
 threeUp.story = {
-  name: 'Card Layout - Three Up'
+  name: 'Card Layout - Three Up',
+  parameters: {
+    docs: { iframeHeight: 600 },
+  },
 };
 
 export const fourUp = () => ({
@@ -358,4 +374,7 @@ export const fourUp = () => ({
 
 fourUp.story = {
   name: 'Card Layout - Four Up',
+  parameters: {
+    docs: { iframeHeight: 600 },
+  },
 };

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.stories.ts
@@ -16,6 +16,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/dictionary)
     `,
+    docs: { iframeHeight: 500 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-divider/sprk-divider.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-divider/sprk-divider.stories.ts
@@ -16,6 +16,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/divider)
     `,
+    docs: { iframeHeight: 60 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.stories.ts
@@ -18,6 +18,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/dropdown)
     `,
+    docs: { iframeHeight: 200 },
   },
 };
 
@@ -95,3 +96,9 @@ export const informational = () => ({
     </sprk-dropdown>
   `
 });
+
+informational.story = {
+  parameters: {
+    docs: { iframeHeight: 400 },
+  },
+}

--- a/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.component.ts
@@ -264,6 +264,16 @@ export class SprkFooterComponent {
   connectHeading: string;
   /**
    * Array of objects to build the links in the "Global" section.
+   * @code `cats`
+   * @code `
+     globalLinks = [{
+        text: 'Lorem ipsum dolor sit amet, consectetur.',
+        href: '/global-1',
+        icon: 'auto-loans',
+        iconCSS: 'sprk-c-Icon--xl sprk-c-Icon--stroke-current-color',
+        analytics: 'link-1',
+        iconScreenReaderText: 'cats'
+      }]`
    */
   @Input()
   globalLinks: object[];

--- a/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.component.ts
@@ -264,16 +264,6 @@ export class SprkFooterComponent {
   connectHeading: string;
   /**
    * Array of objects to build the links in the "Global" section.
-   * @code `cats`
-   * @code `
-     globalLinks = [{
-        text: 'Lorem ipsum dolor sit amet, consectetur.',
-        href: '/global-1',
-        icon: 'auto-loans',
-        iconCSS: 'sprk-c-Icon--xl sprk-c-Icon--stroke-current-color',
-        analytics: 'link-1',
-        iconScreenReaderText: 'cats'
-      }]`
    */
   @Input()
   globalLinks: object[];

--- a/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.stories.ts
@@ -19,6 +19,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/footer)
     `,
+    docs: { iframeHeight: 800 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
@@ -18,6 +18,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/highlight-board)
     `,
+    docs: { iframeHeight: 600 },
   },
 };
 
@@ -67,6 +68,12 @@ export const noImage = () => ({
   `,
 });
 
+noImage.story = {
+  parameters: {
+    docs: { iframeHeight: 300 },
+  }
+};
+
 export const stacked = () => ({
   moduleMetadata: modules,
   template: `
@@ -81,4 +88,10 @@ export const stacked = () => ({
     </sprk-highlight-board>
   `,
 });
+
+stacked.story = {
+  parameters: {
+    docs: { iframeHeight: 800 },
+  }
+}
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.stories.ts
@@ -16,6 +16,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/icon)
     `,
+    docs: { iframeHeight: 90 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.stories.ts
@@ -19,6 +19,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/link)
     `,
+    docs: { iframeHeight: 60 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -21,6 +21,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/masthead)
     `,
+    docs: { iframeHeight: 300 },
   },
 };
 
@@ -687,3 +688,9 @@ export const extended = () => ({
     ],
   },
 });
+
+extended.story = {
+  parameters: {
+    docs: { iframeHeight: 450 },
+  },
+}

--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
@@ -16,6 +16,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/modal)
     `,
+    docs: { iframeHeight: 450 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-ordered-list/sprk-list.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-ordered-list/sprk-list.stories.ts
@@ -14,6 +14,12 @@ export default {
       )
     )
   ],
+  parameters: {
+    info: `
+  ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/list)
+    `,
+    docs: { iframeHeight: 100 },
+  },
 };
 
 const modules = {

--- a/angular/projects/spark-angular/src/lib/components/sprk-pagination/sprk-pagination.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-pagination/sprk-pagination.stories.ts
@@ -18,6 +18,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/pagination)
     `,
+    docs: { iframeHeight: 70 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-promo/sprk-promo.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-promo/sprk-promo.stories.ts
@@ -18,6 +18,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/promo)
     `,
+    docs: { iframeHeight: 430 },
   },
 };
 
@@ -70,6 +71,12 @@ export const flag = () => ({
     </sprk-promo>
   `,
 });
+
+flag.story = {
+  parameters: {
+    docs: { iframeHeight: 300 },
+  },
+}
 
 export const withImage = () => ({
   moduleMetadata: modules,

--- a/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.stories.ts
@@ -17,6 +17,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/stack)
     `,
+    docs: { iframeHeight: 180 },
   },
 };
 
@@ -415,4 +416,7 @@ export const stackSplitLayoutMixed = () => ({
 
 stackSplitLayoutMixed.story = {
   name: 'Stack/Split - Mixed',
+  parameters: {
+    docs: { iframeHeight: 400 },
+  },
 };

--- a/angular/projects/spark-angular/src/lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tabbed-navigation/sprk-tabbed-navigation.stories.ts
@@ -23,6 +23,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/tabs)
     `,
+    docs: { iframeHeight: 300 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-table/sprk-table.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-table/sprk-table.stories.ts
@@ -16,6 +16,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/table)
     `,
+    docs: { iframeHeight: 380 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.stories.ts
@@ -19,6 +19,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/toggle)
     `,
+    docs: { iframeHeight: 160 },
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
@@ -16,6 +16,7 @@ export default {
     info: `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/button)
     `,
+    docs: { iframeHeight: 100 },
   },
  };
 

--- a/storybook-theming/_docs.scss
+++ b/storybook-theming/_docs.scss
@@ -117,3 +117,7 @@ body {
   border: 2px solid $sprk-black;
   height: 4rem;
 }
+
+.sbdocs.sbdocs-content {
+  max-width: $sprk-centered-column-width;
+}


### PR DESCRIPTION
## What does this PR do?
Tweak iframe heights in sb docs. This is in the angular SB. Also extended the max-width of the center column in the storybook docs pane.


### Associated Issue 
no issue yet

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Code
 - [x] update sb code

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
