### PR TITLE
Prevent Dropdown from navigating away - Vanilla

### DIFF
--- a/html/components/dropdown.js
+++ b/html/components/dropdown.js
@@ -38,7 +38,8 @@ const bindUIEvents = (dropdownTrigger) => {
     '[data-sprk-dropdown-choice]',
   );
 
-  dropdownTrigger.addEventListener('click', () => {
+  dropdownTrigger.addEventListener('click', (e) => {
+    e.preventDefault();
     toggleDropDown(dropdownElement);
   });
 

--- a/html/components/masthead.js
+++ b/html/components/masthead.js
@@ -217,7 +217,8 @@ const bindUIEvents = () => {
         });
       });
 
-      wideSelectorTriggerInDropdown.addEventListener('click', () => {
+      wideSelectorTriggerInDropdown.addEventListener('click', (e) => {
+        e.preventDefault();
         const dropdownIsOpen = wideSelectorDropdown.classList.contains(
           'sprk-c-Dropdown--open',
         );


### PR DESCRIPTION
## What does this PR do?
Adds preventDefault() to the dropdown trigger to prevent a click event navigating to another page.

### Associated Issue 
Fixes #2441 

### Code
 - [x] Build Component in Spark Vanilla (Sass, HTML, JS)
 - [x] Unit Testing in Spark Vanilla with `npm run test` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
 
