### PR TITLE
Add Highlight Board docs to NDS

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
@@ -16,7 +16,14 @@ export default {
     )
   ],
   parameters: {
-    info: markdownDocumentationLinkBuilder('highlight-board'),
+    info: `
+${markdownDocumentationLinkBuilder('highlight-board')}
+##### Accessibility
+- If the Buttons are being used to navigate
+to a new page, they should be \`<a>\` elements.
+If they are being used to trigger an event or action,
+then they should be \`<button>\` elements with \`aria-role=button\`.
+`,
     docs: { iframeHeight: 600 },
   },
 };

--- a/html/components/highlight-board.stories.js
+++ b/html/components/highlight-board.stories.js
@@ -1,3 +1,5 @@
+import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
+
 export default {
   title: 'Components/Highlight Board',
   decorators: [
@@ -5,8 +7,17 @@ export default {
   ],
   parameters: {
     info: `
-##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/highlight-board)
-    `,
+${markdownDocumentationLinkBuilder('highlight-board')}
+- Users are able to activate the buttons in Highlight Board
+using the Enter or Space keys on the keyboard.
+Make sure to include keypress handlers in your JavaScript.  
+
+##### Accessibility
+- If the Buttons are being used to navigate
+to a new page, they should be \`<a>\` elements.
+If they are being used to trigger an event or action,
+then they should be \`<button>\` elements with \`aria-role=button\`. 
+`,
   },
 };
 

--- a/react/src/components/highlight-board/SprkHighlightBoard.stories.js
+++ b/react/src/components/highlight-board/SprkHighlightBoard.stories.js
@@ -10,7 +10,14 @@ export default {
   ],
   parameters: {
     jest: ['SprkHighlightBoard'],
-    info: markdownDocumentationLinkBuilder('highlight-board'),
+    info: `
+${markdownDocumentationLinkBuilder('highlight-board')}
+##### Accessibility
+- If the Buttons are being used to navigate
+to a new page, they should be \`<a>\` elements.
+If they are being used to trigger an event or action,
+then they should be \`<button>\` elements with \`aria-role=button\`.
+`,
   },
 };
 

--- a/src/pages/using-spark/components/highlight-board.mdx
+++ b/src/pages/using-spark/components/highlight-board.mdx
@@ -1,0 +1,93 @@
+---
+  title: Highlight Board
+---
+import ComponentPreview from '../../../components/ComponentPreview';
+import { SprkDivider } from '@sparkdesignsystem/spark-react';
+
+# Highlight Board
+
+The Highlight Board component is a prominent
+way to introduce an experience and present
+the user with a clear call-to-action. 
+
+<ComponentPreview
+  componentName="highlight-board--default-story"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Usage
+
+Highlight Board is typically used at
+the top of a page, below the Masthead.
+It can also be used as a call-to-action
+on other parts of a page. 
+
+### Guidelines
+
+- Effective use of a Highlight Board involves
+a clear, concise headline that grabs attention.
+- The background can either be an image or a solid color.
+- The headline should not exceed 2-3 lines.
+- The background image can either take up the full width
+of the site’s main container or extend to the full width
+of the viewport. 
+
+<SprkDivider
+ element="span"
+ additionalClasses="sprk-u-Measure"
+></SprkDivider>
+
+## Variants
+
+### Default
+
+The Default Highlight Board is used to encourage engagement
+with strong imagery or a solid background color. 
+
+<ComponentPreview
+  componentName="highlight-board--default-story"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### No Image
+
+The No Image Highlight Board omits the background
+image and centers the content. 
+
+<ComponentPreview
+  componentName="highlight-board--no-image"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Stacked
+
+The Stacked Highlight Board places the image,
+content, and buttons in a vertical stack.
+This places greater emphasis on the image. 
+
+<ComponentPreview
+  componentName="highlight-board--stacked"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+## Anatomy
+
+- Highlight Board must contain a headline.
+- Highlight Board should include one or more buttons.
+- Highlight Board may have either a background image,
+a solid background color, or no image.
+
+## Accessibility
+
+- When using a Highlight Board that includes an image,
+be sure to include a descriptive `alt` attribute.
+- When using a solid background color, the contrast ratio
+between the headline and the background must be at least 3:1.


### PR DESCRIPTION
## What does this PR do?
Adds Highlight board docs to Gatsby site and Storybook instances.

### Associated Issue 
Fixes #2284 

### Documentation
 - [x] Update Spark Docs React
 - [x] Update Spark Docs Angular
 - [x] Update Spark Docs Vanilla
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
