### PR TITLE
add docs iframe height html

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-promo/sprk-promo.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-promo/sprk-promo.stories.ts
@@ -75,7 +75,7 @@ flag.story = {
   parameters: {
     docs: { iframeHeight: 300 },
   },
-}
+};
 
 export const withImage = () => ({
   moduleMetadata: modules,

--- a/html/base/inputs/Checkbox.stories.js
+++ b/html/base/inputs/Checkbox.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Date.stories.js
+++ b/html/base/inputs/Date.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/DatePicker.stories.js
+++ b/html/base/inputs/DatePicker.stories.js
@@ -8,6 +8,7 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 320 },
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,

--- a/html/base/inputs/HelperText.stories.js
+++ b/html/base/inputs/HelperText.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/HugeSelect.stories.js
+++ b/html/base/inputs/HugeSelect.stories.js
@@ -11,6 +11,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/HugeText.stories.js
+++ b/html/base/inputs/HugeText.stories.js
@@ -11,6 +11,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Monetary.stories.js
+++ b/html/base/inputs/Monetary.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Password.stories.js
+++ b/html/base/inputs/Password.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Percentage.stories.js
+++ b/html/base/inputs/Percentage.stories.js
@@ -9,6 +9,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Phone.stories.js
+++ b/html/base/inputs/Phone.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Radio.stories.js
+++ b/html/base/inputs/Radio.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/SSN.stories.js
+++ b/html/base/inputs/SSN.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Search.stories.js
+++ b/html/base/inputs/Search.stories.js
@@ -9,6 +9,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Select.stories.js
+++ b/html/base/inputs/Select.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Text.stories.js
+++ b/html/base/inputs/Text.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/inputs/Textarea.stories.js
+++ b/html/base/inputs/Textarea.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/input)
     `,
+    docs: { iframeHeight: 250 },
   },
 };
 

--- a/html/base/link.stories.js
+++ b/html/base/link.stories.js
@@ -6,6 +6,7 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 80 },
     info: `
 ${markdownDocumentationLinkBuilder('link')}
 - Spark Link styles are for text-based links.
@@ -14,7 +15,7 @@ Images that are links should not use Spark classes.
 automated tools. If you have multiple instances
 of the same variant of a component on the same page,
 make sure each instance has a unique \`data-id\` property
-("link-1", "link-2", "link-3", etc).  
+("link-1", "link-2", "link-3", etc).
 `,
   },
 };

--- a/html/base/list.stories.js
+++ b/html/base/list.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/list)
     `,
+    docs: { iframeHeight: 140 },
   },
 };
 

--- a/html/base/table.stories.js
+++ b/html/base/table.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/table)
     `,
+    docs: { iframeHeight: 380 },
   },
 };
 

--- a/html/base/typography.stories.js
+++ b/html/base/typography.stories.js
@@ -9,6 +9,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/foundations/typography)
     `,
+    docs: { iframeHeight: 180 },
   },
 };
 

--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -14,13 +14,14 @@ ${markdownDocumentationLinkBuilder('accordion')}
 - \`data-sprk-toggle\` and \`data-sprk-toggle-type\` are
 necessary attributes for this component to function.
 This will take care of visually expanding/collapsing
-the accordion as well as toggling the \`aria-expanded\` attribute. 
+the accordion as well as toggling the \`aria-expanded\` attribute.
 - The \`data-id\` property is provided as a hook for
 automated tools. If you have multiple instances of the
 same variant of a component on the same page, make
 sure each instance has a unique \`data-id\` property
-("accordion-primary-1", "accordion-primary-2", "accordion-secondary-1", etc). 
+("accordion-primary-1", "accordion-primary-2", "accordion-secondary-1", etc).
 `,
+    docs: { iframeHeight: 420 },
   },
 };
 

--- a/html/components/alert.stories.js
+++ b/html/components/alert.stories.js
@@ -7,6 +7,7 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 120 },
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/alert)
     `,

--- a/html/components/award.stories.js
+++ b/html/components/award.stories.js
@@ -8,6 +8,7 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 400 },
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/award)
     `,

--- a/html/components/button.stories.js
+++ b/html/components/button.stories.js
@@ -6,12 +6,13 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 100 },
     info: `
 ${markdownDocumentationLinkBuilder('button')}
 ##### When to Use \`<button>\` vs. \`<a>\`
 The Button component can use either a button (\`<button>\`)
 or anchor (\`<a>\`) HTML element. It is very important
-for accessibility to choose the correct element.  
+for accessibility to choose the correct element.
 
 - Button should use an \`<a>\` element if it navigates to a new page.
 - Button should use a \`<button>\` element if it is performing
@@ -23,7 +24,7 @@ always use a \`<button>\` element.
 - If a Button is using an \`<a>\` element, you
 must include a \`title=””\` attribute.
 - If a Button only includes an Icon with no text,
-alternative text must be provided. 
+alternative text must be provided.
 
 ##### Guidelines
 - If a Button is in a form, but is not intended to
@@ -32,7 +33,7 @@ submit the form, the attribute \`type=”button”\` must be used.
 Instead use \`<button type=”submit”>\`
 - If a Button is Disabled, you must add the \`disabled\` attribute
 in addition to the \`sprk-is-Disabled\` class so that it doesn’t
-receive interaction. 
+receive interaction.
 `,
   },
 };

--- a/html/components/card.stories.js
+++ b/html/components/card.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/card)
     `,
+    docs: { iframeHeight: 200 },
   },
 };
 
@@ -31,6 +32,9 @@ export const defaultStory = () => (
 
 defaultStory.story = {
   name: 'Default',
+  parameters: {
+    docs: { iframeHeight: 150 },
+  },
 };
 
 export const standout = () => (
@@ -110,6 +114,9 @@ export const highlightedHeader = () => (
 
 highlightedHeader.story = {
   name: 'Highlighted Header',
+  parameters: {
+    docs: { iframeHeight: 300 },
+  },
 };
 
 export const teaser = () => (
@@ -154,6 +161,12 @@ export const teaser = () => (
     </div>
   `
 );
+
+teaser.story = {
+  parameters: {
+    docs: { iframeHeight: 500 },
+  },
+};
 
 export const teaserWithDifferentElementOrder = () => (
   `
@@ -203,6 +216,9 @@ export const teaserWithDifferentElementOrder = () => (
 
 teaserWithDifferentElementOrder.story = {
   name: 'Teaser With Different Element Order',
+  parameters: {
+    docs: { iframeHeight: 500 },
+  },
 };
 
 export const twoUpCards = () => (
@@ -327,6 +343,9 @@ export const twoUpCards = () => (
 
 twoUpCards.story = {
   name: 'Card Layout - Two Up',
+  parameters: {
+    docs: { iframeHeight: 600 },
+  },
 };
 
 export const threeUpCards = () => (
@@ -511,6 +530,9 @@ export const threeUpCards = () => (
 
 threeUpCards.story = {
   name: 'Card Layout - Three Up',
+  parameters: {
+    docs: { iframeHeight: 600 },
+  },
 };
 
 export const fourUpCards = () => (
@@ -658,4 +680,7 @@ export const fourUpCards = () => (
 
 fourUpCards.story = {
   name: 'Card Layout - Four Up',
+  parameters: {
+    docs: { iframeHeight: 600 },
+  },
 };

--- a/html/components/dictionary.stories.js
+++ b/html/components/dictionary.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/dictionary)
     `,
+    docs: { iframeHeight: 500 },
   },
 };
 

--- a/html/components/divider.stories.js
+++ b/html/components/divider.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/divider)
     `,
+    docs: { iframeHeight: 60 },
   },
 };
 

--- a/html/components/dropdown.stories.js
+++ b/html/components/dropdown.stories.js
@@ -10,6 +10,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/dropdown)
     `,
+    docs: { iframeHeight: 200 },
   },
 };
 

--- a/html/components/footer.stories.js
+++ b/html/components/footer.stories.js
@@ -11,6 +11,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/footer)
     `,
+    docs: { iframeHeight: 800 },
   },
 };
 

--- a/html/components/highlight-board.stories.js
+++ b/html/components/highlight-board.stories.js
@@ -6,17 +6,18 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 600 },
     info: `
 ${markdownDocumentationLinkBuilder('highlight-board')}
 - Users are able to activate the buttons in Highlight Board
 using the Enter or Space keys on the keyboard.
-Make sure to include keypress handlers in your JavaScript.  
+Make sure to include keypress handlers in your JavaScript.
 
 ##### Accessibility
 - If the Buttons are being used to navigate
 to a new page, they should be \`<a>\` elements.
 If they are being used to trigger an event or action,
-then they should be \`<button>\` elements with \`aria-role=button\`. 
+then they should be \`<button>\` elements with \`aria-role=button\`.
 `,
   },
 };
@@ -117,6 +118,9 @@ export const noImage = () => `
 
 noImage.story = {
   name: 'No Image',
+  parameters: {
+    docs: { iframeHeight: 300 },
+  },
 };
 
 export const stacked = () => `

--- a/html/components/icons.stories.js
+++ b/html/components/icons.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/icons)
     `,
+    docs: { iframeHeight: 90 },
   },
 };
 

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -11,6 +11,7 @@ export default {
     story => `<div data-sprk-main>${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 300 },
     info: `
 ${markdownDocumentationLinkBuilder('masthead')}
 - You should configure the size of your own logo.
@@ -1336,3 +1337,9 @@ export const extended = () => {
     </header>
   `;
 };
+
+extended.story = {
+  parameters: {
+    docs: { iframeHeight: 450 },
+  },
+}

--- a/html/components/modal.stories.js
+++ b/html/components/modal.stories.js
@@ -8,21 +8,22 @@ export default {
     story => `<div class="sprk-o-Box" data-sprk-main>${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 450 },
     info: `
 ${markdownDocumentationLinkBuilder('modal')}
-- There are two parts to a Modal 
+- There are two parts to a Modal
     - 1. Modal Trigger (typically in the form of a Button) - When
-    pressed, it triggers the Modal to appear. 
-    - 2. The Modal – Containing the information or actions. 
+    pressed, it triggers the Modal to appear.
+    - 2. The Modal – Containing the information or actions.
 - The Modal and background mask are hidden by default.
-- A Modal should not be launched from within another Modal. 
+- A Modal should not be launched from within another Modal.
 - The \`data-id\` property is provided as a hook for automated tools.
 Each instance should have a unique \`data-id\` property.
 ("modal-choice-1", "modal-choice-2", "modal-info-1", etc).
 - Make sure that the \`data-sprk-main\` attribute is applied to
-the main body content container or modals will not work. 
+the main body content container or modals will not work.
 - Refer to the table of HTML data attributes to make sure
-the correct attributes are applied in the correct places. 
+the correct attributes are applied in the correct places.
     `,
   },
 };

--- a/html/components/pagination.stories.js
+++ b/html/components/pagination.stories.js
@@ -8,6 +8,7 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 70 },
     info: `
 ${markdownDocumentationLinkBuilder('pagination')}
 - The outer container must include the \`data-sprk-pagination\`

--- a/html/components/promo.stories.js
+++ b/html/components/promo.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/promo)
     `,
+    docs: { iframeHeight: 430 },
   },
 };
 
@@ -74,6 +75,12 @@ export const flag = () => (`
 
   </div>
 `);
+
+flag.story = {
+  parameters: {
+    docs: { iframeHeight: 300 },
+  },
+};
 
 export const withImage = () => (`
   <div

--- a/html/components/stepper.stories.js
+++ b/html/components/stepper.stories.js
@@ -11,6 +11,7 @@ export default {
     story => `<div class="sprk-o-Box">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 300 },
     info: `
 ${markdownDocumentationLinkBuilder('stepper')}
 For this component to function properly,
@@ -276,6 +277,12 @@ export const withStepDescriptions = () => {
   `;
 };
 
+withStepDescriptions.story = {
+  parameters: {
+    docs: { iframeHeight: 600 },
+  },
+};
+
 export const withDarkBackground = () => {
   useEffect(() => {
     stepper();
@@ -418,6 +425,12 @@ export const withDarkBackground = () => {
 
   </div>
   `;
+};
+
+withDarkBackground.story = {
+  parameters: {
+    docs: { iframeHeight: 600 },
+  },
 };
 
 export const withCarousel = () => {
@@ -630,4 +643,10 @@ export const withCarousel = () => {
     </div>
   </div>
   `;
+};
+
+withCarousel.story = {
+  parameters: {
+    docs: { iframeHeight: 800 },
+  },
 };

--- a/html/components/tabs.stories.js
+++ b/html/components/tabs.stories.js
@@ -9,6 +9,7 @@ export default {
     story => `<div class="sprk-o-Box sprk-u-JavaScript">${story()}</div>`,
   ],
   parameters: {
+    docs: { iframeHeight: 300 },
     info: `
 ${markdownDocumentationLinkBuilder('tabs')}
 For this component to function properly, the

--- a/html/components/toggle.stories.js
+++ b/html/components/toggle.stories.js
@@ -11,6 +11,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/toggle)
     `,
+    docs: { iframeHeight: 160 },
   },
 };
 

--- a/html/objects/box.stories.js
+++ b/html/objects/box.stories.js
@@ -9,6 +9,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/box)
     `,
+    docs: { iframeHeight: 130 },
   },
 };
 

--- a/html/objects/centered-column.stories.js
+++ b/html/objects/centered-column.stories.js
@@ -8,6 +8,7 @@ export default {
     `,
   ],
   parameters: {
+    docs: { iframeHeight: 140 },
     info: `${markdownDocumentationLinkBuilder('centered-column')}
 - The \`sprk-o-CenteredColumn\` class can be applied to
 any parent element that

--- a/html/objects/flag.stories.js
+++ b/html/objects/flag.stories.js
@@ -7,6 +7,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/flag)
     `,
+    docs: { iframeHeight: 400 },
   },
 };
 

--- a/html/objects/stack.stories.js
+++ b/html/objects/stack.stories.js
@@ -9,6 +9,7 @@ export default {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/stack)
     `,
+    docs: { iframeHeight: 230 },
   },
 };
 
@@ -263,4 +264,7 @@ export const stackSplitLayoutMixed = () => (
 
 stackSplitLayoutMixed.story = {
   name: 'Stack/Split - Mixed Column',
+  parameters: {
+    docs: { iframeHeight: 450 },
+  },
 };


### PR DESCRIPTION
## What does this PR do?
Adds iframe heights to the html sb because the default height is too large.

### Associated Issue 
Fixes #2354 

### Code
 - [x] Build Component in Spark Vanilla SB

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE) - SB not working in IE11 right now
  - [ ] Microsoft Edge - SB not working in edge right now
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)