### PR TITLE
Adds ctaIcon input to sprk-card in Angular

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.spec.ts
@@ -77,6 +77,30 @@ describe('SparkCardComponent', () => {
     );
   });
 
+  it('should add the correct classes if ctaIcon is set and ctaType is set to link', () => {
+    component.cardType = 'teaser';
+    component.body = 'Some body copy.';
+    component.title = 'Title!';
+    component.ctaIcon = 'bell';
+    component.ctaType = 'link';
+    fixture.detectChanges();
+    expect(component.getClassesCta()).toEqual(
+      'sprk-b-Link sprk-b-Link--simple sprk-b-Link--has-icon'
+    );
+  });
+
+  it('should not add the ctaIcon classes if the ctaType is button', () => {
+    component.cardType = 'teaser';
+    component.body = 'Some body copy.';
+    component.title = 'Title!';
+    component.ctaIcon = 'bell';
+    component.ctaType = 'button';
+    fixture.detectChanges();
+    expect(component.getClassesCta()).toEqual(
+      'sprk-c-Button'
+    );
+  });
+
   it('should add the correct classes if cardType and additionalClasses have values', () => {
     component.cardType = 'teaser';
     component.media = 'img';

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
@@ -121,6 +121,10 @@ import { Component, Input } from '@angular/core';
           >
             {{ ctaText }}
           </sprk-link>
+          <sprk-icon
+            *ngIf="ctaIcon && (ctaType === 'link')"
+            [iconType]="ctaIcon"
+          ></sprk-icon>
         </div>
       </div>
     </div>

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
@@ -56,11 +56,11 @@ import { Component, Input } from '@angular/core';
             [analyticsString]="ctaAnalytics"
           >
             {{ ctaText }}
+            <sprk-icon
+              *ngIf="ctaIcon && (ctaType === 'link')"
+              [iconType]="ctaIcon"
+            ></sprk-icon>
           </sprk-link>
-          <sprk-icon
-            *ngIf="ctaIcon && (ctaType === 'link')"
-            [iconType]="ctaIcon"
-          ></sprk-icon>
         </div>
       </div>
     </div>
@@ -120,11 +120,11 @@ import { Component, Input } from '@angular/core';
             [analyticsString]="ctaAnalytics"
           >
             {{ ctaText }}
+            <sprk-icon
+              *ngIf="ctaIcon && (ctaType === 'link')"
+              [iconType]="ctaIcon"
+            ></sprk-icon>
           </sprk-link>
-          <sprk-icon
-            *ngIf="ctaIcon && (ctaType === 'link')"
-            [iconType]="ctaIcon"
-          ></sprk-icon>
         </div>
       </div>
     </div>

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
@@ -195,7 +195,8 @@ export class SprkCardComponent {
   @Input()
   imgHref: string;
   /**
-   * Determines what icon `sprk-icon` renders next to the Call to Action.
+   * Determines what icon `sprk-icon` renders
+   * next to the call-to-action link.
    */
   @Input()
   ctaIcon: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
@@ -57,6 +57,10 @@ import { Component, Input } from '@angular/core';
           >
             {{ ctaText }}
           </sprk-link>
+          <sprk-icon
+            *ngIf="ctaIcon && (ctaType === 'link')"
+            [iconType]="ctaIcon"
+          ></sprk-icon>
         </div>
       </div>
     </div>
@@ -187,6 +191,11 @@ export class SprkCardComponent {
   @Input()
   imgHref: string;
   /**
+   * Determines what icon `sprk-icon` renders next to the Call to Action.
+   */
+  @Input()
+  ctaIcon: string;
+  /**
    * Determines which type of call to action is rendered.
    * The available values are `link` and `button`.
    */
@@ -255,6 +264,10 @@ export class SprkCardComponent {
       ctaClassArray.push('sprk-c-Button');
     } else {
       ctaClassArray.push('sprk-b-Link');
+      if (this.ctaIcon) {
+        ctaClassArray.push('sprk-b-Link--simple');
+        ctaClassArray.push('sprk-b-Link--has-icon');
+      }
     }
 
     if (this.additionalCtaClasses) {

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.component.ts
@@ -136,7 +136,7 @@ export class SprkCardComponent {
    * The available values are `base`, `teaser`, and `teaserHeading`.
    */
   @Input()
-  cardType = 'base';
+  cardType: 'base' | 'teaser' | 'teaserHeading' = 'base' ;
   /**
    * The main content
    * of the Card. Placed between
@@ -205,7 +205,7 @@ export class SprkCardComponent {
    * The available values are `link` and `button`.
    */
   @Input()
-  ctaType = 'link';
+  ctaType: 'link' | 'button' = 'link';
   /**
    * The text content of the call to action.
    */

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -142,7 +142,6 @@ export const teaser = () => ({
       ctaText="Learn More"
       ctaHref="#nogo"
       ctaAnalytics="Button: Spark"
-      additionalCtaClasses="sprk-c-Button--secondary"
       idString="card-teaser"
     >
     </sprk-card>
@@ -151,6 +150,35 @@ export const teaser = () => ({
 
 teaser.story = {
   name: 'Teaser',
+  parameters: {
+    docs: { iframeHeight: 500 },
+  },
+};
+
+export const teaserWithCtaIcon = () => ({
+  moduleMetadata: modules,
+  template: `
+    <sprk-card
+      media="img"
+      cardType="teaser"
+      title="Teaser Card Title"
+      body="Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua."
+      imgSrc="https://spark-assets.netlify.com/desktop.jpg"
+      imgAlt="Placeholder Image"
+      imgHref="#nogo"
+      ctaType="link"
+      ctaText="Learn More"
+      ctaHref="#nogo"
+      ctaAnalytics="Button: Spark"
+      idString="card-teaser"
+      ctaIcon="chevron-right"
+    >
+    </sprk-card>
+ `
+});
+
+teaserWithCtaIcon.story = {
+  name: 'Teaser w/ CTA Icon',
   parameters: {
     docs: { iframeHeight: 500 },
   },

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -156,35 +156,6 @@ teaser.story = {
   },
 };
 
-export const teaserWithCtaIcon = () => ({
-  moduleMetadata: modules,
-  template: `
-    <sprk-card
-      media="img"
-      cardType="teaser"
-      title="Teaser Card Title"
-      body="Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua."
-      imgSrc="https://spark-assets.netlify.com/desktop.jpg"
-      imgAlt="Placeholder Image"
-      imgHref="#nogo"
-      ctaType="link"
-      ctaText="Learn More"
-      ctaHref="#nogo"
-      ctaAnalytics="Link: Spark"
-      idString="card-teaser"
-      ctaIcon="chevron-right"
-    >
-    </sprk-card>
- `
-});
-
-teaserWithCtaIcon.story = {
-  name: 'Teaser w/ CTA Icon',
-  parameters: {
-    docs: { iframeHeight: 500 },
-  },
-};
-
 export const twoUpCards = () => ({
   moduleMetadata: modules,
   template: `

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -142,6 +142,7 @@ export const teaser = () => ({
       ctaText="Learn More"
       ctaHref="#nogo"
       ctaAnalytics="Button: Spark"
+      additionalCtaClasses="sprk-c-Button--secondary"
       idString="card-teaser"
     >
     </sprk-card>

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -170,7 +170,7 @@ export const teaserWithCtaIcon = () => ({
       ctaType="link"
       ctaText="Learn More"
       ctaHref="#nogo"
-      ctaAnalytics="Button: Spark"
+      ctaAnalytics="Link: Spark"
       idString="card-teaser"
       ctaIcon="chevron-right"
     >


### PR DESCRIPTION
## What does this PR do?
Add the ctaIcon input to sprk-card Angular. It adds the option to render an icon next to the CTA in the teaser variant, if the ctaType is a link and an icon name is provided. 
Adds tests for sprk-card to account for the additional input. 
Update the cardType and ctaType Inputs to explicitly check the types.
cardType checks for `base`, `teaser` && `teaserHeading` setting the default to `base`.
ctaType checks for `link` && `button` setting the default to `link`.

### Associated Issue
Fixes #1001 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Manual Testing Plan
  - [x] Update excel sheet with component changes

### Screenshots
![image](https://user-images.githubusercontent.com/15703773/74351246-def76b00-4d84-11ea-80c2-d5ae5ea860e9.png)
![image](https://user-images.githubusercontent.com/15703773/74341840-6ee1e880-4d76-11ea-94c1-b03075e94711.png)
![image](https://user-images.githubusercontent.com/15703773/74343356-ee70b700-4d78-11ea-8e45-392be69fe3b7.png)

