### PR TITLE
Add Accordion docs to NDS

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
@@ -25,11 +25,11 @@ export default {
     info: `
 ${markdownDocumentationLinkBuilder('accordion')}
 - The Accordion component in spark-angular consists of two Angular components:
-    - sprk-accordion
-    - sprk-accordion-item
-- sprk-accordion expects you to add sprk-accordion-item
+    - \`sprk-accordion\`
+    - \`sprk-accordion-item\`
+- \`sprk-accordion\` expects you to add \`sprk-accordion-item\`
 components as children. Any other content you add outside of a
-sprk-accordion-item will render, but may not be styled correctly.
+\`sprk-accordion-item\` will render, but may not be styled correctly.
 `,
     docs: { iframeHeight: 420 },
   },

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
@@ -22,7 +22,15 @@ export default {
     subcomponents: {
       SprkAccordionItemComponent,
     },
-    info: markdownDocumentationLinkBuilder('accordion'),
+    info: `
+${markdownDocumentationLinkBuilder('accordion')}
+- The Accordion component in spark-angular consists of two Angular components:
+    - sprk-accordion
+    - sprk-accordion-item
+- sprk-accordion expects you to add sprk-accordion-item
+components as children. Any other content you add outside of a
+sprk-accordion-item will render, but may not be styled correctly.
+`,
     docs: { iframeHeight: 420 },
   },
 };

--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -14,11 +14,11 @@ ${markdownDocumentationLinkBuilder('accordion')}
 - \`data-sprk-toggle\` and \`data-sprk-toggle-type\` are
 necessary attributes for this component to function.
 This will take care of visually expanding/collapsing
-the accordion as well as toggling the aria-expanded attribute. 
-- The data-id property is provided as a hook for
+the accordion as well as toggling the \`aria-expanded\` attribute. 
+- The \`data-id\` property is provided as a hook for
 automated tools. If you have multiple instances of the
 same variant of a component on the same page, make
-sure each instance has a unique data-id property
+sure each instance has a unique \`data-id\` property
 ("accordion-primary-1", "accordion-primary-2", "accordion-secondary-1", etc). 
 `,
   },

--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -9,7 +9,18 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
-    info: markdownDocumentationLinkBuilder('accordion'),
+    info: `
+${markdownDocumentationLinkBuilder('accordion')}
+- 'data-sprk-toggle' and 'data-sprk-toggle-type' are
+necessary attributes for this component to function.
+This will take care of visually expanding/collapsing
+the accordion as well as toggling the aria-expanded attribute. 
+- The data-id property is provided as a hook for
+automated tools. If you have multiple instances of the
+same variant of a component on the same page, make
+sure each instance has a unique data-id property
+("accordion-primary-1", "accordion-primary-2", "accordion-secondary-1", etc). 
+`,
   },
 };
 

--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -11,7 +11,7 @@ export default {
   parameters: {
     info: `
 ${markdownDocumentationLinkBuilder('accordion')}
-- 'data-sprk-toggle' and 'data-sprk-toggle-type' are
+- \`data-sprk-toggle\` and \`data-sprk-toggle-type\` are
 necessary attributes for this component to function.
 This will take care of visually expanding/collapsing
 the accordion as well as toggling the aria-expanded attribute. 

--- a/src/pages/using-spark/components/accordion.mdx
+++ b/src/pages/using-spark/components/accordion.mdx
@@ -2,16 +2,12 @@
   title: Accordion
 ---
 import ComponentPreview from '../../../components/ComponentPreview';
+import { SprkDivider } from '@sparkdesignsystem/spark-react';
 
 # Accordion
 
-An Accordion is a simple way of showing,
-hiding and breaking down content. It
-should be used when a large group
-of related content needs to be
-separated into smaller, digestible
-chunks. An Accordion consists of a
-series of Toggle components.
+Accordion expands and collapses multiple
+sections of related content. 
 
 <ComponentPreview
   componentName="accordion--default-story"
@@ -21,19 +17,42 @@ series of Toggle components.
 />
 
 ### Usage
-An Accordion should be used when
-content needs to be broken down,
-but is still important enough to
-be of primary interest on the page.
-This Accordion's design is used to
-give it some visual weight
-within the design and make it
-apparent that the content is important.
+
+Accordion is used when you have lower-priority
+content that needs to be broken up into digestible chunks.
 
 ### Guidelines
-- Content length inside the Accordion does not have a limit.
-- Title content of the Accordion can wrap, but it is recommended
-  that it is short and to the point.
+
+- By default, all section of an Accordion are
+collapsed, so high-priority content should be avoided. 
+- Avoid complex interactions in Accordion.
+Things like forms, buttons, dropdowns, and nested
+Accordions weaken usability. 
+- Keep Accordion titles short so the text
+stays on one line. 
+- Accordion titles should be relevant to the content
+inside so the user can quickly decide if opening
+it will provide the information they need. 
+- The width of the Accordion should be
+controlled by the layout of the page. 
+- Expand/collapse is indicated by a chevron Icon,
+but the entire header area is clickable for the same action. 
+
+<SprkDivider
+ element="span"
+ additionalClasses="sprk-u-Measure"
+></SprkDivider>
+
+## Anatomy
+
+- An Accordion Item must have a left aligned title. 
+- An Accordion Item must contain content. 
+- An Accordion Item must have a right aligned
+Chevron-[Up/Down]-Circle-Two-Color Icon 
 
 ## Accessibility
-This is a11y stuf.
+
+- Can be accessed through the keyboard.
+TAB and SHIFT-TAB are used to navigate through
+Accordion titles and ENTER will expand or
+collapse each section. 


### PR DESCRIPTION
## What does this PR do?
Adds Accordion docs to Gatsby site, Angular storybook and HTML storybook

### Associated Issue 
Fixes #2273 

### Documentation
 - [x] Update Spark Docs Gatsby
 - [x] Update Spark Docs Angular
 - [x] Update Spark Docs Vanilla

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
