### PR TITLE
add centered column docs to gatsby

### DIFF
--- a/html/objects/centered-column.stories.js
+++ b/html/objects/centered-column.stories.js
@@ -1,3 +1,5 @@
+import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
+
 export default {
   title: 'Components/Centered Column',
   decorators: [
@@ -6,8 +8,11 @@ export default {
     `,
   ],
   parameters: {
-    info: `
-##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/centered-column)
+    info: `${markdownDocumentationLinkBuilder('centered-column')}
+- The \`sprk-o-CenteredColumn\` class can be applied to
+any parent element that
+is being used to contain the application contents within
+a maximum width.
     `,
   },
 };

--- a/src/pages/using-spark/components/centered-column.mdx
+++ b/src/pages/using-spark/components/centered-column.mdx
@@ -1,0 +1,34 @@
+---
+  title: Centered Column
+---
+import ComponentPreview from '../../../components/ComponentPreview';
+import { SprkDivider } from '@sparkdesignsystem/spark-react';
+
+# Centered Column
+
+Centered Column is a
+layout container that
+horizontally centers the
+page content with a maximum width.
+
+<ComponentPreview
+  componentName="centered-column--default-story"
+  hasHTML
+/>
+
+### Usage
+
+The Centered Column container wraps the
+main content of an application.
+The maximum width on the container
+ensures that content doesn’t
+become too wide on large viewports.
+
+<SprkDivider
+ element="span"
+ additionalClasses="sprk-u-Measure"
+></SprkDivider>
+
+## Anatomy
+
+- A container with a maximum width.


### PR DESCRIPTION
## What does this PR do?
Add centered column docs to gatsby.

### Associated Issue 
Fixes #2327 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE) - SB bug currently
  - [ ] Microsoft Edge  - SB bug currently
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
