### PR TITLE
Add Masthead to NDS

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -25,7 +25,39 @@ export default {
       SprkMastheadAccordionComponent,
       SprkMastheadAccordionItemComponent,
     },
-    info: markdownDocumentationLinkBuilder('masthead'),
+    info: `
+${markdownDocumentationLinkBuilder('masthead')}
+- You should configure the size of your own logo.
+By default, the logo will be automatically sized
+between the \`$sprk-masthead-logo-min-width\` (174px)
+and \`$sprk-masthead-logo-max-width\` (192px).
+You can additionally override those min and max
+settings by resetting the variables in your own Sass file.
+- The default height of the Masthead on narrow
+viewports is 81px. Your logo might require you to
+update this value in your application’s Sass file using the
+\`$sprk-masthead-narrow-height\` variable. To get the
+correct value, put your logo in the Masthead and view
+the total height at a narrow viewport size. This
+will ensure your navigation items are lined up correctly.
+- Because of the differences in Masthead design between
+narrow and wide viewports, each viewport has its own HTML.
+You must duplicate the HTML for your navigation in both places.
+- The default breakpoint between narrow and wide viewports
+is 54rem (864px). If the content needs of your application
+require this breakpoint to be larger or smaller, it can be
+changed in your application’s Sass file with the
+variable \`$sprk-masthead-breakpoint\`.
+- The Masthead component has 4 slots to inject markup
+into the component template.
+    - \`little-nav-slot\`: Used for adding navigation
+    to the Default Masthead.
+    - \`utility-slot\`: Used to add optional features
+    like account menu, sign in button, search, etc.
+    - \`logo-slot\`: Used for adding your logo.
+    - \`navItem-slot\`: Used for the link in the upper right
+    of the mobile version of the masthead (typically a sign in link)
+`,
     docs: { iframeHeight: 300 },
   },
 };

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -48,6 +48,11 @@ is 54rem (864px). If the content needs of your application
 require this breakpoint to be larger or smaller, it can be
 changed in your application’s Sass file with the
 variable \`$sprk-masthead-breakpoint\`.
+- In Default Masthead the little nav is the section to the
+right of the logo, containing the navigation links and utility
+items. When the number of navigation items is too large to
+fit in one row, the Extended Masthead utilizes a second row,
+the big nav, to display the navigation items.
 - The Masthead component has 4 slots to inject markup
 into the component template.
     - \`little-nav-slot\`: Used for adding navigation

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -34,6 +34,11 @@ is 54rem (864px). If the content needs of your application
 require this breakpoint to be larger or smaller, it can be
 changed in your application’s Sass file with the
 variable \`$sprk-masthead-breakpoint\`.
+- In Default Masthead the little nav is the section to the
+right of the logo, containing the navigation links and utility
+items. When the number of navigation items is too large to
+fit in one row, the Extended Masthead utilizes a second row,
+the big nav, to display the navigation items.
 `,
   },
 };

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -3,6 +3,7 @@ import { masthead, toggleScrollEvent } from './masthead';
 import { toggle } from '../components/toggle';
 import { dropdowns } from '../components/dropdown';
 import isElementVisible from '../utilities/isElementVisible';
+import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
 
 export default {
   title: 'Components/Masthead',
@@ -11,8 +12,29 @@ export default {
   ],
   parameters: {
     info: `
-##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/masthead)
-    `,
+${markdownDocumentationLinkBuilder('masthead')}
+- You should configure the size of your own logo.
+By default, the logo will be automatically sized
+between the \`$sprk-masthead-logo-min-width\` (174px)
+and \`$sprk-masthead-logo-max-width\` (192px).
+You can additionally override those min and max
+settings by resetting the variables in your own Sass file.
+- The default height of the Masthead on narrow
+viewports is 81px. Your logo might require you to
+update this value in your application’s Sass file using the
+\`$sprk-masthead-narrow-height\` variable. To get the
+correct value, put your logo in the Masthead and view
+the total height at a narrow viewport size. This
+will ensure your navigation items are lined up correctly.
+- Because of the differences in Masthead design between
+narrow and wide viewports, each viewport has its own HTML.
+You must duplicate the HTML for your navigation in both places.
+- The default breakpoint between narrow and wide viewports
+is 54rem (864px). If the content needs of your application
+require this breakpoint to be larger or smaller, it can be
+changed in your application’s Sass file with the
+variable \`$sprk-masthead-breakpoint\`.
+`,
   },
 };
 

--- a/react/src/components/masthead/SprkMasthead.stories.js
+++ b/react/src/components/masthead/SprkMasthead.stories.js
@@ -56,6 +56,11 @@ is 54rem (864px). If the content needs of your application
 require this breakpoint to be larger or smaller, it can be
 changed in your application’s Sass file with the
 variable \`$sprk-masthead-breakpoint\`.
+- In Default Masthead the little nav is the section to the
+right of the logo, containing the navigation links and utility
+items. When the number of navigation items is too large to
+fit in one row, the Extended Masthead utilizes a second row,
+the big nav, to display the navigation items.
 `,
   },
 };

--- a/react/src/components/masthead/SprkMasthead.stories.js
+++ b/react/src/components/masthead/SprkMasthead.stories.js
@@ -33,7 +33,30 @@ export default {
       'SprkMastheadMenuIcon',
       'SprkMastheadNarrowNav',
     ],
-    info: markdownDocumentationLinkBuilder('masthead'),
+    info:`
+${markdownDocumentationLinkBuilder('masthead')}
+- You should configure the size of your own logo.
+By default, the logo will be automatically sized
+between the \`$sprk-masthead-logo-min-width\` (174px)
+and \`$sprk-masthead-logo-max-width\` (192px).
+You can additionally override those min and max
+settings by resetting the variables in your own Sass file.
+- The default height of the Masthead on narrow
+viewports is 81px. Your logo might require you to
+update this value in your application’s Sass file using the
+\`$sprk-masthead-narrow-height\` variable. To get the
+correct value, put your logo in the Masthead and view
+the total height at a narrow viewport size. This
+will ensure your navigation items are lined up correctly.
+- Because of the differences in Masthead design between
+narrow and wide viewports, each viewport has its own HTML.
+You must duplicate the HTML for your navigation in both places.
+- The default breakpoint between narrow and wide viewports
+is 54rem (864px). If the content needs of your application
+require this breakpoint to be larger or smaller, it can be
+changed in your application’s Sass file with the
+variable \`$sprk-masthead-breakpoint\`.
+`,
   },
 };
 

--- a/src/pages/using-spark/components/masthead.mdx
+++ b/src/pages/using-spark/components/masthead.mdx
@@ -6,8 +6,9 @@ import { SprkDivider } from '@sparkdesignsystem/spark-react';
 
 # Masthead
 
-The Masthead is the first component on
-a page and includes navigation elements.
+The Masthead component provides a consistent
+way to convey brand identity. It contains the
+logo and navigation elements for the application. 
 
 <ComponentPreview
   componentName="masthead--default-masthead"
@@ -19,17 +20,28 @@ a page and includes navigation elements.
 />
 
 ### Usage
-This version of the Masthead is commonly
-used when the user is signed out,
-the site has no user accounts or there
-is a small amount of navigational links.
-The big navigation (wide gray navigation bar)
-is not included in this version.
+
+Nearly all applications should have a Masthead
+at the top of every page. An example of an
+exception would be a marketing landing page
+with a unique design.  
+
+On wide viewports, the Masthead is fixed to the
+top of the screen. As the user scrolls, content
+moves under the Masthead. On narrow viewports,
+when the user scrolls, the Masthead moves off
+the top of the screen. When the user scrolls back
+up the page, the Masthead returns into view
+for easy access. 
 
 ### Guidelines
-- The Masthead is "sticky" and content will flow under it.
-- On narrow viewports when a user scrolls down the page, the masthead will become hidden.
-When the user scrolls back up towards the top of the page, the masthead will come back into view.
+
+- There is room for flexibility inside of
+the Masthead so you can combine navigation
+with other functionality (e.g. search, phone
+numbers, settings, etc.). Avoid trying to
+add too many additional features that may
+overwhelm or confuse the user.
 
 <SprkDivider
  element="span"
@@ -38,11 +50,36 @@ When the user scrolls back up towards the top of the page, the masthead will com
 
 ## Variants
 
+### Default Masthead
+
+The Default Masthead is the most compact
+way to convey brand identity and provide
+basic navigation and other features.  
+- The number of navigation items that
+can be used in the Default Masthead is
+only limited by what can fit on a single
+row on wide viewports.
+- When the number of navigation items is
+too large to fit in one row, the Extended
+Masthead must be used instead. 
+
+<ComponentPreview
+  componentName="masthead--default-masthead"
+  hasReact
+  hasAngular
+  hasHTML
+  minHeight="20rem"
+  maxWidth="100%"
+/>
+
 ### Extended Masthead
 
-Shows information that is
-important for a client to read.
-Information Alerts have a Bell icon.
+The Extended Masthead moves the navigation
+items to a separate row. This allows for
+more navigation items to be used and
+additional features to be added to the first row.  
+- The number of navigation items in the Extended
+Masthead should be a minimum of 3 and maximum of 6.
 
 <ComponentPreview
   componentName="masthead--extended"
@@ -53,5 +90,15 @@ Information Alerts have a Bell icon.
   minHeight="20rem"
 />
 
+## Anatomy
+
+- Masthead must have a logo
+- Masthead may include navigation
+- Masthead has space for optional features
+e.g. phone number, sign in button, account menu,
+account selector, etc. 
+
 ## Accessibility
-This is a11y stuff.
+
+The Masthead is a navigation landmark for accessibility
+tools. The attribute `role=”banner”` must be present. 


### PR DESCRIPTION
## What does this PR do?
Adds the Masthead documentation to Gatsby and Storybook instances.

### Associated Issue 
Fixes #2292 

### Documentation
 - [x] Update Spark Docs React
 - [x] Update Spark Docs Angular
 - [x] Update Spark Docs Vanilla
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
