### PR TITLE
update onChange prop for SprkSelectionInput

### DIFF
--- a/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.js
+++ b/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.js
@@ -38,7 +38,7 @@ class SprkSelectionInput extends React.Component {
  * a value.
  */
   handleChange(e, variant) {
-    const { onChangeFunc } = this.props;
+    const { onChange } = this.props;
     const isHugeSelect = variant === 'hugeSelect';
 
     if (isHugeSelect) {
@@ -46,7 +46,7 @@ class SprkSelectionInput extends React.Component {
         selectHugeHasValue: e.target.value !== '',
       });
     }
-    if (onChangeFunc) onChangeFunc(e);
+    if (onChange) onChange(e);
   }
 
   render() {
@@ -66,7 +66,8 @@ class SprkSelectionInput extends React.Component {
       ...other
     } = this.props;
     const { choiceItems, id, selectHugeHasValue } = this.state;
-
+    const onChange = onChangeFunc ? onChangeFunc : this.props.onChange;
+    
     return (
       <div
         className={classNames('sprk-b-InputContainer', additionalClasses, {
@@ -90,6 +91,7 @@ class SprkSelectionInput extends React.Component {
                     aria-describedby={`errorcontainer-${id}`}
                     name={name}
                     value={value}
+                    onChange={onChange}
                     {...rest}
                   />
                   <label

--- a/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.js
+++ b/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.js
@@ -37,8 +37,7 @@ class SprkSelectionInput extends React.Component {
  * Updates state if huge selects have
  * a value.
  */
-  handleChange(e, variant) {
-    const { onChange } = this.props;
+  handleChange(e, variant, onChangeFunc) {
     const isHugeSelect = variant === 'hugeSelect';
 
     if (isHugeSelect) {
@@ -46,7 +45,7 @@ class SprkSelectionInput extends React.Component {
         selectHugeHasValue: e.target.value !== '',
       });
     }
-    if (onChange) onChange(e);
+    if (onChangeFunc) onChangeFunc(e);
   }
 
   render() {
@@ -62,11 +61,11 @@ class SprkSelectionInput extends React.Component {
       valid,
       variant,
       hasBlankFirstOption,
-      onChangeFunc,
+      onChange,
       ...other
     } = this.props;
     const { choiceItems, id, selectHugeHasValue } = this.state;
-    const onChange = onChangeFunc ? onChangeFunc : this.props.onChange;
+    const onChangeFunc = onChange ? onChange : this.props.onChangeFunc;
     
     return (
       <div
@@ -91,7 +90,7 @@ class SprkSelectionInput extends React.Component {
                     aria-describedby={`errorcontainer-${id}`}
                     name={name}
                     value={value}
-                    onChange={onChange}
+                    onChange={onChangeFunc}
                     {...rest}
                   />
                   <label
@@ -123,7 +122,7 @@ class SprkSelectionInput extends React.Component {
                 disabled={disabled}
                 aria-describedby={`errorcontainer-${id}`}
                 onChange={(e) => {
-                  this.handleChange(e, variant);
+                  this.handleChange(e, variant, onChangeFunc);
                 }}
                 ref={this.selectRef}
                 {...other}
@@ -257,7 +256,7 @@ SprkSelectionInput.propTypes = {
   /**
    * Passes in a function that handles the onChange of the input.
    */
-  onChangeFunc: PropTypes.func,
+  onChange: PropTypes.func,
   /**
    * Determines what type of input is rendered.
    */

--- a/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.test.js
+++ b/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.test.js
@@ -95,12 +95,32 @@ describe('SprkSelectionInput:', () => {
     const onCheckboxChangeMock = jest.fn();
     const wrapper = mount(
       <SprkSelectionInput
+        onChange= {onCheckboxChangeMock}
         choices={[
           {
             name: 'item-choice',
             label: 'Item 1',
             value: '1',
-            onChange: onCheckboxChangeMock,
+          },
+        ]}
+        variant="checkbox"
+      />,
+    );
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    checkbox.simulate('change', { target: { value: 'test-value' } });
+    expect(onCheckboxChangeMock.mock.calls.length).toBe(1);
+  });
+
+  it('should run the supplied onChangeFunc function for checkboxes', () => {
+    const onCheckboxChangeMock = jest.fn();
+    const wrapper = mount(
+      <SprkSelectionInput
+        onChangeFunc={onCheckboxChangeMock}
+        choices={[
+          {
+            name: 'item-choice',
+            label: 'Item 1',
+            value: '1',
           },
         ]}
         variant="checkbox"
@@ -126,7 +146,38 @@ describe('SprkSelectionInput:', () => {
     expect(onChangeMock.mock.calls.length).toBe(1);
   });
 
+  it('should run the supplied onChangeFunc function for selects', () => {
+    const onChangeMock = jest.fn();
+    const wrapper = mount(
+      <SprkSelectionInput
+        choices={choices}
+        variant="select"
+        onChangeFunc={onChangeMock}
+      />,
+    );
+    const select = wrapper.find('.sprk-b-Select');
+    select.value = '1';
+    select.simulate('change', { target: { value: 'test-value' } });
+    expect(onChangeMock.mock.calls.length).toBe(1);
+  });
+
   it('should run the supplied onChange function for huge selects', () => {
+    const onChangeMock = jest.fn();
+    const wrapper = mount(
+      <SprkSelectionInput
+        choices={choices}
+        variant="hugeSelect"
+        onChange={onChangeMock}
+        defaultValue=""
+      />,
+    );
+    const select = wrapper.find('.sprk-b-Select');
+    select.value = '1';
+    select.simulate('change', { target: { value: 'test-value' } });
+    expect(onChangeMock.mock.calls.length).toBe(1);
+  });
+
+  it('should run the supplied onChangeFunc function for huge selects', () => {
     const onChangeMock = jest.fn();
     const wrapper = mount(
       <SprkSelectionInput


### PR DESCRIPTION
## What does this PR do?
- Adds support for the `onChange` function to be passed into input variants `checkbox` and `radio`.
- Updates the `select` and `hugeSelect` variants to use `onChange` while maintaining support for the `onChangeFunc` prop. Which will be deprecated in the future.
- Adds tests for the `onChange` props for `checkbox` and `radio` variants.

### Associated Issue
Fixes #2791 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
![image](https://user-images.githubusercontent.com/15703773/74475390-5b697700-4e75-11ea-8538-4c828b169f0f.png)

