### PR TITLE
Add Typography docs to NDS

### DIFF
--- a/html/base/typography.stories.js
+++ b/html/base/typography.stories.js
@@ -8,7 +8,34 @@ export default {
   parameters: {
     info: `
 ##### For design and usage information check out the [documentation.](https://spark-docs.netlify.com/using-spark/foundations/typography)
-    `,
+
+- Heading elements have Typography settings automatically applied,
+but the classes can be used to change the style of a heading
+without affecting the page outline by modifying the heading
+element that is used.
+- All body copy will automatically have the style and size 
+applied by Spark. Use the classes to modify the default.
+
+##### Line-height Collision
+
+By default, line height on type will create extra
+whitespace around the top and bottom of the text.
+When the text is in a container that has padding applied,
+it appears larger than intended, due to this extra
+whitespace.  
+
+Spark automatically removes this whitespace from headings,
+but it will only be removed on body copy if the Spark
+body classes are used.  
+
+For details on how we remove the whitespace, please see this article:
+[Cropping Away Negative Impacts of Line Height](https://medium.com/eightshapes-llc/cropping-away-negative-impacts-of-line-height-84d744e016ce)  
+
+The type sizes defined in spark all have this extra
+whitespace removed. Heading elements have this cropping
+automatically applied, where body copy will need the
+correct type classes applied. 
+`,
     docs: { iframeHeight: 180 },
   },
 };

--- a/src/pages/using-spark/foundations/typography.mdx
+++ b/src/pages/using-spark/foundations/typography.mdx
@@ -1,0 +1,157 @@
+---
+  title: Typography
+---
+import ComponentPreview from '../../../components/ComponentPreview';
+
+# Typography
+
+Typography is the physical appearance of written
+text. It includes the sizes, line heights,
+colors, and fonts that are used.
+
+### Usage
+
+Typography settings are foundational to Spark
+components and will also be foundational to
+your application. See each variant below for
+specific usage.
+
+## Variants
+
+### Page Title
+
+The Page Title is used on primary pages that
+contain multiple jumping off points as well as
+core product features and flows. It should
+only be used once at the top of the main content
+of a page. Page Title should only be used with
+Display One and Display Two.
+
+<ComponentPreview
+  componentName="typography--page-title"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Display One
+
+This display size is intended to be used
+for primary headings. 
+
+<ComponentPreview
+  componentName="typography--display-one"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Display Two
+
+This display size is intended to be used
+for secondary headings.
+
+<ComponentPreview
+  componentName="typography--display-two"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Display Three
+
+This display size is intended to be used
+for third-level headings.
+
+<ComponentPreview
+  componentName="typography--display-three"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Display Four
+
+This display size is intended to be used
+for fourth-level headings.
+
+<ComponentPreview
+  componentName="typography--display-four"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Display Five
+
+This display size is intended to be used
+for fifth-level headings.
+
+<ComponentPreview
+  componentName="typography--display-five"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Display Six
+
+This display size is intended to be used
+for sixth-level headings.
+
+<ComponentPreview
+  componentName="typography--display-six"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Display Seven
+
+This display size is intended to be used
+for seventh-level headings.
+
+<ComponentPreview
+  componentName="typography--display-seven"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Body One
+
+This body type is intended for sub-labels
+and any copy within a paragraph that needs
+to be emphasized.
+
+<ComponentPreview
+  componentName="typography--body-one"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Body Two
+
+This is the default sizing for all
+non-display text.
+
+<ComponentPreview
+  componentName="typography--body-two"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Body Three
+
+This body type has a larger line height
+and is intended for long sections of text
+that need greater readability.
+
+<ComponentPreview
+  componentName="typography--body-three"
+  componentType="fundamentals"
+  hasHTML
+/>
+
+### Body Four
+
+This body type is intended for legal text
+and other de-emphasized text.
+
+<ComponentPreview
+  componentName="typography--body-four"
+  componentType="fundamentals"
+  hasHTML
+/>


### PR DESCRIPTION
## What does this PR do?
Adds Typography documentation to the Gatsby site and HTML Storybook instance.

### Associated Issue 
Fixes #2304 

### Documentation
 - [x] Update Spark Docs Gatsby
 - [x] Update Spark Docs Vanilla

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
