### PR TITLE
Add Stepper docs to NDS

### DIFF
--- a/html/components/stepper.stories.js
+++ b/html/components/stepper.stories.js
@@ -3,6 +3,7 @@ import { stepper } from './stepper';
 import '../utilities/polyfills/classListSVG';
 import '../utilities/polyfills/CustomEvent';
 import '../utilities/polyfills/ObjectPrepend';
+import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
 
 export default {
   title: 'Components/Stepper',
@@ -11,8 +12,46 @@ export default {
   ],
   parameters: {
     info: `
-##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/stepper)
-    `,
+${markdownDocumentationLinkBuilder('stepper')}
+For this component to function properly,
+the HTML must be structured correctly:  
+
+- \`data-sprk-stepper=”container”\` on the \`<ol>\`.
+- \`data-sprk-stepper=”step”\` on individual steps.
+- \`data-sprk-stepper=”description”\` on the step
+description containers.
+- \`data-sprk-stepper=”heading”\` on the step
+heading elements. 
+- \`aria-selected=true\` on the active step.
+- \`aria-role=”tablist”\` on the \`<ol>\`. 
+- \`aria-role=”tab”\` on each step.
+- \`aria-role=”tabpanel”\` on the description container.
+- \`aria-labelledby\` with a value that ties the
+descriptions to the related step heading on the
+description container.
+
+When using the Carousel variant:  
+
+- \`data-sprk-carousel=”ID”\` on the carousel
+element with a unique value for ID. 
+- \`data-sprk-stepper-carousel=”id”\` on the
+\`<ol>\` with the same value as \`data-spark-carousel\`.  
+- \`data-sprk-carousel-dots\` on the container
+that will contain the clickable “dots” used to
+navigate on small viewports.
+
+Other considerations:  
+
+- The active step cannot be programmatically
+updated in the HTML implementation of Stepper.
+- Stepper makes use of the \`sprk-u-JavaScript\`
+class to provide a graceful degradation experience
+in environments where JavaScript is not enabled. 
+If \`sprk-u-JavaScript\` is not found on the \`<html>\`
+element of the page, all the steps will be visible.
+If \`sprk-u-JavaScript\` is present, only one step
+will be visible at a time.
+`,
   },
 };
 

--- a/react/src/components/stepper/SprkStepper.stories.js
+++ b/react/src/components/stepper/SprkStepper.stories.js
@@ -15,7 +15,16 @@ export default {
       SprkStepperSlider,
       SprkStepperStep
     },
-    info: markdownDocumentationLinkBuilder('stepper'),
+    info: `
+${markdownDocumentationLinkBuilder('stepper')}
+- The React Stepper uses the index of its children
+to keep track of the active step. If you want to modify
+the index of the child steps (for example, by sorting
+them or adding more steps) you need to re-initialize
+the component so that it tracks the updated indexes.
+- The active step can be updated programmatically
+by changing the value of \`isSelected\` on the steps. 
+`,
     jest: [
       'SprkStepper',
       'SprkStepperSlider',

--- a/src/pages/using-spark/components/stepper.mdx
+++ b/src/pages/using-spark/components/stepper.mdx
@@ -6,35 +6,28 @@ import { SprkDivider } from '@sparkdesignsystem/spark-react';
 
 # Stepper
 
-An Accordion is a simple way of showing,
-hiding and breaking down content. It
-should be used when a large group
-of related content needs to be
-separated into smaller, digestible
-chunks. An Accordion consists of a
-series of Toggle components.
+Stepper displays a series of sequential steps
+with optional descriptions and images. 
 
 <ComponentPreview
   componentName="stepper--default-story"
   hasReact
-  hasAngular
   hasHTML
 />
 
 ### Usage
-An Accordion should be used when
-content needs to be broken down,
-but is still important enough to
-be of primary interest on the page.
-This Accordion's design is used to
-give it some visual weight
-within the design and make it
-apparent that the content is important.
+
+The Stepper is useful for displaying a high-level
+breakdown of a sequential process. Users can manually
+move between steps to access the related descriptions and images. 
 
 ### Guidelines
-- Content length inside the Accordion does not have a limit.
-- Title content of the Accordion can wrap, but it is recommended
-  that it is short and to the point.
+
+- Stepper must have a minimum of 2 items.
+- Only one step can be selected at a time.
+- Stepper should *not* be used as a progress indicator.
+There is currently no built-in way to mark a step as
+"completed". 
 
 <SprkDivider
  element="span"
@@ -43,33 +36,66 @@ apparent that the content is important.
 
 ## Variants
 
-### Stepper With Step Descriptions
-Info for this.
+### Default
+
+The Default Stepper is a series of steps with titles.
+
+<ComponentPreview
+  componentName="stepper--default-story"
+  hasReact
+  hasHTML
+/>
+
+### With Step Descriptions
+
+Each step can have an associated text description
+that is visible when the step is selected. 
 
 <ComponentPreview
   componentName="stepper--with-step-descriptions"
   hasReact
-  hasAngular
   hasHTML
 />
 
-### Stepper With Dark Background
-Info for this.
+### With Dark Background
+
+If Stepper is on a dark background, the
+font colors will be inverted for better legibility. 
 
 <ComponentPreview
   componentName="stepper--with-dark-background"
-  hasReact
-  hasAngular
   hasHTML
 />
 
-### Stepper With Carousel
-Info for this.
+### With Carousel
+
+In addition to descriptions, each step can have an
+associated image that is displayed in a carousel.
+The carousel rotates so that the image associated
+with the active step is always visible.  
+
+On small screens, the image will stack on top of a
+row of step indicators followed by the step heading
+and description. 
 
 <ComponentPreview
   componentName="stepper--with-carousel"
   hasHTML
 />
 
+## Anatomy
+
+- Stepper must have two or more steps.
+- Stepper must have a heading for each step.
+- Each step may include a description.
+- Each step may have an associated image
+displayed in a carousel.
+
 ## Accessibility
-This is a11y stuff.
+
+- Users can use the UP or LEFT arrow keys
+to select the previous step.
+- Users can use the DOWN or RIGHT arrow
+keys to select the next step.
+- Users can use the HOME or END keys to
+select the first or last step.

--- a/src/pages/using-spark/components/stepper.mdx
+++ b/src/pages/using-spark/components/stepper.mdx
@@ -23,7 +23,7 @@ move between steps to access the related descriptions and images.
 
 ### Guidelines
 
-- Stepper must have a minimum of 2 items.
+- Stepper must have a minimum of two items.
 - Only one step can be selected at a time.
 - Stepper should *not* be used as a progress indicator.
 There is currently no built-in way to mark a step as


### PR DESCRIPTION
## What does this PR do?
Adds Stepper documentation to Gatsby and React & HTML Storybook.

### Associated Issue 
Fixes #2289 

### Documentation
 - [x] Update Spark Docs React
 - [x] Update Spark Docs Gatsby
 - [x] Update Spark Docs Vanilla

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)