### PR TITLE
Add sassdoc comments to button, card, dictionary and dropdown

### DIFF
--- a/html/components/_buttons.scss
+++ b/html/components/_buttons.scss
@@ -47,7 +47,7 @@
 
 
 /// Reduces the padding of the normal button
-/// to $space-inset-short-m
+/// to $space-inset-short-m.
 .sprk-c-Button--compact {
   padding: $sprk-space-inset-short-m;
 }
@@ -63,6 +63,9 @@
   }
 }
 
+/// Makes the button full width of its parent container until it flips
+/// to normal width at the $sprk-btn-breakpoint-s breakpoint.
+/// @name .sprk-c-Button--full@s
 .sprk-c-Button--full\@sm,
 .sprk-c-Button--full\@s {
   width: 100%;
@@ -72,6 +75,7 @@
   }
 }
 
+/// Styles the button as the secondary variant.
 .sprk-c-Button--secondary {
   background-color: $sprk-btn-secondary-background-color;
   border: $sprk-btn-border-width $sprk-btn-border-style
@@ -94,6 +98,7 @@
   }
 }
 
+/// Styles the button as the tertiary variant.
 .sprk-c-Button--tertiary {
   background-color: $sprk-btn-tertiary-background-color;
   box-shadow: none;

--- a/html/components/_card.scss
+++ b/html/components/_card.scss
@@ -17,7 +17,6 @@
 }
 
 /// Use on cards that you would like to standout from the rest.
-/// @name .sprk-c-Card--standout
 .sprk-c-Card--standout {
   box-shadow: $sprk-card-shadow-standout;
 
@@ -82,6 +81,9 @@
   }
 }
 
+/// Sets `max-width` to 100%, allowing card to fill
+/// the entire width of it's container. Best used
+/// with base cards.
 .sprk-c-Card--full {
   max-width: 100%;
 }

--- a/html/components/_dictionary.scss
+++ b/html/components/_dictionary.scss
@@ -2,6 +2,10 @@
 // Dictionary
 // ==================================================================
 
+////
+/// @group dictionary
+////
+
 .sprk-c-Dictionary {
   border: $sprk-dictionary-border;
 }
@@ -22,6 +26,10 @@
   line-height: $sprk-dictionary-label-line-height;
   font-weight: $sprk-dictionary-label-font-weight;
 }
+
+/// Adds a background color to every
+/// even-numbered row in the dictionary.
+/// @name .sprk-c-Dictionary--striped
 
 // prettier-ignore
 .sprk-c-Dictionary--striped .sprk-c-Dictionary__keyvaluepair:nth-child(even) {

--- a/html/components/_dropdown.scss
+++ b/html/components/_dropdown.scss
@@ -1,6 +1,11 @@
 // ==================================================================
 // Dropdown
 // ==================================================================
+
+////
+/// @group dropdown
+////
+
 .sprk-c-Dropdown {
   background-color: $sprk-white;
   border: $sprk-dropdown-border;
@@ -64,6 +69,8 @@
   }
 }
 
+/// Adds styles to indicate that the dropdown
+/// link is currently active. 
 .sprk-c-Dropdown__link--active {
   box-shadow: $sprk-dropdown-active-box-shadow;
   border-left: $sprk-dropdown-active-border;


### PR DESCRIPTION
## What does this PR do?
Adds comments to the scss files for button, card, dictionary and dropdown.

### Associated Issue 
Fixes #2414 

### Documentation
 - [x] Update Component Sass Var/Class Modifier table

### Screenshots

![image](https://user-images.githubusercontent.com/15703773/71270745-57f7ba80-2320-11ea-991e-c78bc1dcd2af.png)
![image](https://user-images.githubusercontent.com/15703773/71270750-5af2ab00-2320-11ea-96de-6ad704cad7a0.png)
![image](https://user-images.githubusercontent.com/15703773/71270757-5cbc6e80-2320-11ea-94f0-0fc078e89936.png)
![image](https://user-images.githubusercontent.com/15703773/71270761-5f1ec880-2320-11ea-85c9-601def284eb3.png)
