### PR TITLE
patch spark-react package with spark exports fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "@mdx-js/mdx": "^1.5.0",
     "@mdx-js/react": "^1.5.0",
     "@sparkdesignsystem/spark": "^12.3.0",
-    "@sparkdesignsystem/spark-react": "^1.4.0",
+    "@sparkdesignsystem/spark-react": "^1.4.1",
     "babel-plugin-react-docgen": "^3.1.0",
     "classnames": "^2.2.6",
     "gatsby": "^2.18.17",

--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkdesignsystem/spark-react",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkdesignsystem/spark-react",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "A collection of Spark Design System components in React 16+",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Quick hotfix version bump to fix the issue where the stepper and stepperstep wasn't exported in spark-react-exports.js