### PR TITLE
add flag docs to gatsby

### DIFF
--- a/src/pages/using-spark/components/flag.mdx
+++ b/src/pages/using-spark/components/flag.mdx
@@ -1,0 +1,51 @@
+---
+  title: Flag
+---
+import ComponentPreview from '../../../components/ComponentPreview';
+import { SprkDivider } from '@sparkdesignsystem/spark-react';
+
+# Flag
+
+The Flag object is a simple abstraction that displays an
+image or other media next to descriptive content.
+The concept comes from the
+[Nicole Sullivan’s Media Object](http://www.stubbornella.org/content/2010/06/25/the-media-object-saves-hundreds-of-lines-of-code/)
+and was updated to allow vertical
+alignment and renamed the
+[Flag Object by Harry Roberts](https://csswizardry.com/2013/05/the-flag-object/).
+
+<ComponentPreview
+  componentName="flag--default-story"
+  minHeight="20rem"
+  maxWidth="100%"
+  hasHTML
+/>
+
+### Usage
+
+The Flag object is a simple concept but can
+be used any time there is an image or other
+media next to descriptive content.
+
+### Guidelines
+
+- The media can be on the left or right of the content area.
+- The content area can be vertically aligned
+to the top, middle, or the bottom of the media.
+- There are no restrictions on the content
+that can be put in the content area.
+- The Flag object can be nested inside another Flag object.
+- The spacing between the media and the content
+area can be set to any Spacing value.
+- On small viewports, the content area
+can be configured to move below the media.
+
+<SprkDivider
+ element="span"
+ additionalClasses="sprk-u-Measure"
+></SprkDivider>
+
+## Anatomy
+
+- A Flag object must have a fixed image or other media.
+- A Flag object must have a flexible content area.


### PR DESCRIPTION
## What does this PR do?
Add flag docs to gatsby. When browser testing I noticed that the flag object in our HTML SB doesnt stack the image and text in small viewports. I made an issue here to fix it https://github.com/sparkdesignsystem/spark-design-system/issues/2517.

### Associated Issue 
Fixes #2332 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)  - SB bug currently
  - [ ] Microsoft Edge - SB bug currently 
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
