### PR TITLE
Modal docs

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
@@ -22,8 +22,8 @@ ${markdownDocumentationLinkBuilder('modal')}
     - 2. The Modal – Containing the information or actions.
 - The Modal and background mask are hidden by default.
 - A Modal should not be launched from within another Modal.
-- The data-id property is provided as a hook for automated tools.
-Each instance should have a unique data-id property.
+- The \`data-id\` property is provided as a hook for automated tools.
+Each instance should have a unique \`data-id\` property.
 ("modal-choice-1", "modal-choice-2", "modal-info-1", etc).
 - Dismissing a Wait Modal is done programmatically.
 You must write your own function to toggle dismissal through the '(hide)' input.

--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
@@ -14,7 +14,20 @@ export default {
     )
   ],
   parameters: {
-    info: markdownDocumentationLinkBuilder('modal'),
+    info: `
+${markdownDocumentationLinkBuilder('modal')}
+- There are two parts to a Modal
+    - 1. Modal Trigger (typically in the form of a Button) - When
+    pressed, it triggers the Modal to appear.
+    - 2. The Modal – Containing the information or actions.
+- The Modal and background mask are hidden by default.
+- A Modal should not be launched from within another Modal.
+- The data-id property is provided as a hook for automated tools.
+Each instance should have a unique data-id property.
+("modal-choice-1", "modal-choice-2", "modal-info-1", etc).
+- Dismissing a Wait Modal is done programmatically.
+You must write your own function to toggle dismissal through the '(hide)' input.
+    `,
     docs: { iframeHeight: 450 },
   },
 };

--- a/html/components/modal.stories.js
+++ b/html/components/modal.stories.js
@@ -16,10 +16,10 @@ ${markdownDocumentationLinkBuilder('modal')}
     - 2. The Modal – Containing the information or actions. 
 - The Modal and background mask are hidden by default.
 - A Modal should not be launched from within another Modal. 
-- The data-id property is provided as a hook for automated tools.
-Each instance should have a unique data-id property.
+- The \`data-id\` property is provided as a hook for automated tools.
+Each instance should have a unique \`data-id\` property.
 ("modal-choice-1", "modal-choice-2", "modal-info-1", etc).
-- Make sure that the 'data-sprk-main' attribute is applied to
+- Make sure that the \`data-sprk-main\` attribute is applied to
 the main body content container or modals will not work. 
 - Refer to the table of HTML data attributes to make sure
 the correct attributes are applied in the correct places. 

--- a/html/components/modal.stories.js
+++ b/html/components/modal.stories.js
@@ -1,5 +1,6 @@
 import { useEffect } from '@storybook/client-api';
 import { modals } from './modals';
+import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
 
 export default {
   title: 'Components/Modal',
@@ -8,7 +9,20 @@ export default {
   ],
   parameters: {
     info: `
-##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/modal)
+${markdownDocumentationLinkBuilder('modal')}
+- There are two parts to a Modal 
+    - 1. Modal Trigger (typically in the form of a Button) - When
+    pressed, it triggers the Modal to appear. 
+    - 2. The Modal – Containing the information or actions. 
+- The Modal and background mask are hidden by default.
+- A Modal should not be launched from within another Modal. 
+- The data-id property is provided as a hook for automated tools.
+Each instance should have a unique data-id property.
+("modal-choice-1", "modal-choice-2", "modal-info-1", etc).
+- Make sure that the 'data-sprk-main' attribute is applied to
+the main body content container or modals will not work. 
+- Refer to the table of HTML data attributes to make sure
+the correct attributes are applied in the correct places. 
     `,
   },
 };

--- a/react/src/components/modals/SprkModal.stories.js
+++ b/react/src/components/modals/SprkModal.stories.js
@@ -23,7 +23,20 @@ export default {
       'Mask',
       'ModalFooter',
     ],
-    info: markdownDocumentationLinkBuilder('modal'),
+    info: `
+${markdownDocumentationLinkBuilder('modal')}
+- There are two parts to a Modal 
+    - 1. Modal Trigger (typically in the form of a Button) - When
+    pressed, it triggers the Modal to appear. 
+    - 2. The Modal – Containing the information or actions. 
+- The Modal and background mask are hidden by default.
+- A Modal should not be launched from within another Modal. 
+- The data-id property is provided as a hook for automated tools.
+Each instance should have a unique data-id property.
+("modal-choice-1", "modal-choice-2", "modal-info-1", etc).
+- Wait Modal visibility is controlled by writing a function
+that sets the value of the 'isVisible' property. 
+`,
   },
 
 };

--- a/react/src/components/modals/SprkModal.stories.js
+++ b/react/src/components/modals/SprkModal.stories.js
@@ -31,11 +31,11 @@ ${markdownDocumentationLinkBuilder('modal')}
     - 2. The Modal – Containing the information or actions. 
 - The Modal and background mask are hidden by default.
 - A Modal should not be launched from within another Modal. 
-- The data-id property is provided as a hook for automated tools.
-Each instance should have a unique data-id property.
+- The \`data-id\` property is provided as a hook for automated tools.
+Each instance should have a unique \`data-id\` property.
 ("modal-choice-1", "modal-choice-2", "modal-info-1", etc).
 - Wait Modal visibility is controlled by writing a function
-that sets the value of the 'isVisible' property. 
+that sets the value of the \`isVisible\` property. 
 `,
   },
 

--- a/src/pages/using-spark/components/modal.mdx
+++ b/src/pages/using-spark/components/modal.mdx
@@ -78,7 +78,7 @@ A Modal that shows critical information to the user.
 
 ### Wait
 
-A modal that acts as a loading screen.
+A Modal that acts as a loading screen.
 Once loading is finished, it will dismiss itself. 
 
 <ComponentPreview

--- a/src/pages/using-spark/components/modal.mdx
+++ b/src/pages/using-spark/components/modal.mdx
@@ -6,13 +6,10 @@ import { SprkDivider } from '@sparkdesignsystem/spark-react';
 
 # Modal
 
-The Modal component is a dialog that
-is displayed on top of all site content.
-When a Modal is present, the rest of
-the site is inactive and covered by a
-mask overlay. Modals are by definition an
-interruption of the current user flow
-(they put the page into a new "mode").
+The Modal component interrupts the
+user without leaving the current page.
+It forces the user to interact with
+critical information. 
 
 <ComponentPreview
   componentName="modal--default-story"
@@ -23,39 +20,29 @@ interruption of the current user flow
 />
 
 ### Usage
-A Choice Modal poses a question to the
-user and allows them to take an action.
-Use a Modal when you need the user to
-enter a new flow before they continue
-their current task, or to provide additional
-contextual information about the current task.
-For example, you could use a modal to get confirmation from
-the user before deleting a record, or to display a
-critical error message before continuing the
-task at hand. Keep in mind that modals will
-always interrupt the current user task and
-should not be used if such an interruption is
-not desired. Research shows that mandatory
-interruptions are very detrimental to productivity.
+
+A Modal should be used when there
+is critical information to show the user,
+a choice that the user must make immediately,
+a small amount of user information is needed,
+or when an action will result in a longer
+than normal wait.  
+
+The Modal component is inherently disruptive.
+It disables everything on the page below it
+until it is dismissed. The Modal component
+should be used sparingly, thoughtfully, and
+only when interruption is necessary to
+continuing a task. 
 
 ### Guidelines
-- Spark Modals can be fully-controlled using a mouse, keyboard,
-  and/or screen reader.
-- Modals can be closed by pressing the "Escape" key, clicking the Cancel button
-  (in the Choice variant), clicking the Close icon (in the Choice or Info variants),
-  or clicking the mask overlay (in the Choice or Info variants). Wait variant
-  modals must be closed programatically.
-- The Modal and mask elements are hidden by default.
-- If the content in the Modal is too large for the viewport
-  then the Modal will show a scroll bar.
-- When the Modal is opened, the first focusable element
-  inside the Modal will receive focus.
-- While the Modal is open, focus is "trapped" inside the
-  Modal. Pressing the Tab or Shift+Tab keys to move focus
-  will only shift focus between the elements in the Modal.
-- When the Modal is closed, focus will be returned to
-  the element that last had focus before the modal was opened.
-- The trigger element should always be outside the Modal container.
+
+- Ensure that messaging is helpful and provides
+a clear path of action for the user.
+- The content inside of a Modal should be short
+and concise. If much more information is needed,
+consider sending the user to a new page. 
+- A Modal should not be launched from within another Modal.
 
 <SprkDivider
  element="span"
@@ -64,9 +51,22 @@ interruptions are very detrimental to productivity.
 
 ## Variants
 
+### Choice
+
+A Modal that asks a question and
+allows a user to take an action.
+
+<ComponentPreview
+  componentName="modal--default-story"
+  hasReact
+  hasAngular
+  hasHTML
+  minHeight="25rem"
+/>
+
 ### Info
 
-An Info Modal shows information to the user.
+A Modal that shows critical information to the user.
 
 <ComponentPreview
   componentName="modal--info"
@@ -78,10 +78,8 @@ An Info Modal shows information to the user.
 
 ### Wait
 
-Wait Modals display a message to the user
-and can only be dismissed programatically.
-This variant is useful for displaying
-loading screens
+A modal that acts as a loading screen.
+Once loading is finished, it will dismiss itself. 
 
 <ComponentPreview
   componentName="modal--wait"
@@ -91,5 +89,37 @@ loading screens
   minHeight="25rem"
 />
 
+## Anatomy
+
+- A Modal (excluding the Wait Modal)
+must have a Button to trigger it. 
+- A Modal (excluding the Wait Modal)
+must have a Close Icon to dismiss it. 
+- A Modal has a background mask that
+covers up the page below. 
+- A Modal must have a title. 
+- A Modal must have informational text. 
+- A Choice Modal must include a Button. 
+
 ## Accessibility
-This is a11y stuff.
+
+- The Modal component can be fully
+controlled using a mouse, keyboard,
+and/or screen reader. 
+- When a Modal is opened:
+    - The first focusable element
+    inside it will receive focus. 
+    - The focus is "trapped" inside
+    the Modal. Pressing the Tab or Shift+Tab
+    keys to move focus will only shift
+    focus between the elements in the Modal. 
+- Modals can be closed several ways: 
+    - Pressing the "Escape" key on the
+    keyboard (excluding Wait Modal) 
+    - Pressing the Cancel button
+    (in the Choice Modal). 
+    - Pressing the Close Icon
+    (in the Choice Modal or Info Modal). 
+    - Pressing the background mask overlay
+    (in the Choice Modal or Info Modal). 
+    - Wait Modal will close on its own. 

--- a/storybook-utilities/markdownDocumentationLinkBuilder.js
+++ b/storybook-utilities/markdownDocumentationLinkBuilder.js
@@ -1,7 +1,7 @@
 const markdownDocumentationLinkBuilder = (component) => {
   return `
   ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/${component})
-  `;
+`;
 };
 
 export { markdownDocumentationLinkBuilder };


### PR DESCRIPTION
## What does this PR do?
Adds the Modal documentation to the Gatsby site and Storybook instances.

### Associated Issue 
Fixes #2278  

### Documentation
 - [x] Update Spark Docs Gatsby
 - [x] Update Spark Docs React
 - [x] Update Spark Docs HTML
 - [x] Update Spark Docs Angular

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots

