### PR TITLE
Hotfix & Doc site grid updates

### DIFF
--- a/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.js
+++ b/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.js
@@ -37,8 +37,7 @@ class SprkSelectionInput extends React.Component {
  * Updates state if huge selects have
  * a value.
  */
-  handleChange(e, variant) {
-    const { onChangeFunc } = this.props;
+  handleChange(e, variant, onChangeFunc) {
     const isHugeSelect = variant === 'hugeSelect';
 
     if (isHugeSelect) {
@@ -62,10 +61,11 @@ class SprkSelectionInput extends React.Component {
       valid,
       variant,
       hasBlankFirstOption,
-      onChangeFunc,
+      onChange,
       ...other
     } = this.props;
     const { choiceItems, id, selectHugeHasValue } = this.state;
+    const onChangeFunc = onChange ? onChange : this.props.onChangeFunc;
 
     return (
       <div
@@ -90,6 +90,7 @@ class SprkSelectionInput extends React.Component {
                     aria-describedby={`errorcontainer-${id}`}
                     name={name}
                     value={value}
+                    onChange={onChangeFunc}
                     {...rest}
                   />
                   <label
@@ -121,7 +122,7 @@ class SprkSelectionInput extends React.Component {
                 disabled={disabled}
                 aria-describedby={`errorcontainer-${id}`}
                 onChange={(e) => {
-                  this.handleChange(e, variant);
+                  this.handleChange(e, variant, onChangeFunc);
                 }}
                 ref={this.selectRef}
                 {...other}
@@ -255,7 +256,7 @@ SprkSelectionInput.propTypes = {
   /**
    * Passes in a function that handles the onChange of the input.
    */
-  onChangeFunc: PropTypes.func,
+  onChange: PropTypes.func,
   /**
    * Determines what type of input is rendered.
    */

--- a/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.test.js
+++ b/react/src/base/inputs/SprkSelectionInput/SprkSelectionInput.test.js
@@ -95,12 +95,32 @@ describe('SprkSelectionInput:', () => {
     const onCheckboxChangeMock = jest.fn();
     const wrapper = mount(
       <SprkSelectionInput
+        onChange= {onCheckboxChangeMock}
         choices={[
           {
             name: 'item-choice',
             label: 'Item 1',
             value: '1',
-            onChange: onCheckboxChangeMock,
+          },
+        ]}
+        variant="checkbox"
+      />,
+    );
+    const checkbox = wrapper.find('input[type="checkbox"]');
+    checkbox.simulate('change', { target: { value: 'test-value' } });
+    expect(onCheckboxChangeMock.mock.calls.length).toBe(1);
+  });
+
+  it('should run the supplied onChangeFunc function for checkboxes', () => {
+    const onCheckboxChangeMock = jest.fn();
+    const wrapper = mount(
+      <SprkSelectionInput
+        onChangeFunc={onCheckboxChangeMock}
+        choices={[
+          {
+            name: 'item-choice',
+            label: 'Item 1',
+            value: '1',
           },
         ]}
         variant="checkbox"
@@ -126,7 +146,38 @@ describe('SprkSelectionInput:', () => {
     expect(onChangeMock.mock.calls.length).toBe(1);
   });
 
+  it('should run the supplied onChangeFunc function for selects', () => {
+    const onChangeMock = jest.fn();
+    const wrapper = mount(
+      <SprkSelectionInput
+        choices={choices}
+        variant="select"
+        onChangeFunc={onChangeMock}
+      />,
+    );
+    const select = wrapper.find('.sprk-b-Select');
+    select.value = '1';
+    select.simulate('change', { target: { value: 'test-value' } });
+    expect(onChangeMock.mock.calls.length).toBe(1);
+  });
+
   it('should run the supplied onChange function for huge selects', () => {
+    const onChangeMock = jest.fn();
+    const wrapper = mount(
+      <SprkSelectionInput
+        choices={choices}
+        variant="hugeSelect"
+        onChange={onChangeMock}
+        defaultValue=""
+      />,
+    );
+    const select = wrapper.find('.sprk-b-Select');
+    select.value = '1';
+    select.simulate('change', { target: { value: 'test-value' } });
+    expect(onChangeMock.mock.calls.length).toBe(1);
+  });
+
+  it('should run the supplied onChangeFunc function for huge selects', () => {
     const onChangeMock = jest.fn();
     const wrapper = mount(
       <SprkSelectionInput

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -182,7 +182,7 @@ const IndexPage = () => (
       </SprkStackItem>
 
       <SprkStackItem>
-        <div className="docs-o-Grid docs-o-Grid--three-col docs-o-Grid--large">
+        <div className="docs-o-Grid docs-o-Grid--home-page docs-o-Grid--large">
           <SprkCard
             additionalClasses="docs-c-Card"
             variant="teaser"

--- a/src/scss/_settings.scss
+++ b/src/scss/_settings.scss
@@ -1,5 +1,8 @@
 $doc-site-mobile-breakpoint: 57rem;
 $doc-site-layout-max-width: 90rem;
 $docs-search-wrap-breakpoint: 635px;
-$docs-color-swatch-min-width: 220px;
-$docs-color-swatch-max-width: 257px;
+$docs-color-swatch-min-width: 210px;
+$docs-color-swatch-max-width: 1fr;
+$docs-color-swatch-three-column-breakpoint: 1200px;
+$docs-color-swatch-two-column-breakpoint: 800px;
+$docs-color-swatch-one-column-breakpoint: 500px;

--- a/src/scss/components/_layout.scss
+++ b/src/scss/components/_layout.scss
@@ -72,7 +72,19 @@ body,
 }
 
 .docs-o-Grid--three-col {
-  grid-template-columns: repeat(auto-fit, minmax(310px, 425px));
+  grid-template-columns: repeat(auto-fit, minmax(265px, 1fr));
+}
+
+.docs-o-Grid--home-page {
+  grid-template-columns: repeat(auto-fill, minmax(310px, 1fr));
+
+  @media (min-width: $doc-site-mobile-breakpoint) {
+    grid-template-columns: repeat(3, minmax(256px, 1fr));
+  }
+
+  .docs-c-Card {
+    justify-self: center;
+  }
 }
 
 .docs-o-Grid--large {

--- a/src/scss/objects/_color-swatch-grid.scss
+++ b/src/scss/objects/_color-swatch-grid.scss
@@ -1,5 +1,17 @@
 .docs-o-ColorSwatchGrid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax($docs-color-swatch-min-width, $docs-color-swatch-max-width));
+  grid-template-columns: repeat(4, minmax($docs-color-swatch-min-width, $docs-color-swatch-max-width));
   gap: $sprk-space-m;
+
+  @media (max-width: $docs-color-swatch-three-column-breakpoint) {
+    grid-template-columns: repeat(3, minmax($docs-color-swatch-min-width, $docs-color-swatch-max-width));
+  }
+
+  @media (max-width: $docs-color-swatch-two-column-breakpoint) {
+    grid-template-columns: repeat(2, minmax($docs-color-swatch-min-width, $docs-color-swatch-max-width));
+  }
+
+  @media (max-width: $docs-color-swatch-one-column-breakpoint) {
+    grid-template-columns: minmax($docs-color-swatch-min-width, $docs-color-swatch-max-width);
+  }
 }


### PR DESCRIPTION
## What does this PR do?
- Adds support for the `onChange` function to be passed into input variants `checkbox` and `radio`.
- Updates the `select` and `hugeSelect` variants to use `onChange` while maintaining support for the `onChangeFunc` prop. Which will be deprecated in the future.
- Adds tests for the `onChange` props for `checkbox` and `radio` variants.

- Updates to the grids on the Gatsby doc site.

### Associated Issue
Fixes #2791 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
![image](https://user-images.githubusercontent.com/15703773/74475390-5b697700-4e75-11ea-8538-4c828b169f0f.png)
