### PR TITLE
add installing icons docs to gatsby

### DIFF
--- a/src/pages/installing-spark/installing-icons.mdx
+++ b/src/pages/installing-spark/installing-icons.mdx
@@ -14,7 +14,7 @@ detailed below.
 For more information on working with SVG icons, check out
 [this guide](https://css-tricks.com/svg-sprites-use-better-icon-fonts/).
 
-### At Complile Time
+### At Compile Time
 
 This method involves downloading the latest
 SVG from the correct CDN URL as part of your

--- a/src/pages/installing-spark/installing-icons.mdx
+++ b/src/pages/installing-spark/installing-icons.mdx
@@ -1,0 +1,108 @@
+---
+  title: Installing Icons
+---
+
+# Getting Started with Spark Icons
+
+The Spark Design System supports two methods
+for including SVG icons. Icons can either be
+built into your site at **compile time** or
+dynamically loaded at **run time**. Each
+method has advantages and disadvantages,
+detailed below.
+
+For more information on working with SVG icons, check out
+[this guide](https://css-tricks.com/svg-sprites-use-better-icon-fonts/).
+
+### At Complile Time
+
+This method involves downloading the latest
+SVG from the correct CDN URL as part of your
+build/development process, and then embedding
+that SVG directly into your compiled site.
+This way, all the SVGs are already include
+in your site when the page loads and an additional
+request is not necessary. All the load time for
+downloading the SVG from the CDN takes place
+during development, not while the user is using
+the page. 
+
+The big advantage of this method is performance
+and reliability. Since the SVG has already been
+downloaded as part of the build process, the user
+does not need to wait for the CDN to serve the SVG.
+That makes this method ideal for production
+environments where load times are critical. 
+
+This method also gives development teams more
+control over which SVGs are included in the site.
+Since the SVG file is downloaded during development,
+developers can review the SVG file before publishing,
+and can include only the SVG versions they’ve tested. 
+
+The downside of this method is more development work
+up front setting up the build and maintaining the
+connection to the CDN over the long term.
+
+***NOTE***: If you use this method you must not put
+the SVG file in your source control repository.
+The SVG file should only be hosted on the official CDN.
+
+1. Here’s an example using **Gulp**  
+[https://github.com/sparkdesignsystem/spark-starter-html/blob/master/gulpfile.js#L11](https://github.com/sparkdesignsystem/spark-starter-html/blob/master/gulpfile.js#L11)
+2. Here’s an example using a **Gatsby** plugin 
+[https://github.com/sparkdesignsystem/spark-design-system/blob/staging/plugins/gatsby-symbol-set-fetch/gatsby-node.js](https://github.com/sparkdesignsystem/spark-design-system/blob/staging/plugins/gatsby-symbol-set-fetch/gatsby-node.js)  
+
+[https://github.com/sparkdesignsystem/spark-design-system/blob/staging/gatsby-config.js#L55](https://github.com/sparkdesignsystem/spark-design-system/blob/staging/gatsby-config.js#L55)
+
+### At Run Time
+
+Using this method, the full SVG including the entire icon
+set is injected into your site as a separate HTTP request
+while the page is loading. This is typically done with an
+AJAX request that executes on page load. The full SVG
+containing all the icons is embedded at the top of the
+page so that they are available to be used in the body
+of the page. 
+
+The big downside of this method is performance. You can
+easily end up downloading the icons more than once on
+subsequent page loads (making the user wait for multiple
+downloads), and even if you’re only downloading them once,
+the user still needs to wait for that download to complete
+separate from the main site download, during which time
+the page has loaded but the icons are not visible. 
+
+The big advantage of this method is that it requires the
+least amount of setup and additional tooling. This makes
+it ideal for quick, non-production projects. 
+
+Another potential side-effect of this method is that if
+the SVG file on the CDN changes, you’ll get the update
+immediately without a chance for review.
+
+1. Here’s an example using an **AJAX call on page load**  
+[https://github.com/sparkdesignsystem/spark-design-system/blob/staging/storybook-utilities/icon-utilities/icon-loader.js](https://github.com/sparkdesignsystem/spark-design-system/blob/staging/storybook-utilities/icon-utilities/icon-loader.js)  
+2. Here’s an example using an **Angular** component  
+[https://github.com/sparkdesignsystem/spark-starter-angular/blob/kitchen-sink/src/app/spark-docs/icon-set/icon-set.component.ts](https://github.com/sparkdesignsystem/spark-starter-angular/blob/kitchen-sink/src/app/spark-docs/icon-set/icon-set.component.ts)
+3. Here’s an example using a **React** component  
+[https://github.com/sparkdesignsystem/spark-starter-react/blob/kitchen-sink/src/components/IconSet/IconSet.js](https://github.com/sparkdesignsystem/spark-starter-react/blob/kitchen-sink/src/components/IconSet/IconSet.js) 
+
+### Tips
+- The Icon SVG must be included in the page before the
+first icon is used, typically at the top of the page,
+directly after the `<body>` element.
+- To use your own icon set with the Spark components,
+you must make sure your icons have the exact same names
+as the icons listed on this [page](TBD). 
+
+### Resources
+
+For more information on usage and customization of
+Spark Icon components, check out our documentation
+and storybook pages. (links tbd) 
+
+For internal users, you can access a directory of
+our CDN resources here: 
+
+[http://shorty/sparkassetcdn](http://shorty/sparkassetcdn)

--- a/src/pages/installing-spark/installing-icons.mdx
+++ b/src/pages/installing-spark/installing-icons.mdx
@@ -20,7 +20,7 @@ This method involves downloading the latest
 SVG from the correct CDN URL as part of your
 build/development process, and then embedding
 that SVG directly into your compiled site.
-This way, all the SVGs are already include
+This way, all the SVGs are already included
 in your site when the page loads and an additional
 request is not necessary. All the load time for
 downloading the SVG from the CDN takes place


### PR DESCRIPTION
## What does this PR do?
Adds Installing Icons docs to Gatsby site.

### Associated Issue 
Fixes #2367 

### Documentation
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
