### PR TITLE
update side nav links to be simple SprkLink

### DIFF
--- a/src/components/ContextSubMenu.js
+++ b/src/components/ContextSubMenu.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'gatsby';
+import { SprkLink } from '@sparkdesignsystem/spark-react';
 
 function ContextSubMenu({heading, collection, directory}) {
   return (
@@ -9,12 +10,13 @@ function ContextSubMenu({heading, collection, directory}) {
         { collection.map(item => (
           <li
             key={item.node.parent.name}
-            className="docs-menu__collection-item">
-            <Link
-              className="docs-menu__link"
+            className="docs-menu__collection-item sprk-u-pbs">
+            <SprkLink
+              element={Link}
+              variant='simple'
               to={`/using-spark/${directory}/${item.node.parent.name}`}>
                 { item.node.frontmatter.title || item.node.parent.name }
-            </Link>
+            </SprkLink>
           </li>
         ))}
       </ul>

--- a/src/components/InstallingSparkDocsMenu.js
+++ b/src/components/InstallingSparkDocsMenu.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, StaticQuery, graphql } from 'gatsby';
+import { SprkLink } from '@sparkdesignsystem/spark-react';
 
 const InstallingSparkDocsMenu = () => (
   <StaticQuery
@@ -34,12 +35,13 @@ const InstallingSparkDocsMenu = () => (
               { guides.map(guide => (
                 <li
                   key={guide.node.parent.name}
-                  className="docs-menu__collection-item">
-                  <Link
-                    className="docs-menu__link"
+                  className="docs-menu__collection-item sprk-u-pbs">
+                  <SprkLink
+                    element={Link}
+                    variant='simple'
                     to={`/installing-spark/${guide.node.parent.name}`}>
                       { guide.node.frontmatter.title || guide.node.parent.name }
-                  </Link>
+                  </SprkLink>
                 </li>
               ))}
             </ul>

--- a/src/components/PrinciplesDocsMenu.js
+++ b/src/components/PrinciplesDocsMenu.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link, StaticQuery, graphql } from 'gatsby';
+import { SprkLink } from '@sparkdesignsystem/spark-react';
 
 const PrinciplesSparkDocsMenu = () => (
   <StaticQuery
@@ -34,12 +35,13 @@ const PrinciplesSparkDocsMenu = () => (
               { guides.map(guide => (
                 <li
                   key={guide.node.parent.name}
-                  className="docs-menu__collection-item">
-                  <Link
-                    className="docs-menu__link"
+                  className="docs-menu__collection-item sprk-u-pbs">
+                  <SprkLink
+                    element={Link}
+                    variant='simple'
                     to={`/principles/${guide.node.parent.name}`}>
                       { guide.node.frontmatter.title || guide.node.parent.name }
-                  </Link>
+                  </SprkLink>
                 </li>
               ))}
             </ul>

--- a/src/scss/components/_menu.scss
+++ b/src/scss/components/_menu.scss
@@ -20,25 +20,6 @@
   padding-left: 1rem;
 }
 
-.docs-menu__link {
-  color: $sprk-black;
-  display: block;
-  font-weight: 300;
-  padding: 0.3rem 0;
-}
-
-.docs-menu__link--main {
-  font-size: 1.2rem;
-}
-
-.docs-menu__link--active {
-  background-color: darkgrey;
-}
-
-.docs-menu__link:hover {
-  font-weight: 700;
-}
-
 .docs-menu__select {
   width: 100%;
 }


### PR DESCRIPTION
## What does this PR do?
Utilizes SprkLink, variant="simple" to update the styles of the side navigation on the Gatsby site.

### Associated Issue 
Fixes #2594 

### Documentation
 - [x] Update Spark Docs Gatsby

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
