### PR TITLE
Change inline code to Github prism theme

### DIFF
--- a/src/components/markdown-render/inlineCode.js
+++ b/src/components/markdown-render/inlineCode.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import Highlight, { defaultProps } from 'prism-react-renderer';
-import darkTheme from 'prism-react-renderer/themes/duotoneDark';
+import customTheme from 'prism-react-renderer/themes/github';
 
 const InlineCode = ({ children, className, additionalPreClasses, theme }) => {
   className = className ? className : '';
@@ -10,7 +10,7 @@ const InlineCode = ({ children, className, additionalPreClasses, theme }) => {
       {...defaultProps}
       code={children}
       language={language}
-      theme={theme || darkTheme}
+      theme={theme || customTheme}
     >
       {({ className, style, tokens, getLineProps, getTokenProps }) => (
         <pre


### PR DESCRIPTION
## What does this PR do?
Change our inline code theme to github theme.
Upon Jane's reccomendation, the github theme matches our branding the closest, and I put in a issue to make a custom Spark Theme in the future.
![image](https://user-images.githubusercontent.com/4342363/73963721-d9aaa400-48de-11ea-8f9e-19a091326523.png)
