### PR TITLE
Add Link docs to NDS

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.stories.ts
@@ -17,7 +17,11 @@ export default {
     )
   ],
   parameters: {
-    info: markdownDocumentationLinkBuilder('link'),
+    info: `
+${markdownDocumentationLinkBuilder('link')}
+- Spark Link styles are for text-based links.
+Images that are links should not use Spark classes.
+`,
     docs: { iframeHeight: 60 },
   },
 };

--- a/html/base/link.stories.js
+++ b/html/base/link.stories.js
@@ -1,3 +1,5 @@
+import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
+
 export default {
   title: 'Components/Link',
   decorators: [
@@ -5,8 +7,15 @@ export default {
   ],
   parameters: {
     info: `
-##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/link)
-    `,
+${markdownDocumentationLinkBuilder('link')}
+- Spark Link styles are for text-based links.
+Images that are links should not use Spark classes.
+- The data-id property is provided as a hook for
+automated tools. If you have multiple instances
+of the same variant of a component on the same page,
+make sure each instance has a unique data-id property
+("link-1", "link-2", "link-3", etc).  
+`,
   },
 };
 

--- a/html/base/link.stories.js
+++ b/html/base/link.stories.js
@@ -10,10 +10,10 @@ export default {
 ${markdownDocumentationLinkBuilder('link')}
 - Spark Link styles are for text-based links.
 Images that are links should not use Spark classes.
-- The data-id property is provided as a hook for
+- The \`data-id\` property is provided as a hook for
 automated tools. If you have multiple instances
 of the same variant of a component on the same page,
-make sure each instance has a unique data-id property
+make sure each instance has a unique \`data-id\` property
 ("link-1", "link-2", "link-3", etc).  
 `,
   },

--- a/react/src/base/links/SprkLink.stories.js
+++ b/react/src/base/links/SprkLink.stories.js
@@ -11,7 +11,11 @@ export default {
   component: SprkLink,
   parameters: {
     jest: ['SprkLink'],
-    info: markdownDocumentationLinkBuilder('link'),
+    info: `
+${markdownDocumentationLinkBuilder('link')}
+- Spark Link styles are for text-based links.
+Images that are links should not use Spark classes. 
+`,
   },
 };
 

--- a/src/pages/using-spark/components/link.mdx
+++ b/src/pages/using-spark/components/link.mdx
@@ -1,0 +1,110 @@
+---
+  title: Link
+---
+import ComponentPreview from '../../../components/ComponentPreview';
+import { SprkDivider } from '@sparkdesignsystem/spark-react';
+
+# Link
+
+A Link takes the user to another page
+or to a specific location on a page. 
+
+<ComponentPreview
+  componentName="link--default-link"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Usage
+
+Use a Link when you want the user to
+navigate to another page, a specific
+location on a page, or to download a document. 
+
+### Guidelines
+
+- Link text should clearly describe where
+the Link will take the user. It must answer,
+“what will the user get when they interact
+with this?” 
+- Avoid ambiguous Link text like “Click Here”.
+- Don’t use a Link if you aren’t navigating
+somewhere or downloading a document unless 
+the proper accessibility considerations are met.
+- Links should primarily be part of a sentence
+or near other text content. 
+
+<SprkDivider
+ element="span"
+ additionalClasses="sprk-u-Measure"
+></SprkDivider>
+
+## Variants
+
+### Base Link
+
+Base Link is the standard Link style and
+should be used for most hyperlinks. 
+
+<ComponentPreview
+  componentName="link--default-link"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Simple Link
+
+Simple Link is a more subtle styles which
+looks more like regular body copy. It is
+perfect inside menus, footers, and other
+elements where context implies an ability
+to interact with the text. 
+
+<ComponentPreview
+  componentName="link--simple"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Icon with Text Link
+
+This style combines an Icon with text.
+This is most useful in menus or standalone
+text and shouldn’t be used in a sentence.  
+
+<ComponentPreview
+  componentName="link--icon-with-text-link"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Disabled
+
+Disabled Link represents a link that is not
+currently available for interaction. Using
+this variation helps screen readers and other
+assistive technologies understand that the
+Link can’t be interacted with.
+
+<ComponentPreview
+  componentName="link--disabled"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+## Anatomy
+
+- A Link must contain text.
+- A Link may contain an icon. 
+
+## Accessibility
+
+- Avoid using Link to perform actions other than
+navigation or accessing external resources, like
+a file download. If you do, you must provide the
+appropriate [accessibility controls](https://www.w3.org/TR/wai-aria-practices-1.1/).


### PR DESCRIPTION
## What does this PR do?
Add Link documentation to Gatsby and Storybook instances.

### Associated Issue 
Fixes #2279 

### Documentation
 - [x] Update Spark Docs React
 - [x] Update Spark Docs Angular
 - [x] Update Spark Docs Vanilla
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
