### PR TITLE
Gatsby: Change to "Default Link"

### DIFF
--- a/src/pages/using-spark/components/link.mdx
+++ b/src/pages/using-spark/components/link.mdx
@@ -7,7 +7,7 @@ import { SprkDivider } from '@sparkdesignsystem/spark-react';
 # Link
 
 A Link takes the user to another page
-or to a specific location on a page. 
+or to a specific location on a page.
 
 <ComponentPreview
   componentName="link--default-story"
@@ -20,20 +20,20 @@ or to a specific location on a page.
 
 Use a Link when you want the user to
 navigate to another page, a specific
-location on a page, or to download a document. 
+location on a page, or to download a document.
 
 ### Guidelines
 
 - Link text should clearly describe where
 the Link will take the user. It must answer,
 “what will the user get when they interact
-with this?” 
+with this?”
 - Avoid ambiguous Link text like “Click Here”.
 - Don’t use a Link if you aren’t navigating
-somewhere or downloading a document unless 
+somewhere or downloading a document unless
 the proper accessibility considerations are met.
 - Links should primarily be part of a sentence
-or near other text content. 
+or near other text content.
 
 <SprkDivider
  element="span"
@@ -42,13 +42,13 @@ or near other text content.
 
 ## Variants
 
-### Base Link
+### Default Link
 
-Base Link is the standard Link style and
-should be used for most hyperlinks. 
+Default Link is the standard Link style and
+should be used for most hyperlinks.
 
 <ComponentPreview
-  componentName="link--default-link"
+  componentName="link--default-story"
   hasReact
   hasAngular
   hasHTML
@@ -60,7 +60,7 @@ Simple Link is a more subtle styles which
 looks more like regular body copy. It is
 perfect inside menus, footers, and other
 elements where context implies an ability
-to interact with the text. 
+to interact with the text.
 
 <ComponentPreview
   componentName="link--simple"
@@ -73,7 +73,7 @@ to interact with the text.
 
 This style combines an Icon with text.
 This is most useful in menus or standalone
-text and shouldn’t be used in a sentence.  
+text and shouldn’t be used in a sentence.
 
 <ComponentPreview
   componentName="link--icon-with-text-link"
@@ -100,7 +100,7 @@ Link can’t be interacted with.
 ## Anatomy
 
 - A Link must contain text.
-- A Link may contain an icon. 
+- A Link may contain an icon.
 
 ## Accessibility
 


### PR DESCRIPTION
## What does this PR do?
Change Base Link to "Default Link" for consistency
Make iframe of default link show up

![image](https://user-images.githubusercontent.com/4342363/72558146-20712500-3870-11ea-86ab-4a58e9d3a9de.png)


### Associated Issue 
Fixes (Issue Number that this PR is closing out)
Fixes #2596 


### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE) -- known issues with storybook
  - [ ] Microsoft Edge -- Known issues with storybook
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
