### PR TITLE
Add Toggle docs to NDS

### DIFF
--- a/src/pages/using-spark/components/toggle.mdx
+++ b/src/pages/using-spark/components/toggle.mdx
@@ -1,0 +1,44 @@
+---
+  title: Toggle
+---
+import ComponentPreview from '../../../components/ComponentPreview';
+import { SprkDivider } from '@sparkdesignsystem/spark-react';
+
+# Toggle
+
+Toggle shows and hides a block of content.
+
+<ComponentPreview
+  componentName="toggle--default-story"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Usage
+
+Use Toggle when you need to toggle the
+visibility of a block of content. For
+example, a disclaimer. 
+
+### Guidelines
+
+- By default, Toggle content is hidden,
+so high-priority content should be avoided. 
+- If you are using several Toggle components
+in succession, consider the
+[Accordion](/using-spark/components/accordion) component. 
+- The content within a Toggle should be kept
+short and relevant to its context for maximum usability. 
+- Keep the text of the Toggle trigger short. 
+
+<SprkDivider
+ element="span"
+ additionalClasses="sprk-u-Measure"
+></SprkDivider>
+
+## Anatomy
+
+- A Toggle component must have an element that
+triggers visibility of the Toggle content.
+- A Toggle component must have a content area.


### PR DESCRIPTION
## What does this PR do?
Add Toggle documentation to the Gatsby site.

### Associated Issue 
Fixes #2286 

### Documentation
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
