### PR TITLE
setting flex-grow instead of flex, cause ie11

### DIFF
--- a/src/scss/components/_layout.scss
+++ b/src/scss/components/_layout.scss
@@ -81,12 +81,12 @@ body,
 
 // Spark override to align card btns to bottom
 .docs-c-Card .sprk-c-Card__content {
-  flex: 1;
+  flex-grow: 1;
 }
 
 .docs-c-Card .sprk-c-Card__content div.sprk-o-Stack__item {
   display: flex;
-  flex: 1;
+  flex-grow: 1;
 }
 
 .docs-c-Card .sprk-c-Card__content div.sprk-o-Stack__item .sprk-c-Button {


### PR DESCRIPTION
## What does this PR do?
Fixes the homepage cards overlapping in ie11