### PR TITLE
Add Secondary Spinner to React

### DIFF
--- a/react/src/components/buttons/SprkButton.js
+++ b/react/src/components/buttons/SprkButton.js
@@ -39,7 +39,9 @@ const SprkButton = ({
       href={TagName !== 'button' ? href : undefined}
       {...rest}
     >
-      {(loading && <SprkSpinner />) || children}
+      {(loading &&
+        <SprkSpinner lightness={variant === 'secondary' ? 'dark' : undefined}/>)
+      || children}
     </TagName>
   );
 };

--- a/react/src/components/buttons/SprkButton.stories.js
+++ b/react/src/components/buttons/SprkButton.stories.js
@@ -95,11 +95,23 @@ export const loading = () => (
   </SprkButton>
 );
 
-export const fullWidthAtSmallViewport = () => (
+export const loadingSecondary = () => (
   <SprkButton
+    loading={true}
+    variant="secondary"
     element="button"
     idString="button-6"
     analyticsString="button-6-analytics"
+  >
+    Button
+  </SprkButton>
+);
+
+export const fullWidthAtSmallViewport = () => (
+  <SprkButton
+    element="button"
+    idString="button-7"
+    analyticsString="button-7-analytics"
     additionalClasses="sprk-c-Button--full@s"
   >
     Button
@@ -109,8 +121,8 @@ export const fullWidthAtSmallViewport = () => (
 export const fullWidthAtExtraSmallViewport = () => (
   <SprkButton
     element="button"
-    idString="button-7"
-    analyticsString="button-7-analytics"
+    idString="button-8"
+    analyticsString="button-8-analytics"
     additionalClasses="sprk-c-Button--full@xs"
   >
     Button
@@ -121,8 +133,8 @@ export const asALinkElement = () => (
   <SprkButton
     element="a"
     href="#nogo"
-    idString="button-8"
-    analyticsString="button-8-analytics"
+    idString="button-9"
+    analyticsString="button-9-analytics"
   >
     Button
   </SprkButton>

--- a/react/src/components/buttons/SprkButton.test.js
+++ b/react/src/components/buttons/SprkButton.test.js
@@ -39,6 +39,11 @@ describe('SprkButton:', () => {
     expect(wrapper.find('.sprk-c-Spinner').length).toBe(1);
   });
 
+  it('if loading is set and variant is secondary, should render the secondary spinner', () => {
+    const wrapper = mount(<SprkButton loading variant="secondary"/>);
+    expect(wrapper.find('.sprk-c-Spinner--dark').length).toBe(1);
+  });
+
   it('should add role=button if an anchor is rendered', () => {
     const wrapper = mount(<SprkButton element="a" href="#nogo" />);
     expect(wrapper.find('[role="button"]').length).toBe(1);

--- a/src/pages/using-spark/components/button.mdx
+++ b/src/pages/using-spark/components/button.mdx
@@ -127,6 +127,7 @@ indicator may replace the Button text.
 <ComponentPreview
   componentName="button--loading-secondary"
   hasHTML
+  hasReact
 />
 
 


### PR DESCRIPTION
## What does this PR do?
Add story for Loading Secondary.
Update SprkButton to pass `lightness` to SprkSpinner if `variant='secondary'`
Update documentation on Gatsby site.
Add unit test to cover passing `lightness` to SprkSpinner

### Associated Issue
Fixes #2913 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots
![image](https://user-images.githubusercontent.com/15703773/76864774-0d5edf00-6838-11ea-9041-bac6196d63e9.png)
![image](https://user-images.githubusercontent.com/15703773/76864815-1cde2800-6838-11ea-9687-6e86f4c84fed.png)

