### PR TITLE
Refactor flag into flexbox, add reverse

### DIFF
--- a/html/objects/_flag.scss
+++ b/html/objects/_flag.scss
@@ -8,7 +8,6 @@
 
 .sprk-o-Flag {
   display: flex;
-  align-items: flex-start;
 }
 
 .sprk-o-Flag__figure {
@@ -16,7 +15,9 @@
 }
 
 .sprk-o-Flag__body {
-  flex: 1;
+  flex-grow: 1;
+  flex-shrink: 1;
+  flex-basis: 0;
 
   > :last-child,
   & {
@@ -118,7 +119,7 @@
 
   /// Stacked flag at smaller screen width.
   .sprk-o-Flag--stacked {
-    flex-flow: column;
+    flex-direction: column;
 
     &.sprk-o-Flag--rev {
       > .sprk-o-Flag__figure {

--- a/html/objects/_flag.scss
+++ b/html/objects/_flag.scss
@@ -122,12 +122,6 @@
   .sprk-o-Flag--stacked {
     flex-direction: column;
 
-    &.sprk-o-Flag--rev {
-      > .sprk-o-Flag__figure {
-        order: 0;
-      }
-    }
-
     > .sprk-o-Flag__figure {
       padding-right: 0;
       padding-left: 0;

--- a/html/objects/_flag.scss
+++ b/html/objects/_flag.scss
@@ -28,8 +28,9 @@
 /// Reverses the flag and places the
 /// image on the right of the body content.
 .sprk-o-Flag--rev {
+  flex-direction: row-reverse;
+
   > .sprk-o-Flag__figure {
-    order: 1;
     padding-right: 0;
     padding-left: $sprk-flag-gutter;
   }

--- a/html/objects/_flag.scss
+++ b/html/objects/_flag.scss
@@ -7,27 +7,16 @@
 ////
 
 .sprk-o-Flag {
-  display: table;
-  width: 100%;
-}
-
-.sprk-o-Flag__body,
-.sprk-o-Flag__figure {
-  display: table-cell;
-  vertical-align: top;
+  display: flex;
+  align-items: flex-start;
 }
 
 .sprk-o-Flag__figure {
   padding-right: $sprk-flag-gutter;
-
-  > img {
-    display: block;
-    max-width: none;
-  }
 }
 
 .sprk-o-Flag__body {
-  width: 100%;
+  flex: 1;
 
   > :last-child,
   & {
@@ -35,17 +24,11 @@
   }
 }
 
-/// Reverses the flag and places the 
+/// Reverses the flag and places the
 /// image on the right of the body content.
 .sprk-o-Flag--rev {
-  direction: rtl;
-
-  > .sprk-o-Flag__body,
   > .sprk-o-Flag__figure {
-    direction: ltr;
-  }
-
-  > .sprk-o-Flag__figure {
+    order: 1;
     padding-right: 0;
     padding-left: $sprk-flag-gutter;
   }
@@ -132,15 +115,15 @@
 }
 
 @media all and (max-width: $sprk-flag-stacked-breakpoint) {
-  
+
   /// Stacked flag at smaller screen width.
   .sprk-o-Flag--stacked {
-    direction: ltr;
+    flex-flow: column;
 
-    > .sprk-o-Flag__body,
-    > .sprk-o-Flag__figure,
-    & {
-      display: block;
+    &.sprk-o-Flag--rev {
+      > .sprk-o-Flag__figure {
+        order: 0;
+      }
     }
 
     > .sprk-o-Flag__figure {

--- a/html/objects/flag.stories.js
+++ b/html/objects/flag.stories.js
@@ -35,3 +35,22 @@ export const defaultStory = () => (
 defaultStory.story = {
   name: 'Default',
 };
+
+export const reverse = () => (
+  `
+    <div class="sprk-o-Flag sprk-o-Flag--stacked sprk-o-Flag--rev">
+      <div class="sprk-o-Flag__figure">
+        <img
+          alt="Provide useful alternative text"
+          src="https://spark-assets.netlify.com/spark-logo-mark.svg"
+        />
+      </div>
+      <div class="sprk-o-Flag__body">
+        <p>
+          Lorem ipsum dolor. Sit amet pede. Tempus donec et.
+          Suspendisse id inventore integer eum non enim diam habitant.
+        </p>
+      </div>
+    </div>
+  `
+);

--- a/src/pages/using-spark/components/flag.mdx
+++ b/src/pages/using-spark/components/flag.mdx
@@ -38,6 +38,13 @@ area can be set to any Spacing value.
 - On small viewports, the content area
 can be configured to move below the media.
 
+### Reverse Modifier
+This modifier rearranges elements of the flag so the media is to the right of the content area.
+<ComponentPreview
+  componentName="flag--reverse"
+  hasHTML
+/>
+
 <SprkDivider
  element="span"
  additionalClasses="sprk-u-Measure"

--- a/src/pages/using-spark/components/flag.mdx
+++ b/src/pages/using-spark/components/flag.mdx
@@ -40,6 +40,8 @@ can be configured to move below the media.
 
 ### Reverse Modifier
 This modifier rearranges elements of the flag so the media is to the right of the content area.
+#### Accessibility
+Tabbing and screen readers are based on DOM order. Keep in mind that this reverse modifier is purely a visual change, not a DOM change. With more complex layouts, be mindful that visual and DOM order misatches will affect keyboard, magnifier, and screen reader users.
 <ComponentPreview
   componentName="flag--reverse"
   hasHTML


### PR DESCRIPTION
## What does this PR do?
HTML - Refactor flag to use flexbox, and add reverse story
![flag](https://user-images.githubusercontent.com/4342363/76653581-531d5e00-653f-11ea-991a-690d6c325bf8.gif)

### Associated Issue
Fixes #2907 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in HTML
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
