### PR TITLE
update footer copyright on NDS

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -66,9 +66,11 @@ const connectIcons = {
   ],
 }
 
+const date = new Date();
+const year = date.getFullYear();
 const paragraphs = [
    {
-     text: 'TBD Footer ©2000 – 2019... Information that we will put here.',
+     text: `©2000 – ${year} Quicken Loans Inc. All rights reserved.`,
    },
  ]
 


### PR DESCRIPTION
## What does this PR do?
Adds footer copyright verbiage to the Gatsby site.

### Associated Issue 
Fixes (#2308 

### Documentation
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  