### PR TITLE
add accessibility guidelines page to gatsby

### DIFF
--- a/src/pages/principles/accessibility-guidelines.mdx
+++ b/src/pages/principles/accessibility-guidelines.mdx
@@ -10,7 +10,7 @@
 
 Information and user interface components must
 be presentable to users in ways they can perceive
-(e.g. alt tags that say what the item actually
+(e.g., alt tags that say what the item actually
 does, like ‘Submit form Button’).
 
 ##### Operable
@@ -22,7 +22,7 @@ the site using a keyboard as well as a mouse).
 ##### Understandable
 
 Information and the operation of user interface
-must be understandable, (e.g. error messaging
+must be understandable, (e.g., error messaging
 on a form should make sense; instead of ‘Invalid
 field’ messaging, use ‘The Email field must be
 in a valid format’).
@@ -45,7 +45,7 @@ certain browsers understand.
 
 - ##### Time-Based Media
 
-    Provide an alternative (e.g. transcript)
+    Provide an alternative (e.g., transcript)
     for time-based media (e.g., audio/video) that
     presents equivalent information, or link to
     textual information with comparable information

--- a/src/pages/principles/accessibility-guidelines.mdx
+++ b/src/pages/principles/accessibility-guidelines.mdx
@@ -45,7 +45,7 @@ certain browsers understand.
 
 - ##### Time-Based Media
 
-    Provide an alternative (e.g., transcript)
+    Provide an alternative (e.g. transcript)
     for time-based media (e.g., audio/video) that
     presents equivalent information, or link to
     textual information with comparable information

--- a/src/pages/principles/accessibility-guidelines.mdx
+++ b/src/pages/principles/accessibility-guidelines.mdx
@@ -1,0 +1,108 @@
+---
+  title: Accessibility Guidelines
+---
+
+# Accessibility Guidelines
+
+### Four Principles of Accessibility
+
+##### Perceivable
+
+Information and user interface components must
+be presentable to users in ways they can perceive
+(e.g. alt tags that say what the item actually
+does, like ‘Submit form Button’).
+
+##### Operable
+
+User interface components and navigation must
+be operable (e.g., you must be able to navigate
+the site using a keyboard as well as a mouse).
+
+##### Understandable
+
+Information and the operation of user interface
+must be understandable, (e.g. error messaging
+on a form should make sense; instead of ‘Invalid
+field’ messaging, use ‘The Email field must be
+in a valid format’).
+
+##### Robust
+
+Content must be robust enough so it can be
+interpreted reliably by a wide variety of user
+agents, including assistive technologies. In
+other words, don’t use tags or code that only
+certain browsers understand.
+
+### Guidelines Checklist
+
+- ##### Text Alternatives
+
+    Provide alternatives for non-text content
+    (e.g., images) so that the content is
+    accessible for all users.
+
+- ##### Time-Based Media
+
+    Provide an alternative (e.g., transcript)
+    for time-based media (e.g., audio/video) that
+    presents equivalent information, or link to
+    textual information with comparable information
+    for non-prerecorded media).
+
+- ##### Adaptable
+
+    Create content that can be presented in different
+    ways without losing information or structure.
+
+- ##### Distinguishable
+
+    Make it easy for users to see and hear content,
+    including separating foreground and background,
+    by using readable fonts, larger font sizes, and
+    highlighted link styling for example.
+
+- ##### Keyboard Accessible
+
+    Make all functionality available from a keyboard.
+
+- ##### Timing
+
+    Provide enough time for users to read and use content.
+
+- ##### Seizures
+
+    Do not include design elements that are known to
+    cause seizures (e.g., rapid flashing).
+
+- ##### Navigable
+
+    Provide multiple ways to allow users to navigate
+    content including obvious/prominent links and
+    other techniques.
+
+- ##### Readable
+
+    Make text content readable and understandable
+    via styling and other techniques.
+
+- ##### Predictable
+
+    Make web pages appear and operate in predictable ways.
+
+- ##### Input Assistance
+
+    Assist users with web experience, correct mistakes
+    and describe errors in text.
+
+- ##### Compatible
+
+    Maximize compatibility with current and future
+    user agents, including assistive technologies.
+
+### Resources
+
+- [Web Content Accessibility Guidelines 2.0 (WCAG 2.0)](https://www.w3.org/TR/WCAG20/)
+- [Section 508 Standards](https://www.section508.gov/)
+- [Usability Standards](https://www.usability.gov/)


### PR DESCRIPTION
## What does this PR do?
Adds Accessibility Guidelines page to the Gatsby site.

### Associated Issue 
Fixes #2206 

### Documentation
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)