### PR TITLE
set inlineStories to false to fix Modal iframe height issue for react SB

### DIFF
--- a/react/src/components/modals/SprkModal.stories.js
+++ b/react/src/components/modals/SprkModal.stories.js
@@ -12,6 +12,10 @@ export default {
     story => <div className="sprk-o-Box">{story()}</div>
   ],
   parameters: {
+    docs: {
+      inlineStories: false,
+      iframeHeight: 450
+    },
     subcomponents: {
       Mask,
       ModalFooter,
@@ -25,17 +29,17 @@ export default {
     ],
     info: `
 ${markdownDocumentationLinkBuilder('modal')}
-- There are two parts to a Modal 
+- There are two parts to a Modal
     - 1. Modal Trigger (typically in the form of a Button) - When
-    pressed, it triggers the Modal to appear. 
-    - 2. The Modal – Containing the information or actions. 
+    pressed, it triggers the Modal to appear.
+    - 2. The Modal – Containing the information or actions.
 - The Modal and background mask are hidden by default.
-- A Modal should not be launched from within another Modal. 
+- A Modal should not be launched from within another Modal.
 - The \`data-id\` property is provided as a hook for automated tools.
 Each instance should have a unique \`data-id\` property.
 ("modal-choice-1", "modal-choice-2", "modal-info-1", etc).
 - Wait Modal visibility is controlled by writing a function
-that sets the value of the \`isVisible\` property. 
+that sets the value of the \`isVisible\` property.
 `,
   },
 


### PR DESCRIPTION
## What does this PR do?
Sets inlineStories to false in the Modal story file to fix Modal iframe height issue for react SB.

### Associated Issue 
Fixes #2535 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Code
 - [x] Build Component in Spark React

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE) - SB not loading in IE right now, unrelated to this PR
  - [ ] Microsoft Edge - SB not loading in edge right now, unrelated to this PR
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
Before:
<img width="1653" alt="Screen Shot 2020-01-07 at 4 06 58 PM" src="https://user-images.githubusercontent.com/2117593/71929667-2415f500-3168-11ea-8b0a-af65180c24de.png">
After:
<img width="1649" alt="Screen Shot 2020-01-07 at 4 06 38 PM" src="https://user-images.githubusercontent.com/2117593/71929688-3132e400-3168-11ea-8a74-e49727f3a362.png">


