### PR TITLE
Add Pagination docs to NDS

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-pagination/sprk-pagination.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-pagination/sprk-pagination.stories.ts
@@ -16,7 +16,14 @@ export default {
     )
   ],
   parameters: {
-    info: markdownDocumentationLinkBuilder('pagination'),
+    info: `
+${markdownDocumentationLinkBuilder('pagination')}
+- The goToPage event includes the newly selected page
+in a property called “page”, while the goBack and
+goForward events include this value in a property called
+“newPage”. This is further documented in
+[Issue 1730](https://github.com/sparkdesignsystem/spark-design-system/issues/1730).
+`,
     docs: { iframeHeight: 70 },
   },
 };

--- a/html/components/pagination.stories.js
+++ b/html/components/pagination.stories.js
@@ -1,5 +1,6 @@
 import { useEffect } from '@storybook/client-api';
 import { pagination } from './pagination';
+import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
 
 export default {
   title: 'Components/Pagination',
@@ -8,8 +9,29 @@ export default {
   ],
   parameters: {
     info: `
-##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/components/pagination)
-    `,
+${markdownDocumentationLinkBuilder('pagination')}
+- The outer container must include the \`data-sprk-pagination\`
+attribute and each page \`<li>\` must include the
+\`data-sprk-pagination=”item”\` attribute. This is used
+to automatically set the \`aria-label\` on those elements. 
+- In order to use this component, you will need to write
+JavaScript handlers for the following functionality: 
+    - When a page is clicked:
+        - Set its \`aria-current\` attribute to “true” and
+        set \`aria-current\` to “false” on all other pages. 
+        - Add the \`sprk-c-Pagination__link--current\`
+        class and remove it from other page numbers. 
+        - If the current page is the first page, disable
+        the “previous” Icon chevron. 
+        - If the current page is the last page, disable
+        the “next” Icon chevron. 
+        - If there are more than 3 pages in the control,
+        insert an \`<li>\` containing an ellipsis (…) between
+        the first and current links and between the current and last links. 
+    - Developers will also need to implement the JavaScript
+    that uses the currently selected page to determine
+    which paged data to show to the user. 
+`,
   },
 };
 

--- a/src/pages/using-spark/components/pagination.mdx
+++ b/src/pages/using-spark/components/pagination.mdx
@@ -1,0 +1,89 @@
+---
+  title: Pagination
+---
+import ComponentPreview from '../../../components/ComponentPreview';
+import { SprkDivider } from '@sparkdesignsystem/spark-react';
+
+# Pagination
+
+Pagination breaks related content or data into
+multiple pages and allows a client to navigate through them. 
+
+<ComponentPreview
+  componentName="pagination--default-story"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Usage
+
+Use Pagination when splitting related content or a
+large set of data into smaller chunks across several
+pages will make the content easier to consume. 
+
+### Guidelines
+
+- Pagination only includes navigation elements for paging
+and does not manipulate data or control the display of a
+data grid; this control is used only to provide navigation
+and to indicate the current page and number of pages. 
+
+<SprkDivider
+ element="span"
+ additionalClasses="sprk-u-Measure"
+></SprkDivider>
+
+## Variants
+
+### Default
+
+The Default variant displays back and forward Icon
+chevrons as well as page numbers for each page.
+If there are more than 3 pages, ellipses (…) are used
+to condense the component and make it more readable
+while still showing the first, last, and current pages. 
+
+<ComponentPreview
+  componentName="pagination--default-story"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+### Pager
+
+The Pager variant does not include page numbers and only
+includes Icon chevrons for navigating forwards and backwards
+between pages. Pager should be used when you want the client
+to only navigate in sequential order. 
+
+<ComponentPreview
+  componentName="pagination--pager"
+  hasReact
+  hasAngular
+  hasHTML
+/>
+
+## Anatomy
+
+- Pagination must have Icon chevrons for incrementally
+navigating forward or backward between pages.
+- Default Pagination must have page numbers for
+navigating to specific pages 
+- Pagination must include an ellipsis (…) indicating
+hidden pages when there are more than 3 pages. 
+
+## Accessibility
+
+- Users can navigate to the control using the keyboard
+and are able to activate the Icon chevrons and page
+numbers using the ENTER or SPACE keys. 
+- The component is correctly identified and interpreted
+by screen reader technology. 
+- Each page number is correctly identified and interpreted
+by screen reader technology. 
+- The current page number includes the `aria-current`
+attribute. 
+- The Icon chevrons are correctly identified by screen
+reader technology.


### PR DESCRIPTION
## What does this PR do?
Adds Pagination docs to Gatsby site and Angular & HTML Storybook instances.

### Associated Issue 
Fixes #2291 

### Documentation
 - [x] Update Spark Docs Gatsby
 - [x] Update Spark Docs Angular
 - [x] Update Spark Docs Vanilla

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
