### PR TITLE
NDS Cleanup

### DIFF
--- a/src/pages/installing-spark.mdx
+++ b/src/pages/installing-spark.mdx
@@ -28,4 +28,4 @@ Spark in various states of implementation.
 |---|---|
 | `master` | The Spark Design System and all of its prerequisites are installed. Start building with Spark components right away. |
 | `kitchen-sink` | The Spark Design System and all of its prerequisites are installed. In addition, a test page has been added that includes all the Spark components. This is useful for testing the latest version of Spark. |
-| `without-spark` | This is a boilerplate app without Spark installed. This is useful for following along in our [Getting Started Guides](./html-installation). |
+| `without-spark` | This is a boilerplate app without Spark installed. This is useful for following along in our [Getting Started Guides](/installing-spark/html-installation). |

--- a/src/pages/installing-spark.mdx
+++ b/src/pages/installing-spark.mdx
@@ -28,4 +28,4 @@ Spark in various states of implementation.
 |---|---|
 | `master` | The Spark Design System and all of its prerequisites are installed. Start building with Spark components right away. |
 | `kitchen-sink` | The Spark Design System and all of its prerequisites are installed. In addition, a test page has been added that includes all the Spark components. This is useful for testing the latest version of Spark. |
-| `without-spark` | This is a boilerplate app without Spark installed. This is useful for following along in our [Getting Started Guides](./installing-spark/html-installation). |
+| `without-spark` | This is a boilerplate app without Spark installed. This is useful for following along in our [Getting Started Guides](./html-installation). |

--- a/src/pages/installing-spark.mdx
+++ b/src/pages/installing-spark.mdx
@@ -28,4 +28,4 @@ Spark in various states of implementation.
 |---|---|
 | `master` | The Spark Design System and all of its prerequisites are installed. Start building with Spark components right away. |
 | `kitchen-sink` | The Spark Design System and all of its prerequisites are installed. In addition, a test page has been added that includes all the Spark components. This is useful for testing the latest version of Spark. |
-| `without-spark` | This is a boilerplate app without Spark installed. This is useful for following along in our [Getting Started Guides](). |
+| `without-spark` | This is a boilerplate app without Spark installed. This is useful for following along in our [Getting Started Guides](./installing-spark/html-installation). |

--- a/src/pages/installing-spark/angular.mdx
+++ b/src/pages/installing-spark/angular.mdx
@@ -33,7 +33,7 @@ to the one in the [Angular CLI Overview](https://angular.io/cli)
 ## Installing Spark Packages
 
 1. Start by going to your project
-directory and install `spark` and `spark-angular`
+directory and installing `spark` and `spark-angular`
 by pasting the following line in a command line application.
 
 ``` bash
@@ -73,7 +73,7 @@ export class AppModule { }
 ```
 
 3. Next, edit `styles.scss` to `@import` the Spark
-stylesheet. This file can be found in `you-app/src`.
+stylesheet. This file can be found in `your-app/src`.
 
 ``` scss
 @import "node_modules/@sparkdesignsystem/spark/spark.scss"

--- a/src/pages/installing-spark/html-installation.mdx
+++ b/src/pages/installing-spark/html-installation.mdx
@@ -106,7 +106,11 @@ your site.
 Here are some issues that you might encounter while setting up Spark and
 how to fix them:
 
-**Issue: `Uncaught ReferenceError: SPRK_CURRENT_VERSION is not defined`**
+**Issue:**
+
+```
+Uncaught ReferenceError: SPRK_CURRENT_VERSION is not defined
+```
 
 Make sure you're importing Spark from the correct directory:
 

--- a/src/pages/installing-spark/html-installation.mdx
+++ b/src/pages/installing-spark/html-installation.mdx
@@ -88,9 +88,6 @@ Spark components to correctly handle focus changes.
 </body>
 ```
 
-> This attribute is required for some Spark components to correctly handle
-focus changes.
-
 ## You did it!
 
 You’re ready to start [adding components](./html-add-components) to

--- a/src/pages/using-spark/components/input.mdx
+++ b/src/pages/using-spark/components/input.mdx
@@ -320,7 +320,7 @@ Password Input is used for collecting a password.
 shows the entered value.
 - Password Input can also be a Huge Text Input.
 For full functionality, see guidelines in the
-Text Huge Inputs section.
+[Huge Text Inputs](#huge-text-input) section.
 
 <ComponentPreview
   componentName="input-password--password-input"

--- a/src/scss/_spark-theme.scss
+++ b/src/scss/_spark-theme.scss
@@ -20,13 +20,17 @@ $sprk-webfonts:
   white-space: nowrap;
 }
 
+.sprk-b-Link code {
+  text-decoration: underline;
+}
+
 #gatsby-focus-wrapper code {
   line-height: 1;
   white-space: nowrap;
   font-size: 13px;
   color: rgba(51, 51, 51, 0.9);
   background-color: rgb(248, 248, 248);
-  margin: 0px 2px;
+  margin: 0px 0px;
   padding: 3px 5px;
   border-radius: 3px;
   border-width: 1px;

--- a/src/scss/_spark-theme.scss
+++ b/src/scss/_spark-theme.scss
@@ -30,7 +30,7 @@ $sprk-webfonts:
   font-size: 13px;
   color: rgba(51, 51, 51, 0.9);
   background-color: rgb(248, 248, 248);
-  margin: 0px 0px;
+  margin: 0;
   padding: 3px 5px;
   border-radius: 3px;
   border-width: 1px;


### PR DESCRIPTION
- convert long inline code to block code in Installation Guide
- "[BUG] (not a stopper) - weird horizontal scrolling iOS safari, this is because of the long code"
- "In the Angular guide, I think this should be "installing""
- "We call it "your-app" in one spot and "you-app" in another. This should be consistent."
- "This attribute is required..." is in here twice. Remove one."
- "[BUG] the "Getting Started Guides" link on https://spark-docs.netlify.com/installing-spark/, just reloads the current page"
- "should be a link to that section"
- update css for code in links [`like` this]()