### PR TITLE
[BUG] Awards Component will display a gap between images - Angular 

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -71,18 +71,18 @@ describe('SparkAwardComponent', () => {
   });
 
   it('should add the additionalClasses to imgOne', () => {
-    component.additionalClassesImgOne = 'test-class';
+    component.additionalClassesImgOne = 'test-img-one';
     fixture.detectChanges();
-    expect(component.getClassesImgOne()).toEqual(
-      'sprk-o-Stack__item sprk-o-Stack__item--center-column test-class'
+    expect(element.querySelector('img').classList.toString()).toEqual(
+      component.getClassesImgOne()
     );
   });
 
   it('should add the additionalClasses to imgTwo', () => {
-    component.additionalClassesImgTwo = 'test-class';
+    component.additionalClassesImgTwo = 'test-img-two';
     fixture.detectChanges();
-    expect(component.getClassesImgTwo()).toEqual(
-      'sprk-o-Stack__item sprk-o-Stack__item--center-column test-class'
+    expect(element.querySelectorAll('img')[1].classList.toString()).toEqual(
+      component.getClassesImgTwo()
     );
   });
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -70,6 +70,30 @@ describe('SparkAwardComponent', () => {
     );
   });
 
+  it('should add the additionalClasses to imgOne', () => {
+    component.additionalClassesImgOne = 'test-class';
+    fixture.detectChanges();
+    expect(component.getClassesImgOne()).toEqual(
+      'sprk-o-Stack__item sprk-o-Stack__item--center-column test-class'
+    );
+  });
+
+  it('should add the additionalClasses to imgTwo', () => {
+    component.additionalClassesImgTwo = 'test-class';
+    fixture.detectChanges();
+    expect(component.getClassesImgTwo()).toEqual(
+      'sprk-o-Stack__item sprk-o-Stack__item--center-column test-class'
+    );
+  });
+
+  it('should add the correct class to images if splitAt is set', () => {
+    component.splitAt = 'small';
+    fixture.detectChanges();
+    expect(component.getImgContainerClasses()).toEqual(
+      'sprk-o-Stack__item sprk-o-Stack__item--flex@s'
+    );
+  });
+
   it('should set the data-analytics attribute given a value in the analyticsStringImgOne Input', () => {
     const str = 'One';
     component.splitAt = 'large';

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -21,31 +21,38 @@ import { Component, Input } from '@angular/core';
       </h2>
 
       <div sprkStackItem [ngClass]="getClasses()">
-        <sprk-link
-          linkType="unstyled"
-          additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@s sprk-o-Stack"
-          [href]="imgOneHref"
-          [analyticsString]="analyticsStringImgOne"
+        <div
+          [ngClass]="getImgContainerClasses()"
         >
-          <img
-            [ngClass]="getClassesImgOne()"
-            alt="{{ imgOneAlt }}"
-            src="{{ imgOneSrc }}"
-          />
-        </sprk-link>
-
-        <sprk-link
-          linkType="unstyled"
-          additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@s sprk-o-Stack"
-          [href]="imgTwoHref"
-          [analyticsString]="analyticsStringImgTwo"
+          <sprk-link
+            linkType="unstyled"
+            additionalClasses="sprk-o-Stack"
+            [href]="imgOneHref"
+            [analyticsString]="analyticsStringImgOne"
+          >
+            <img
+              [ngClass]="getClassesImgOne()"
+              alt="{{ imgOneAlt }}"
+              src="{{ imgOneSrc }}"
+            />
+          </sprk-link>
+        </div>
+        <div
+          [ngClass]="getImgContainerClasses()"
         >
-          <img
-            [ngClass]="getClassesImgTwo()"
-            alt="{{ imgTwoAlt }}"
-            src="{{ imgTwoSrc }}"
-          />
-        </sprk-link>
+          <sprk-link
+            linkType="unstyled"
+            additionalClasses="sprk-o-Stack"
+            [href]="imgTwoHref"
+            [analyticsString]="analyticsStringImgTwo"
+          >
+            <img
+              [ngClass]="getClassesImgTwo()"
+              alt="{{ imgTwoAlt }}"
+              src="{{ imgTwoSrc }}"
+            />
+          </sprk-link>
+        </div>
       </div>
 
       <sprk-toggle
@@ -59,8 +66,7 @@ import { Component, Input } from '@angular/core';
         <p class="sprk-b-TypeBodyFour">{{ disclaimerCopy }}</p>
       </sprk-toggle>
     </sprk-stack>
-  `,
-  styles: ['']
+  `
 })
 export class SprkAwardComponent {
   /**
@@ -219,6 +225,38 @@ export class SprkAwardComponent {
     return classArray.join(' ');
   }
 
+  /**
+   * @ignore
+   */
+  getImgContainerClasses(): string {
+    const classArray: string[] = [
+      'sprk-o-Stack__item'
+    ];
+
+    // Handle the choice of item split
+    // breakpoint by adding CSS class
+    switch (this.splitAt) {
+      case 'tiny':
+        classArray.push('sprk-o-Stack__item--flex@xs');
+        break;
+      case 'small':
+        classArray.push('sprk-o-Stack__item--flex@s');
+        break;
+      case 'medium':
+        classArray.push('sprk-o-Stack__item--flex@m');
+        break;
+      case 'large':
+        classArray.push('sprk-o-Stack__item--flex@l');
+        break;
+      case 'huge':
+        classArray.push('sprk-o-Stack__item--flex@xl');
+        break;
+      default:
+        break;
+    }
+
+    return classArray.join(' ');
+  }
   /**
    * @ignore
    */


### PR DESCRIPTION
## What does this PR do?
Angular awards component now has gaps between images.
Also fixed an found issue with the split classes not applying correctly.


Before:
![image](https://user-images.githubusercontent.com/4342363/74471557-68369c80-4e6e-11ea-9bb7-8a1c7f741b62.png)

After:
![image](https://user-images.githubusercontent.com/4342363/74471651-9320f080-4e6e-11ea-8707-f7fef9753135.png)

### Associated Issue
Fixes #1671

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (1000% Coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)