### PR TITLE
Centered Column

### DIFF
--- a/angular/projects/spark-angular/src/lib/directives/sprk-box/sprk-box.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-box/sprk-box.directive.spec.ts
@@ -85,8 +85,6 @@ describe('Spark Box Directive', () => {
     item18Element = fixture.nativeElement.querySelectorAll('div')[18];
     item19Element = fixture.nativeElement.querySelectorAll('div')[19];
     item20Element = fixture.nativeElement.querySelectorAll('div')[20];
-
-
   }));
 
   it('should create itself', () => {
@@ -94,83 +92,83 @@ describe('Spark Box Directive', () => {
   });
 
   it('should have the correct base classes', () => {
-    expect(item0Element.classList.contains('sprk-o-Box'));
+    expect(item0Element.classList.contains('sprk-o-Box')).toBe(true);
   });
 
   it('should apply correct spacing classes for flush spacing', () => {
-    expect(item1Element.classList.contains('sprk-o-Box--flush'));
+    expect(item1Element.classList.contains('sprk-o-Box--flush')).toBe(true);
   });
 
   it('should apply correct spacing classes for tiny spacing', () => {
-    expect(item2Element.classList.contains('sprk-o-Box--tiny'));
+    expect(item2Element.classList.contains('sprk-o-Box--tiny')).toBe(true);
   });
 
   it('should apply correct spacing classes for small spacing', () => {
-    expect(item3Element.classList.contains('sprk-o-Box--small'));
+    expect(item3Element.classList.contains('sprk-o-Box--small')).toBe(true);
   });
 
   it('should apply correct spacing classes for medium spacing', () => {
-    expect(item4Element.classList.contains('sprk-o-Box--medium'));
+    expect(item4Element.classList.contains('sprk-o-Box--medium')).toBe(true);
   });
 
   it('should apply correct spacing classes for large spacing', () => {
-    expect(item5Element.classList.contains('sprk-o-Box--large'));
+    expect(item5Element.classList.contains('sprk-o-Box--large')).toBe(true);
   });
 
   it('should apply correct spacing classes for huge spacing', () => {
-    expect(item6Element.classList.contains('sprk-o-Box--huge'));
+    expect(item6Element.classList.contains('sprk-o-Box--huge')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-short-tiny spacing', () => {
-    expect(item7Element.classList.contains('sprk-o-Box--inset-short-tiny'));
+    expect(item7Element.classList.contains('sprk-o-Box--inset-short-tiny')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-short-small spacing', () => {
-    expect(item8Element.classList.contains('sprk-o-Box--inset-short-small'));
+    expect(item8Element.classList.contains('sprk-o-Box--inset-short-small')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-short-medium spacing', () => {
-    expect(item9Element.classList.contains('sprk-o-Box--inset-short-medium'));
+    expect(item9Element.classList.contains('sprk-o-Box--inset-short-medium')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-short-large spacing', () => {
-    expect(item10Element.classList.contains('sprk-o-Box--inset-short-large'));
+    expect(item10Element.classList.contains('sprk-o-Box--inset-short-large')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-short-huge spacing', () => {
-    expect(item11Element.classList.contains('sprk-o-Box--inset-short-huge'));
+    expect(item11Element.classList.contains('sprk-o-Box--inset-short-huge')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-tall-tiny spacing', () => {
-    expect(item12Element.classList.contains('sprk-o-Box--inset-tall-tiny'));
+    expect(item12Element.classList.contains('sprk-o-Box--inset-tall-tiny')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-tall-small spacing', () => {
-    expect(item13Element.classList.contains('sprk-o-Box--inset-tall-small'));
+    expect(item13Element.classList.contains('sprk-o-Box--inset-tall-small')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-tall-medium spacing', () => {
-    expect(item14Element.classList.contains('sprk-o-Box--inset-tall-medium'));
+    expect(item14Element.classList.contains('sprk-o-Box--inset-tall-medium')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-tall-large spacing', () => {
-    expect(item15Element.classList.contains('sprk-o-Box--inset-tall-large'));
+    expect(item15Element.classList.contains('sprk-o-Box--inset-tall-large')).toBe(true);
   });
 
   it('should apply correct spacing classes for inset-tall-huge spacing', () => {
-    expect(item16Element.classList.contains('sprk-o-Box--inset-tall-huge'));
+    expect(item16Element.classList.contains('sprk-o-Box--inset-tall-huge')).toBe(true);
   });
 
   it('should apply correct spacing classes for misc-a spacing', () => {
-    expect(item17Element.classList.contains('sprk-o-Box--misc-a'));
+    expect(item17Element.classList.contains('sprk-o-Box--misc-a')).toBe(true);
   });
 
   it('should apply correct spacing classes for misc-b spacing', () => {
-    expect(item18Element.classList.contains('sprk-o-Box--misc-b'));
+    expect(item18Element.classList.contains('sprk-o-Box--misc-b')).toBe(true);
   });
 
   it('should apply correct spacing classes for misc-c spacing', () => {
-    expect(item19Element.classList.contains('sprk-o-Box--misc-c'));
+    expect(item19Element.classList.contains('sprk-o-Box--misc-c')).toBe(true);
   });
 
   it('should apply correct spacing classes for misc-d spacing', () => {

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.spec.ts
@@ -1,5 +1,3 @@
-
-
 import { Component } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SprkCenteredColumnDirective } from './sprk-centered-column.directive';

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.spec.ts
@@ -5,7 +5,7 @@ import { SprkCenteredColumnDirective } from './sprk-centered-column.directive';
 @Component({
   selector: 'sprk-test',
   template: `
-    <div sprkCenteredColumn></div>
+    <div sprkCenteredColumn idString='asdf'></div>
   `
 })
 class TestComponent {}
@@ -33,5 +33,9 @@ describe('Spark Centered Column Directive', () => {
 
   it('should have the correct base classes', () => {
     expect(element.classList.contains('sprk-o-CenteredColumn')).toBe(true);
+  });
+
+  it('should apply correct idString value to data-id', () => {
+    expect(element.getAttribute('data-id') === 'asdf').toBe(true);
   });
 });

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.spec.ts
@@ -1,0 +1,39 @@
+
+
+import { Component } from '@angular/core';
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SprkCenteredColumnDirective } from './sprk-centered-column.directive';
+
+@Component({
+  selector: 'sprk-test',
+  template: `
+    <div sprkCenteredColumn></div>
+  `
+})
+class TestComponent {}
+
+describe('Spark Centered Column Directive', () => {
+  let component: TestComponent;
+  let fixture: ComponentFixture<TestComponent>;
+  let element: HTMLElement;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SprkCenteredColumnDirective, TestComponent]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TestComponent);
+    component = fixture.componentInstance;
+
+    fixture.detectChanges();
+    element = fixture.nativeElement.querySelectorAll('div')[0];
+  }));
+
+  it('should create itself', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should have the correct base classes', () => {
+    expect(element.classList.contains('sprk-o-CenteredColumn')).toBe(true);
+  });
+});

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.ts
@@ -1,0 +1,14 @@
+import { Directive, ElementRef, HostBinding } from '@angular/core';
+
+@Directive({
+  selector: '[sprkCenteredColumn]'
+})
+export class SprkCenteredColumnDirective {
+
+  @HostBinding('class.sprk-o-CenteredColumn') true;
+
+  /**
+   * @ignore
+   */
+  constructor(public ref: ElementRef) {}
+}

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostBinding } from '@angular/core';
+import { Directive, Input, HostBinding } from '@angular/core';
 
 @Directive({
   selector: '[sprkCenteredColumn]'
@@ -8,7 +8,13 @@ export class SprkCenteredColumnDirective {
   @HostBinding('class.sprk-o-CenteredColumn') true;
 
   /**
-   * @ignore
+   * The value supplied will be assigned
+   * to the `data-id` attribute on the
+   * component. This is intended to be
+   * used as a selector for automated
+   * tools. This value should be unique
+   * per page.
    */
-  constructor(public ref: ElementRef) {}
+  @HostBinding('attr.data-id')
+  @Input() idString: string;
 }

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.module.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.module.ts
@@ -1,0 +1,10 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { SprkCenteredColumnDirective } from './sprk-centered-column.directive';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [SprkCenteredColumnDirective],
+  exports: [SprkCenteredColumnDirective]
+})
+export class SprkCenteredColumnModule {}

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.stories.ts
@@ -1,0 +1,42 @@
+import { storyWrapper } from '../../../../../../.storybook/helpers/storyWrapper';
+import { SprkCenteredColumnDirective } from './sprk-centered-column.directive';
+import { SprkCenteredColumnModule } from './sprk-centered-column.module';
+import { markdownDocumentationLinkBuilder } from '../../../../../../../storybook-utilities/markdownDocumentationLinkBuilder';
+
+export default {
+  title: 'Components/Centered Column',
+  component: SprkCenteredColumnDirective,
+  decorators: [storyWrapper(storyContent => `<div class="sprk-o-Box sb-decorate">${storyContent}<div>`)],
+  parameters: {
+    docs: { iframeHeight: 140 },
+    info: `${markdownDocumentationLinkBuilder('centered-column')}
+- The \`sprk-o-CenteredColumn\` class can be applied to
+any parent element that
+is being used to contain the application contents within
+a maximum width.
+    `,
+  }
+};
+
+const modules = {
+  imports: [
+    SprkCenteredColumnModule,
+  ],
+};
+
+export const defaultCenteredColumn = () => ({
+  moduleMetadata: modules,
+  template: `
+    <div sprkCenteredColumn>
+    </div>
+  `,
+});
+
+defaultCenteredColumn.story = {
+  name: 'Default',
+  parameters: {
+    jest: [
+      'sprk-centered-column.directive',
+    ],
+  },
+};

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.stories.ts
@@ -27,7 +27,7 @@ const modules = {
 export const defaultStory = () => ({
   moduleMetadata: modules,
   template: `
-    <div sprkCenteredColumn>
+    <div sprkCenteredColumn idString="foo">
     </div>
   `,
 });

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.stories.ts
@@ -24,7 +24,7 @@ const modules = {
   ],
 };
 
-export const defaultCenteredColumn = () => ({
+export const defaultStory = () => ({
   moduleMetadata: modules,
   template: `
     <div sprkCenteredColumn>
@@ -32,7 +32,7 @@ export const defaultCenteredColumn = () => ({
   `,
 });
 
-defaultCenteredColumn.story = {
+defaultStory.story = {
   name: 'Default',
   parameters: {
     jest: [

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -166,7 +166,7 @@ $sprk-icon-custom-stroke-width-xl: 3px !default;
 ///
 
 /// Width value for the Centered Column layout container.
-$sprk-centered-column-width: 64rem !default;
+$sprk-centered-column-width: 77rem !default;
 
 //
 // Layers

--- a/react/src/objects/centered-column/SprkCenteredColumn.js
+++ b/react/src/objects/centered-column/SprkCenteredColumn.js
@@ -6,15 +6,18 @@ const SprkCenteredColumn = (props) => {
   const {
     children,
     additionalClasses,
+    idString,
+    element,
     ...other
   } = props;
 
   const classNames = classnames('sprk-o-CenteredColumn', additionalClasses);
+  const TagName = element;
 
   return (
-    <div className={classNames} {...other}>
+    <TagName className={classNames} {...other} data-id={idString}>
       {children}
-    </div>
+    </TagName>
   );
 };
 
@@ -24,6 +27,21 @@ SprkCenteredColumn.propTypes = {
    * A space-separated string of classes to add to the outermost container of the component.
    */
   additionalClasses: PropTypes.string,
+  /**
+   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   */
+  idString: PropTypes.string,
+  /**
+   * Determines what element to render.
+   */
+  element: PropTypes.string,
 };
+
+SprkCenteredColumn.defaultProps = {
+  /**
+   * Determines what element to render.
+   */
+  element: "div"
+}
 
 export default SprkCenteredColumn;

--- a/react/src/objects/centered-column/SprkCenteredColumn.js
+++ b/react/src/objects/centered-column/SprkCenteredColumn.js
@@ -41,7 +41,7 @@ SprkCenteredColumn.defaultProps = {
   /**
    * Determines what element to render.
    */
-  element: "div"
+  element: 'div'
 }
 
 export default SprkCenteredColumn;

--- a/react/src/objects/centered-column/SprkCenteredColumn.js
+++ b/react/src/objects/centered-column/SprkCenteredColumn.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+
+const SprkCenteredColumn = (props) => {
+  const {
+    children,
+    additionalClasses,
+    ...other
+  } = props;
+
+  const classNames = classnames('sprk-o-CenteredColumn', additionalClasses);
+
+  return (
+    <div className={classNames} {...other}>
+      {children}
+    </div>
+  );
+};
+
+SprkCenteredColumn.propTypes = {
+  children: PropTypes.node,
+  /**
+   * A space-separated string of classes to add to the outermost container of the component.
+   */
+  additionalClasses: PropTypes.string,
+};
+
+export default SprkCenteredColumn;

--- a/react/src/objects/centered-column/SprkCenteredColumn.stories.js
+++ b/react/src/objects/centered-column/SprkCenteredColumn.stories.js
@@ -21,7 +21,7 @@ a maximum width.
 };
 
 export const defaultStory = () => (
-  <SprkCenteredColumn></SprkCenteredColumn>
+  <SprkCenteredColumn idString="foo"></SprkCenteredColumn>
 );
 
 defaultStory.story = {

--- a/react/src/objects/centered-column/SprkCenteredColumn.stories.js
+++ b/react/src/objects/centered-column/SprkCenteredColumn.stories.js
@@ -20,10 +20,10 @@ a maximum width.
   }
 };
 
-export const defaultCenteredColumn = () => (
+export const defaultStory = () => (
   <SprkCenteredColumn></SprkCenteredColumn>
 );
 
-defaultCenteredColumn.story = {
+defaultStory.story = {
   name: 'Default',
 };

--- a/react/src/objects/centered-column/SprkCenteredColumn.stories.js
+++ b/react/src/objects/centered-column/SprkCenteredColumn.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import SprkCenteredColumn from './SprkCenteredColumn';
+import { markdownDocumentationLinkBuilder } from '../../../../storybook-utilities/markdownDocumentationLinkBuilder';
+
+export default {
+  title: 'Components/Centered Column',
+  component: SprkCenteredColumn,
+  decorators: [
+    story => <div className="sprk-o-Box sb-decorate">{story()}</div>
+  ],
+  parameters: {
+    jest: ['SprkCenteredColumn'],
+    docs: { iframeHeight: 140 },
+    info: `${markdownDocumentationLinkBuilder('centered-column')}
+- The \`sprk-o-CenteredColumn\` class can be applied to
+any parent element that
+is being used to contain the application contents within
+a maximum width.
+    `,
+  }
+};
+
+export const defaultCenteredColumn = () => (
+  <SprkCenteredColumn></SprkCenteredColumn>
+);
+
+defaultCenteredColumn.story = {
+  name: 'Default',
+};

--- a/react/src/objects/centered-column/SprkCenteredColumn.test.js
+++ b/react/src/objects/centered-column/SprkCenteredColumn.test.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import Enzyme, { shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import SprkCenteredColumn from './SprkCenteredColumn';
+
+Enzyme.configure({ adapter: new Adapter() });
+
+describe('SprkCenteredColumn:', () => {
+  it('should display a div with the correct base class', () => {
+    const wrapper = shallow(<SprkCenteredColumn />);
+    expect(wrapper.find('div.sprk-o-CenteredColumn').length).toBe(1);
+  });
+});

--- a/react/src/objects/centered-column/SprkCenteredColumn.test.js
+++ b/react/src/objects/centered-column/SprkCenteredColumn.test.js
@@ -10,4 +10,14 @@ describe('SprkCenteredColumn:', () => {
     const wrapper = shallow(<SprkCenteredColumn />);
     expect(wrapper.find('div.sprk-o-CenteredColumn').length).toBe(1);
   });
+
+  it('should add data-id correctly', () => {
+    const wrapper = shallow(<SprkCenteredColumn idString={'foo'} />);
+    expect(wrapper.find('div.sprk-o-CenteredColumn[data-id="foo"]').length).toBe(1);
+  })
+
+  it('should render with a custom element correctly', () => {
+    const wrapper = shallow(<SprkCenteredColumn element={'main'} />);
+    expect(wrapper.find('main.sprk-o-CenteredColumn').length).toBe(1);
+  })
 });

--- a/src/pages/using-spark/components/centered-column.mdx
+++ b/src/pages/using-spark/components/centered-column.mdx
@@ -14,6 +14,8 @@ page content with a maximum width.
 <ComponentPreview
   componentName="centered-column--default-story"
   hasHTML
+  hasReact
+  hasAngular
 />
 
 ### Usage


### PR DESCRIPTION
## What does this PR do?
- Adds Angular and React CenteredColumn components, tests, stories, and docs
- Changes the default max-width of the centered column from 64rem (1024px) to 77rem (1232px)

### Associated Issue
Fixes 2325
Fixes 2324
Fixes 2584

### Documentation
 - [X] Update Spark Docs

### Code
 - [X] Build Component in HTML
 - [X] Build Component in Angular
 - [X] Build Component in React
 - [X] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [X] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [X] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [X] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
