### PR TITLE
NDS cleanup

### DIFF
--- a/html/components/button.stories.js
+++ b/html/components/button.stories.js
@@ -1,3 +1,5 @@
+import { useEffect } from '@storybook/client-api';
+import { spinners } from './spinners';
 import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/markdownDocumentationLinkBuilder';
 
 export default {
@@ -70,13 +72,17 @@ export const disabled = () => (
   `
 );
 
-export const loading = () => (
-  `
+export const loading = () => {
+  useEffect(() => {
+    spinners();
+  }, []);
+
+  return `
   <button class="sprk-c-Button" data-sprk-spinner="click" data-id="button-spinner">
-    <div class="sprk-c-Spinner sprk-c-Spinner--circle"></div>
+    Button
   </button>
-  `
-);
+  `;
+};
 
 export const fullWidthAtSmallViewport = () => (
   `

--- a/react/src/components/buttons/SprkButton.stories.js
+++ b/react/src/components/buttons/SprkButton.stories.js
@@ -84,15 +84,29 @@ export const disabled = () => (
   </SprkButton>
 );
 
+class LoadingWrapper extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { isLoading: false }
+  }
+
+  render() {
+    return  (
+      <SprkButton
+        loading={this.state.isLoading}
+        element="button"
+        idString="button-5"
+        analyticsString="button-5-analytics"
+        onClick={() => { this.setState({'isLoading': true})}}
+      >
+        Button
+      </SprkButton>
+    )
+  }
+}
+
 export const loading = () => (
-  <SprkButton
-    loading={true}
-    element="button"
-    idString="button-5"
-    analyticsString="button-5-analytics"
-  >
-    Button
-  </SprkButton>
+  <LoadingWrapper></LoadingWrapper>
 );
 
 export const fullWidthAtSmallViewport = () => (


### PR DESCRIPTION
- Fix the HTML Loading Button story (the spinner should appear once the button is clicked)

- Fix the React Loading Button story - I got this to work by wrapping the story in a Higher Order Component that manages state. I don't think this is something we've done in our Storybook before so I'm interested in feedback.

Compare current React behavior:https://react.sparkdesignsystem.com/?path=/story/components-button--loading

to new React behavior: https://5e3c2aba54f52300084c60dd--spark-sb-react.netlify.com/?path=/story/components-button--loading