### PR TITLE
Spark-react fixes

### DIFF
--- a/react/.npmignore
+++ b/react/.npmignore
@@ -3,3 +3,4 @@ coverage/
 .storybook/
 storybook-static/
 *.stories.js
+.cache/

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkdesignsystem/spark-react",
-  "version": "1.4.1",
+  "version": "1.4.2-alpha.1",
   "description": "A collection of Spark Design System components in React 16+",
   "main": "dist/index.js",
   "scripts": {

--- a/react/rollup.config.js
+++ b/react/rollup.config.js
@@ -4,10 +4,11 @@ import resolve from 'rollup-plugin-node-resolve';
 import commonjs from "rollup-plugin-commonjs";
 
 export default {
+  external: ['react', 'react-dom'],
   input: './src/spark-exports-react.js',
   output: {
     file: './dist/index.js',
-    format: 'es',
+    format: 'commonjs',
     globals: {
       react: 'React',
       'react-dom': 'ReactDOM'
@@ -22,6 +23,5 @@ export default {
     babel({
       exclude: path.resolve(__dirname, './node_modules')
     })
-  ],
-  external: ['react', 'react-dom'],
+  ]
 }


### PR DESCRIPTION
## What does this PR do?
- Tells rollup to tranpile to commonjs format instead of es
- Adds .cache to .npmignore so its not published out
- bump version for alpha publish
- move externals line to the top