### PR TITLE
Add Button docs to NDS

### DIFF
--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
@@ -39,7 +39,7 @@ submit the form, the attribute \`type=”button”\` must be used.
 - If a Button submits a form, do not use \`<input type="submit">\`.
 Instead use \`<button type=”submit”>\`
 - If a Button is Disabled, you must add the \`disabled\` attribute
-in addition to the \`spark-is-Disabled\` class so that it doesn’t
+in addition to the \`sprk-is-Disabled\` class so that it doesn’t
 receive interaction.
 `,
     docs: { iframeHeight: 100 },

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
@@ -14,7 +14,34 @@ export default {
     )
   ],
   parameters: {
-    info: markdownDocumentationLinkBuilder('button'),
+    info: `
+${markdownDocumentationLinkBuilder('button')}
+##### When to Use \`<button>\` vs. \`<a>\`
+The Button component can use either a button (\`<button>\`)
+or anchor (\`<a>\`) HTML element. It is very important
+for accessibility to choose the correct element.  
+
+- Button should use an \`<a>\` element if it navigates to a new page.
+- Button should use a \`<button>\` element if it is performing
+an action, such as: “Submit”, “Add”, “Join”,” etc.
+- A Button that does not go to a new page will almost
+always use a \`<button>\` element.
+
+##### Accessibility
+- If a Button is using an \`<a>\` element, you
+must include a \`title=””\` attribute.
+- If a Button only includes an Icon with no text,
+alternative text must be provided. 
+
+##### Guidelines
+- If a Button is in a form, but is not intended to
+submit the form, the attribute \`type=”button”\` must be used.
+- If a Button submits a form, do not use \`<input type="submit">\`.
+Instead use \`<button type=”submit”>\`
+- If a Button is Disabled, you must add the \`disabled\` attribute
+in addition to the \`spark-is-Disabled\` class so that it doesn’t
+receive interaction.
+`,
     docs: { iframeHeight: 100 },
   },
  };

--- a/html/components/button.stories.js
+++ b/html/components/button.stories.js
@@ -1,3 +1,4 @@
+import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
 
 export default {
   title: 'Components/Button',
@@ -6,8 +7,33 @@ export default {
   ],
   parameters: {
     info: `
-##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/button)
-    `,
+${markdownDocumentationLinkBuilder('button')}
+##### When to Use \`<button>\` vs. \`<a>\`
+The Button component can use either a button (\`<button>\`)
+or anchor (\`<a>\`) HTML element. It is very important
+for accessibility to choose the correct element.  
+
+- Button should use an \`<a>\` element if it navigates to a new page.
+- Button should use a \`<button>\` element if it is performing
+an action, such as: “Submit”, “Add”, “Join”,” etc.
+- A Button that does not go to a new page will almost
+always use a \`<button>\` element.
+
+##### Accessibility
+- If a Button is using an \`<a>\` element, you
+must include a \`title=””\` attribute.
+- If a Button only includes an Icon with no text,
+alternative text must be provided. 
+
+##### Guidelines
+- If a Button is in a form, but is not intended to
+submit the form, the attribute \`type=”button”\` must be used.
+- If a Button submits a form, do not use \`<input type="submit">\`.
+Instead use \`<button type=”submit”>\`
+- If a Button is Disabled, you must add the \`disabled\` attribute
+in addition to the \`spark-is-Disabled\` class so that it doesn’t
+receive interaction. 
+`,
   },
 };
 

--- a/html/components/button.stories.js
+++ b/html/components/button.stories.js
@@ -31,7 +31,7 @@ submit the form, the attribute \`type=”button”\` must be used.
 - If a Button submits a form, do not use \`<input type="submit">\`.
 Instead use \`<button type=”submit”>\`
 - If a Button is Disabled, you must add the \`disabled\` attribute
-in addition to the \`spark-is-Disabled\` class so that it doesn’t
+in addition to the \`sprk-is-Disabled\` class so that it doesn’t
 receive interaction. 
 `,
   },

--- a/react/src/components/buttons/SprkButton.stories.js
+++ b/react/src/components/buttons/SprkButton.stories.js
@@ -10,7 +10,34 @@ export default {
   component: SprkButton,
   parameters: {
     jest: ['SprkButton'],
-    info: markdownDocumentationLinkBuilder('button'),
+    info: `
+${markdownDocumentationLinkBuilder('button')}
+##### When to Use \`<button>\` vs. \`<a>\`
+The Button component can use either a button (\`<button>\`)
+or anchor (\`<a>\`) HTML element. It is very important
+for accessibility to choose the correct element.  
+
+- Button should use an \`<a>\` element if it navigates to a new page.
+- Button should use a \`<button>\` element if it is performing
+an action, such as: “Submit”, “Add”, “Join”,” etc.
+- A Button that does not go to a new page will almost
+always use a \`<button>\` element.
+
+##### Accessibility
+- If a Button is using an \`<a>\` element, you
+must include a \`title=””\` attribute.
+- If a Button only includes an Icon with no text,
+alternative text must be provided. 
+
+##### Guidelines
+- If a Button is in a form, but is not intended to
+submit the form, the attribute \`type=”button”\` must be used.
+- If a Button submits a form, do not use \`<input type="submit">\`.
+Instead use \`<button type=”submit”>\`
+- If a Button is Disabled, you must add the \`disabled\` attribute
+in addition to the \`spark-is-Disabled\` class so that it doesn’t
+receive interaction. 
+`,
    },
 };
 

--- a/react/src/components/buttons/SprkButton.stories.js
+++ b/react/src/components/buttons/SprkButton.stories.js
@@ -35,7 +35,7 @@ submit the form, the attribute \`type=”button”\` must be used.
 - If a Button submits a form, do not use \`<input type="submit">\`.
 Instead use \`<button type=”submit”>\`
 - If a Button is Disabled, you must add the \`disabled\` attribute
-in addition to the \`spark-is-Disabled\` class so that it doesn’t
+in addition to the \`sprk-is-Disabled\` class so that it doesn’t
 receive interaction. 
 `,
    },

--- a/src/pages/using-spark/components/button.mdx
+++ b/src/pages/using-spark/components/button.mdx
@@ -1,0 +1,142 @@
+---
+  title: Button
+---
+import ComponentPreview from '../../../components/ComponentPreview';
+import { SprkDivider } from '@sparkdesignsystem/spark-react';
+
+# Button
+
+A Button represents an action or choice for the user. 
+
+### Usage
+
+Buttons are the main actionable items on a page.
+Buttons typically trigger a new UI element to appear
+on the page and are essential to submitting forms,
+beginning a new task, or navigating to the next
+step in a process.
+
+<ComponentPreview
+  componentName="button--primary"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Guidelines
+
+- Effective Button text uses precise, task-specific
+action verbs like: “Add”, “Remove”, “Read Details”,
+and “Submit”. Avoid ambiguous words like “Yes”,
+“No”, “OK”, and “Click Here”.
+- Effective Button text is less than 20 characters. 
+- All button text should be in title case
+(capitalize the first letter of each word). 
+- Button text should never wrap to a second line. 
+- Button width should not exceed 280px. 
+- For navigational actions that appear within
+a line of text, use [Link](https://spark-docs.netlify.com/using-spark/components/link)
+instead of Button.
+
+<SprkDivider
+ element="span"
+ additionalClasses="sprk-u-Measure"
+></SprkDivider>
+
+## Variants
+
+### Primary Button
+
+The most important action on the page should
+use Primary Button. Effective action flows
+contain one Primary Button per page. 
+
+<ComponentPreview
+  componentName="button--primary"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Secondary Button
+
+A Secondary Button typically represents the
+highest priority alternative to the Primary Button.
+There can be more than one on a page and can depict
+similar or different actions. 
+
+<ComponentPreview
+  componentName="button--secondary"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Tertiary Button
+
+A Tertiary Button represents the lowest prioritized
+action on a page. They are typically used in a
+[Modal](https://spark-docs.netlify.com/using-spark/components/modal)
+to cancel a choice. They look like a text 
+[Link](https://spark-docs.netlify.com/using-spark/components/link)
+but have the same padding and focus rules as other Buttons.
+
+<ComponentPreview
+  componentName="button--tertiary"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+## States
+
+### Disabled
+
+A Disabled Button represents an action that is not
+currently available for the user. They imply that
+the Button would be available, given a certain set
+of circumstances. Since a user cannot interact with
+this button, consider if it’s necessary to show the
+disabled button at all. Otherwise, make it clear
+in the interface why a button is Disabled.
+
+<ComponentPreview
+  componentName="button--disabled"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Loading
+
+When data is being saved or submitted, a loading
+indicator may replace the Button text. 
+
+<ComponentPreview
+  componentName="button--spinner"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Full Width at Smaller Viewports
+
+At small viewport sizes, a Button may be used at full width.
+
+<ComponentPreview
+  componentName="button--full-width-at-small-viewport"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+## Anatomy
+
+- A Button must contain text and/or an Icon
+
+## Accessibility
+
+- If a Button is using an `<a>` element,
+you must include a `title=””` attribute.
+- If a Button only includes an Icon with no
+text, alternative text must be provided.


### PR DESCRIPTION
## What does this PR do?
Adds Button documentation to the gatsby site and Storybook instances.

### Associated Issue 
Fixes #2280 

### Documentation
 - [x] Update Spark Docs React
 - [x] Update Spark Docs Angular
 - [x] Update Spark Docs Vanilla
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
 
