### PR TITLE
Fix Wait Modal display bug [IE 11] [3 Frameworks]

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
@@ -90,8 +90,11 @@ export const wait = () => ({
       modalType="wait"
       idString="modal-wait-1"
     >
-      This type of modal can't be closed by the
-      user.
+      <p class="sprk-u-Width-100">
+        Lorem ipsum dolor sit amet,
+        consectetur adipiscing elit, sed do eiusmod
+        tempor incididunt ut labore et dolore magna aliqua.
+      </p>
     </sprk-modal>
   `,
   props: {

--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.stories.ts
@@ -90,7 +90,7 @@ export const wait = () => ({
       modalType="wait"
       idString="modal-wait-1"
     >
-      <p class="sprk-u-Width-100">
+      <p class="sprk-c-Modal__content">
         Lorem ipsum dolor sit amet,
         consectetur adipiscing elit, sed do eiusmod
         tempor incididunt ut labore et dolore magna aliqua.

--- a/html/components/_modals.scss
+++ b/html/components/_modals.scss
@@ -49,6 +49,12 @@
   text-align: center;
 }
 
+// Fixes corner case with wait modal in IE 11
+// https://github.com/philipwalton/flexbugs#flexbug-2
+.sprk-c-Modal--wait .sprk-c-Modal__content {
+  width: 100%;
+}
+
 .sprk-c-Modal__header {
   display: flex;
 }

--- a/html/components/modal.stories.js
+++ b/html/components/modal.stories.js
@@ -199,7 +199,7 @@ export const wait = () => {
               sprk-c-Spinner--circle sprk-c-Spinner--large sprk-c-Spinner--dark"
           ></div>
           <p
-            class="sprk-o-Stack__item sprk-b-TypeBodyTwo sprk-u-Width-100"
+            class="sprk-o-Stack__item sprk-b-TypeBodyTwo sprk-c-Modal__content"
             id="modalWaitContent">
             Lorem ipsum dolor sit amet,
             consectetur adipiscing elit, sed do eiusmod

--- a/html/components/modal.stories.js
+++ b/html/components/modal.stories.js
@@ -199,8 +199,8 @@ export const wait = () => {
               sprk-c-Spinner--circle sprk-c-Spinner--large sprk-c-Spinner--dark"
           ></div>
           <p
-            class="sprk-o-Stack__item sprk-b-TypeBodyTwo" i
-            d="modalWaitContent">
+            class="sprk-o-Stack__item sprk-b-TypeBodyTwo sprk-u-Width-100"
+            id="modalWaitContent">
             Lorem ipsum dolor sit amet,
             consectetur adipiscing elit, sed do eiusmod
             tempor incididunt ut labore et dolore magna aliqua.

--- a/react/src/components/modals/SprkModal.js
+++ b/react/src/components/modals/SprkModal.js
@@ -273,7 +273,7 @@ class SprkModal extends Component {
                     additionalClasses="sprk-o-Stack__item"
                   />
                 )}
-                <div className="sprk-b-TypeBodyTwo">
+                <div className="sprk-b-TypeBodyTwo sprk-u-Width-100">
                   {children}
                 </div>
               </div>

--- a/react/src/components/modals/SprkModal.js
+++ b/react/src/components/modals/SprkModal.js
@@ -273,7 +273,7 @@ class SprkModal extends Component {
                     additionalClasses="sprk-o-Stack__item"
                   />
                 )}
-                <div className="sprk-b-TypeBodyTwo sprk-u-Width-100">
+                <div className="sprk-b-TypeBodyTwo sprk-c-Modal__content">
                   {children}
                 </div>
               </div>


### PR DESCRIPTION
## What does this PR do?

This fix accounts for a [documented bug](https://github.com/philipwalton/flexbugs#flexbug-2) in IE 11's flexbox implementation.

- Creates a new CSS class `sprk-c-Modal__content` that is applied to the text container in the Wait variant story for Angular and HTML. (Applies only to Storybook Wait Modal examples, not the component itself).
- For React, adds the `sprk-c-Modal__content` class to the Modal component (This change applies to all usages of React Modals. No noticeable change to Storybook.).
- Fixes typo in HTML story
- Change Angular story to match lorem ipsum examples in React and HTML

### Associated Issue
Fixes https://github.com/sparkdesignsystem/spark-design-system/issues/2193

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% passing)

### Screenshots

Before:
![image](https://user-images.githubusercontent.com/1424560/74465293-1c322a80-4e63-11ea-97b4-924071e3e83b.png)

After:
![image](https://user-images.githubusercontent.com/1424560/74466132-ae86fe00-4e64-11ea-9eb4-803ef86c1676.png)
