### PR TITLE
IE 11 Masthead Bug

### DIFF
--- a/html/components/_masthead.scss
+++ b/html/components/_masthead.scss
@@ -97,7 +97,9 @@
 // Hide menu element and additional nav link on larger views
 .sprk-c-Masthead__menu,
 .sprk-c-Masthead__nav-item {
-  flex: 1 0 0%; /* 1 */
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: auto;
 
   @media all and (min-width: $sprk-masthead-breakpoint) {
     display: none;
@@ -112,7 +114,9 @@
 // Center logo branding
 .sprk-c-Masthead__branding {
   margin: 0 auto;
-  flex: 2 0 0%; /* 2 */
+  flex-grow: 2;
+  flex-shrink: 1;
+  flex-basis: auto;
   text-align: center;
 
   @media (min-width: $sprk-masthead-breakpoint) {

--- a/html/components/_masthead.scss
+++ b/html/components/_masthead.scss
@@ -97,7 +97,7 @@
 // Hide menu element and additional nav link on larger views
 .sprk-c-Masthead__menu,
 .sprk-c-Masthead__nav-item {
-  flex: 1;
+  flex: 1 0 0%; /* 1 */
 
   @media all and (min-width: $sprk-masthead-breakpoint) {
     display: none;
@@ -112,7 +112,7 @@
 // Center logo branding
 .sprk-c-Masthead__branding {
   margin: 0 auto;
-  flex: 2;
+  flex: 2 0 0%; /* 2 */
   text-align: center;
 
   @media (min-width: $sprk-masthead-breakpoint) {


### PR DESCRIPTION
## What does this PR do?
Makes the Masthead logo clickable in IE 11.

### Associated Issue
Fixes https://github.com/sparkdesignsystem/spark-design-system/issues/2293

### Explanation

This is due to a bug in the IE 11 implementation of Flexbox, documented [here](https://github.com/philipwalton/flexbugs#flexbug-6). The default values for the `flex` shorthand have changed since IE 11's implementation, so we need to be explicit about the values we want to use.

### Browser Testing
  - [X] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [X] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.

Old clickable area:

![image](https://user-images.githubusercontent.com/1424560/74873924-12f70100-532e-11ea-9bec-4596cba8032f.png)

New clickable area:

![image](https://user-images.githubusercontent.com/1424560/74873986-315cfc80-532e-11ea-803f-376f7a028c44.png)
