### PR TITLE
Add sprk-flag component to Angular

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -4,6 +4,7 @@ import { SprkFlagComponent } from './sprk-flag.component';
 describe('SprkFlagComponent', () => {
   let component: SprkFlagComponent;
   let fixture: ComponentFixture<SprkFlagComponent>;
+  let flagElement: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -14,6 +15,7 @@ describe('SprkFlagComponent', () => {
   beforeEach(() => {
     fixture = TestBed.createComponent(SprkFlagComponent);
     component = fixture.componentInstance;
+    flagElement = fixture.nativeElement.querySelector('div');
   });
 
   it('should create', () => {
@@ -26,5 +28,18 @@ describe('SprkFlagComponent', () => {
     expect(component.getClasses()).toEqual(
       'sprk-o-Flag sprk-u-pam sprk-u-man'
     );
+  });
+
+  it('should add data-id when idString has a value', () => {
+    const testString = 'element-id';
+    component.idString = testString;
+    fixture.detectChanges();
+    expect(flagElement.getAttribute('data-id')).toEqual(testString);
+  });
+
+  it('should not add data-id when idString has no value', () => {
+    component.idString = null;
+    fixture.detectChanges();
+    expect(flagElement.getAttribute('data-id')).toBeNull();
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -19,4 +19,12 @@ describe('SprkFlagComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+
+  it('should add the correct classes if additionalClasses are supplied', () => {
+    component.additionalClasses = 'sprk-u-pam sprk-u-man';
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-u-pam sprk-u-man'
+    );
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -73,7 +73,7 @@ describe('SprkFlagComponent', () => {
     );
   });
 
-  it('should add the sprk-o-Flag--flush class when spacing="flush" is true', () => {
+  it('should add the sprk-o-Flag--flush class when spacing="flush"', () => {
     component.spacing = 'flush';
     fixture.detectChanges();
     expect(component.getClasses()).toEqual(
@@ -81,7 +81,7 @@ describe('SprkFlagComponent', () => {
     );
   });
 
-  it('should add the sprk-o-Flag--tiny class when spacing="tiny" is true', () => {
+  it('should add the sprk-o-Flag--tiny class when spacing="tiny"', () => {
     component.spacing = 'tiny';
     fixture.detectChanges();
     expect(component.getClasses()).toEqual(
@@ -89,7 +89,7 @@ describe('SprkFlagComponent', () => {
     );
   });
 
-  it('should add the sprk-o-Flag--small class when spacing="small" is true', () => {
+  it('should add the sprk-o-Flag--small class when spacing="small"', () => {
     component.spacing = 'small';
     fixture.detectChanges();
     expect(component.getClasses()).toEqual(
@@ -97,7 +97,7 @@ describe('SprkFlagComponent', () => {
     );
   });
 
-  it('should add the sprk-o-Flag--large class when spacing="large" is true', () => {
+  it('should add the sprk-o-Flag--large class when spacing="large"', () => {
     component.spacing = 'large';
     fixture.detectChanges();
     expect(component.getClasses()).toEqual(
@@ -105,11 +105,27 @@ describe('SprkFlagComponent', () => {
     );
   });
 
-  it('should add the sprk-o-Flag--huge class when spacing="huge" is true', () => {
+  it('should add the sprk-o-Flag--huge class when spacing="huge"', () => {
     component.spacing = 'huge';
     fixture.detectChanges();
     expect(component.getClasses()).toEqual(
       'sprk-o-Flag sprk-o-Flag--huge'
+    );
+  });
+
+  it('should add the sprk-o-Flag--middle class when verticalAlignment="middle"', () => {
+    component.verticalAlignment = 'middle';
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--middle'
+    );
+  });
+
+  it('should add the sprk-o-Flag--bottom class when verticalAlignment="bottom"', () => {
+    component.verticalAlignment = 'bottom';
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--bottom'
     );
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -42,4 +42,12 @@ describe('SprkFlagComponent', () => {
     fixture.detectChanges();
     expect(flagElement.getAttribute('data-id')).toBeNull();
   });
+
+  it('should add the sprk-o-Flag--rev class when isReversed is true', () => {
+    component.isReversed = true;
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--rev'
+    );
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -22,7 +22,6 @@ describe('SprkFlagComponent', () => {
     expect(component).toBeTruthy();
   });
 
-
   it('should add the correct classes if additionalClasses are supplied', () => {
     component.additionalClasses = 'sprk-u-pam sprk-u-man';
     expect(component.getClasses()).toEqual(
@@ -30,9 +29,9 @@ describe('SprkFlagComponent', () => {
     );
   });
 
-  it('should add the correct classes if additionalFigureClasses are supplied', () => {
-    component.additionalFigureClasses = 'sprk-u-pam sprk-u-man';
-    expect(component.getFigureClasses()).toEqual(
+  it('should add the correct classes if additionalMediaClasses are supplied', () => {
+    component.additionalMediaClasses = 'sprk-u-pam sprk-u-man';
+    expect(component.getMediaClasses()).toEqual(
       'sprk-o-Flag__figure sprk-u-pam sprk-u-man'
     );
   });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -30,6 +30,20 @@ describe('SprkFlagComponent', () => {
     );
   });
 
+  it('should add the correct classes if additionalFigureClasses are supplied', () => {
+    component.additionalFigureClasses = 'sprk-u-pam sprk-u-man';
+    expect(component.getFigureClasses()).toEqual(
+      'sprk-o-Flag__figure sprk-u-pam sprk-u-man'
+    );
+  });
+
+  it('should add the correct classes if additionalBodyClasses are supplied', () => {
+    component.additionalBodyClasses = 'sprk-u-pam sprk-u-man';
+    expect(component.getBodyClasses()).toEqual(
+      'sprk-o-Flag__body sprk-u-pam sprk-u-man'
+    );
+  });
+
   it('should add data-id when idString has a value', () => {
     const testString = 'element-id';
     component.idString = testString;

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -72,4 +72,44 @@ describe('SprkFlagComponent', () => {
       'sprk-o-Flag sprk-o-Flag--stacked'
     );
   });
+
+  it('should add the sprk-o-Flag--flush class when spacing="flush" is true', () => {
+    component.spacing = 'flush';
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--flush'
+    );
+  });
+
+  it('should add the sprk-o-Flag--tiny class when spacing="tiny" is true', () => {
+    component.spacing = 'tiny';
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--tiny'
+    );
+  });
+
+  it('should add the sprk-o-Flag--small class when spacing="small" is true', () => {
+    component.spacing = 'small';
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--small'
+    );
+  });
+
+  it('should add the sprk-o-Flag--large class when spacing="large" is true', () => {
+    component.spacing = 'large';
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--large'
+    );
+  });
+
+  it('should add the sprk-o-Flag--huge class when spacing="huge" is true', () => {
+    component.spacing = 'huge';
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--huge'
+    );
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -50,4 +50,12 @@ describe('SprkFlagComponent', () => {
       'sprk-o-Flag sprk-o-Flag--rev'
     );
   });
+
+  it('should add the sprk-o-Flag--stacked class when isStacked is true', () => {
+    component.isStacked = true;
+    fixture.detectChanges();
+    expect(component.getClasses()).toEqual(
+      'sprk-o-Flag sprk-o-Flag--stacked'
+    );
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.spec.ts
@@ -1,0 +1,22 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { SprkFlagComponent } from './sprk-flag.component';
+
+describe('SprkFlagComponent', () => {
+  let component: SprkFlagComponent;
+  let fixture: ComponentFixture<SprkFlagComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SprkFlagComponent]
+    }).compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SprkFlagComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -110,11 +110,11 @@ export class SprkFlagComponent {
       classArray.push(verticalAlignmentClasses[this.verticalAlignment]);
     }
 
-    if (this.isReversed) {
+    if (this.isReversed === true) {
       classArray.push('sprk-o-Flag--rev');
     }
 
-    if (this.isStacked) {
+    if (this.isStacked === true) {
       classArray.push('sprk-o-Flag--stacked');
     }
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -48,7 +48,8 @@ export class SprkFlagComponent {
   isReversed = false;
 
   /**
-   * The Flag component will use this 
+   * The Flag component will use this to stack
+   * the element at the `$sprk-flag-stacked-breakpoint`
    */
   @Input()
   isStacked = false;

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -3,17 +3,17 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'sprk-flag',
   template: `
-  <div
-    [ngClass]="getClasses()"
-    [attr.data-id]="idString"
-  >
-    <div [ngClass]="getFigureClasses()">
-      <ng-content select="[figure-slot]"></ng-content>
+    <div
+      [ngClass]="getClasses()"
+      [attr.data-id]="idString"
+    >
+      <div [ngClass]="getMediaClasses()">
+        <ng-content select="[media-slot]"></ng-content>
+      </div>
+      <div [ngClass]="getBodyClasses()">
+        <ng-content select="[body-slot]"></ng-content>
+      </div>
     </div>
-    <div [ngClass]="getBodyClasses()">
-      <ng-content select="[body-slot]"></ng-content>
-    </div>
-  </div>
   `
 })
 
@@ -21,7 +21,7 @@ export class SprkFlagComponent {
   /**
    * Expects a space separated string
    * of classes to be added to the
-   * component.
+   * component container.
    */
   @Input()
   additionalClasses: string;
@@ -29,10 +29,10 @@ export class SprkFlagComponent {
   /**
    * Expects a space separated string
    * of classes to be added to the
-   * container of the figure-slot.
+   * container of the media-slot.
    */
   @Input()
-  additionalFigureClasses: string;
+  additionalMediaClasses: string;
 
   /**
    * Expects a space separated string
@@ -55,10 +55,10 @@ export class SprkFlagComponent {
 
   /**
    * The Flag component will use this to decide where
-   * the figure-slot is rendered in relation to the
-   * body-slot. The default is the figure-slot is on
-   * the left of the body-slot. isReversed places the
-   * figure-slot on the right of the body-slot.
+   * the media-slot is rendered in relation to the
+   * body-slot. The default is the media-slot is on
+   * the left of the body-slot. isReversed="true" places the
+   * media-slot on the right of the body-slot.
    */
   @Input()
   isReversed = false;
@@ -72,7 +72,7 @@ export class SprkFlagComponent {
 
   /**
    * Determines how much space between the
-   * figure and the body.
+   * media and the body.
    */
   @Input()
   spacing: 'flush' | 'tiny' | 'small' | 'large' | 'huge';
@@ -126,19 +126,23 @@ export class SprkFlagComponent {
 
     return classArray.join(' ');
   }
+  /**
+   * @ignore
+   */
+  getMediaClasses(): string {
+    const mediaClassArray: string[] = ['sprk-o-Flag__figure'];
 
-  getFigureClasses(): string {
-    const figureClassArray: string[] = ['sprk-o-Flag__figure'];
-
-    if (this.additionalFigureClasses) {
-      this.additionalFigureClasses.split(' ').forEach(className => {
-        figureClassArray.push(className);
+    if (this.additionalMediaClasses) {
+      this.additionalMediaClasses.split(' ').forEach(className => {
+        mediaClassArray.push(className);
       });
     }
 
-    return figureClassArray.join(' ');
+    return mediaClassArray.join(' ');
   }
-
+  /**
+   * @ignore
+   */
   getBodyClasses(): string {
     const bodyClassArray: string[] = ['sprk-o-Flag__body'];
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -75,7 +75,7 @@ export class SprkFlagComponent {
    * media and the body.
    */
   @Input()
-  spacing: 'flush' | 'tiny' | 'small' | 'large' | 'huge';
+  spacing: 'flush' | 'tiny' | 'small' | 'medium' | 'large' | 'huge' = 'medium';
 
   /**
    * Determines the vertical alignment of content.
@@ -89,7 +89,7 @@ export class SprkFlagComponent {
   getClasses(): string {
     const classArray: string[] = ['sprk-o-Flag'];
 
-    if (this.spacing) {
+    if (this.spacing !== 'medium') {
       const spacingClasses = {
         flush: 'sprk-o-Flag--flush',
         tiny: 'sprk-o-Flag--tiny',

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -71,10 +71,29 @@ export class SprkFlagComponent {
   isStacked = false;
 
   /**
+   * Determines how much space between the
+   * figure and the body.
+   */
+  @Input()
+  spacing: 'flush' | 'tiny' | 'small' | 'large' | 'huge';
+
+  /**
    * @ignore
    */
   getClasses(): string {
     const classArray: string[] = ['sprk-o-Flag'];
+
+    if (this.spacing) {
+      const spacingClasses = {
+        flush: 'sprk-o-Flag--flush',
+        tiny: 'sprk-o-Flag--tiny',
+        small: 'sprk-o-Flag--small',
+        large: 'sprk-o-Flag--large',
+        huge: 'sprk-o-Flag--huge',
+      };
+
+      classArray.push(spacingClasses[this.spacing]);
+    }
 
     if (this.isReversed) {
       classArray.push('sprk-o-Flag--rev');

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -81,7 +81,7 @@ export class SprkFlagComponent {
    * Determines the vertical alignment of content.
    */
   @Input()
-  verticalAlignment: 'middle' | 'bottom';
+  verticalAlignment: 'top' | 'middle' | 'bottom' = 'top';
 
   /**
    * @ignore
@@ -101,7 +101,7 @@ export class SprkFlagComponent {
       classArray.push(spacingClasses[this.spacing]);
     }
 
-    if (this.verticalAlignment) {
+    if (this.verticalAlignment !== 'top') {
       const verticalAlignmentClasses = {
         middle: 'sprk-o-Flag--middle',
         bottom: 'sprk-o-Flag--bottom',

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -38,10 +38,24 @@ export class SprkFlagComponent {
   idString: string;
 
   /**
+   * The Flag component will use this to decide where
+   * the figure-slot is rendered in relation to the
+   * body-slot. The default is the figure-slot is on
+   * the left of the body-slot. isReversed places the
+   * figure-slot on the right of the body-slot.
+   */
+  @Input()
+  isReversed = false;
+
+  /**
    * @ignore
    */
   getClasses(): string {
     const classArray: string[] = ['sprk-o-Flag'];
+
+    if (this.isReversed) {
+      classArray.push('sprk-o-Flag--rev');
+    }
 
     if (this.additionalClasses) {
       this.additionalClasses.split(' ').forEach(className => {

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -48,6 +48,12 @@ export class SprkFlagComponent {
   isReversed = false;
 
   /**
+   * The Flag component will use this 
+   */
+  @Input()
+  isStacked = false;
+
+  /**
    * @ignore
    */
   getClasses(): string {
@@ -55,6 +61,10 @@ export class SprkFlagComponent {
 
     if (this.isReversed) {
       classArray.push('sprk-o-Flag--rev');
+    }
+
+    if (this.isStacked) {
+      classArray.push('sprk-o-Flag--stacked');
     }
 
     if (this.additionalClasses) {

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -7,10 +7,10 @@ import { Component, Input } from '@angular/core';
     [ngClass]="getClasses()"
     [attr.data-id]="idString"
   >
-    <div class="sprk-o-Flag__figure">
+    <div [ngClass]="getFigureClasses()">
       <ng-content select="[figure-slot]"></ng-content>
     </div>
-    <div class="sprk-o-Flag__body">
+    <div [ngClass]="getBodyClasses()">
       <ng-content select="[body-slot]"></ng-content>
     </div>
   </div>
@@ -25,6 +25,22 @@ export class SprkFlagComponent {
    */
   @Input()
   additionalClasses: string;
+
+  /**
+   * Expects a space separated string
+   * of classes to be added to the
+   * container of the figure-slot.
+   */
+  @Input()
+  additionalFigureClasses: string;
+
+  /**
+   * Expects a space separated string
+   * of classes to be added to the
+   * container of the body-slot.
+   */
+  @Input()
+  additionalBodyClasses: string;
 
   /**
    * The value supplied will be assigned
@@ -75,5 +91,29 @@ export class SprkFlagComponent {
     }
 
     return classArray.join(' ');
+  }
+
+  getFigureClasses(): string {
+    const figureClassArray: string[] = ['sprk-o-Flag__figure'];
+
+    if (this.additionalFigureClasses) {
+      this.additionalFigureClasses.split(' ').forEach(className => {
+        figureClassArray.push(className);
+      });
+    }
+
+    return figureClassArray.join(' ');
+  }
+
+  getBodyClasses(): string {
+    const bodyClassArray: string[] = ['sprk-o-Flag__body'];
+
+    if (this.additionalBodyClasses) {
+      this.additionalBodyClasses.split(' ').forEach(className => {
+        bodyClassArray.push(className);
+      });
+    }
+
+    return bodyClassArray.join(' ');
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -110,11 +110,11 @@ export class SprkFlagComponent {
       classArray.push(verticalAlignmentClasses[this.verticalAlignment]);
     }
 
-    if (this.isReversed === true) {
+    if (this.isReversed !== false) {
       classArray.push('sprk-o-Flag--rev');
     }
 
-    if (this.isStacked === true) {
+    if (this.isStacked !== false) {
       classArray.push('sprk-o-Flag--stacked');
     }
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -110,11 +110,11 @@ export class SprkFlagComponent {
       classArray.push(verticalAlignmentClasses[this.verticalAlignment]);
     }
 
-    if (this.isReversed !== false) {
+    if (this.isReversed) {
       classArray.push('sprk-o-Flag--rev');
     }
 
-    if (this.isStacked !== false) {
+    if (this.isStacked) {
       classArray.push('sprk-o-Flag--stacked');
     }
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -1,0 +1,19 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'sprk-flag',
+  template: `
+  <div class="sprk-o-Flag sprk-o-Flag--stacked">
+    <div class="sprk-o-Flag__figure">
+      <ng-content select="[figure-slot]"></ng-content>
+    </div>
+    <div class="sprk-o-Flag__body">
+      <ng-content select="[body-slot]"></ng-content>
+    </div>
+  </div>
+  `
+})
+
+export class SprkFlagComponent {
+
+}

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -3,7 +3,10 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'sprk-flag',
   template: `
-  <div [ngClass]="getClasses()">
+  <div
+    [ngClass]="getClasses()"
+    [attr.data-id]="idString"
+  >
     <div class="sprk-o-Flag__figure">
       <ng-content select="[figure-slot]"></ng-content>
     </div>
@@ -22,6 +25,17 @@ export class SprkFlagComponent {
    */
   @Input()
   additionalClasses: string;
+
+  /**
+   * The value supplied will be assigned
+   * to the `data-id` attribute on the
+   * component. This is intended to be
+   * used as a selector for automated
+   * tools. This value should be unique
+   * per page.
+   */
+  @Input()
+  idString: string;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'sprk-flag',
   template: `
-  <div class="sprk-o-Flag sprk-o-Flag--stacked">
+  <div [ngClass]="getClasses()">
     <div class="sprk-o-Flag__figure">
       <ng-content select="[figure-slot]"></ng-content>
     </div>
@@ -15,5 +15,26 @@ import { Component, Input } from '@angular/core';
 })
 
 export class SprkFlagComponent {
+  /**
+   * Expects a space separated string
+   * of classes to be added to the
+   * component.
+   */
+  @Input()
+  additionalClasses: string;
 
+  /**
+   * @ignore
+   */
+  getClasses(): string {
+    const classArray: string[] = ['sprk-o-Flag'];
+
+    if (this.additionalClasses) {
+      this.additionalClasses.split(' ').forEach(className => {
+        classArray.push(className);
+      });
+    }
+
+    return classArray.join(' ');
+  }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.component.ts
@@ -78,6 +78,12 @@ export class SprkFlagComponent {
   spacing: 'flush' | 'tiny' | 'small' | 'large' | 'huge';
 
   /**
+   * Determines the vertical alignment of content.
+   */
+  @Input()
+  verticalAlignment: 'middle' | 'bottom';
+
+  /**
    * @ignore
    */
   getClasses(): string {
@@ -93,6 +99,15 @@ export class SprkFlagComponent {
       };
 
       classArray.push(spacingClasses[this.spacing]);
+    }
+
+    if (this.verticalAlignment) {
+      const verticalAlignmentClasses = {
+        middle: 'sprk-o-Flag--middle',
+        bottom: 'sprk-o-Flag--bottom',
+      };
+
+      classArray.push(verticalAlignmentClasses[this.verticalAlignment]);
     }
 
     if (this.isReversed) {

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.module.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.module.ts
@@ -1,0 +1,11 @@
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { SprkFlagComponent } from './sprk-flag.component';
+
+@NgModule({
+  imports: [CommonModule],
+  declarations: [SprkFlagComponent],
+  exports: [SprkFlagComponent]
+})
+
+export class SprkFlagModule {}

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -28,7 +28,9 @@ const modules = {
 export const defaultStory = () => ({
   moduleMetadata: modules,
   template: `
-    <sprk-flag>
+    <sprk-flag
+      isStacked="true"
+    >
       <img
         figure-slot
         alt="Provide useful alternative text"
@@ -50,7 +52,10 @@ export const reverse = () => ({
   moduleMetadata: modules,
   template:
   `
-    <sprk-flag isReversed="true">
+    <sprk-flag
+      isStacked="true"
+      isReversed="true"
+    >
         <img
           figure-slot
           alt="Provide useful alternative text"

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -14,7 +14,15 @@ export default {
     )
   ],
   parameters: {
-    info: `${markdownDocumentationLinkBuilder('flag')}`,
+    info: `
+${markdownDocumentationLinkBuilder('flag')}
+- The Flag component has two slots to inject markup
+into the component template.
+    - \`figure-slot\`: Used for adding the media to the component.
+    - \`body-slot\`: Used for adding the body content to the component.
+- If you pass something into the Flag component that is not
+in one of the slots mentioned above, it will not render.
+`,
   },
 };
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -57,7 +57,7 @@ defaultStory.story = {
   },
 };
 
-export const reverse = () => ({
+export const reversed = () => ({
   moduleMetadata: modules,
   template: `
     <sprk-flag
@@ -76,7 +76,7 @@ export const reverse = () => ({
   `
 });
 
-reverse.story = {
+reversed.story = {
   parameters: {
     jest: ['sprk-flag.component'],
   },

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -14,6 +14,7 @@ export default {
     )
   ],
   parameters: {
+    docs: { iframeHeight: 200 },
     info: `
 ${markdownDocumentationLinkBuilder('flag')}
 - The Flag component has two slots to inject markup

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -1,0 +1,42 @@
+import { storyWrapper } from '../../../../../../.storybook/helpers/storyWrapper';
+import { SprkFlagModule } from './sprk-flag.module';
+import { SprkFlagComponent } from './sprk-flag.component';
+import { markdownDocumentationLinkBuilder } from '../../../../../../../storybook-utilities/markdownDocumentationLinkBuilder';
+
+export default {
+  title: 'Components/Flag',
+  component: SprkFlagComponent,
+  decorators: [
+    storyWrapper(
+      storyContent => (
+        `<div class="sprk-o-Box">${ storyContent }<div>`
+      )
+    )
+  ],
+  parameters: {
+    info: `${markdownDocumentationLinkBuilder('flag')}`,
+  },
+};
+
+const modules = {
+  imports: [
+    SprkFlagModule,
+  ],
+};
+
+export const defaultStory = () => ({
+  moduleMetadata: modules,
+  template: `
+    <sprk-flag>
+      <img
+        figure-slot
+        alt="Provide useful alternative text"
+        src="https://spark-assets.netlify.com/spark-logo-mark.svg"
+      />
+      <p body-slot>
+        Lorem ipsum dolor. Sit amet pede. Tempus donec et.
+        Suspendisse id inventore integer eum non enim diam habitant.
+      </p>
+    </sprk-flag>
+  `
+});

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -2,6 +2,7 @@ import { storyWrapper } from '../../../../../../.storybook/helpers/storyWrapper'
 import { SprkFlagModule } from './sprk-flag.module';
 import { SprkFlagComponent } from './sprk-flag.component';
 import { markdownDocumentationLinkBuilder } from '../../../../../../../storybook-utilities/markdownDocumentationLinkBuilder';
+import { ModuleWithProviders } from '@angular/core';
 
 export default {
   title: 'Components/Flag',
@@ -37,6 +38,28 @@ export const defaultStory = () => ({
         Lorem ipsum dolor. Sit amet pede. Tempus donec et.
         Suspendisse id inventore integer eum non enim diam habitant.
       </p>
+    </sprk-flag>
+  `
+});
+
+defaultStory.story = {
+  name: 'Default',
+};
+
+export const reverse = () => ({
+  moduleMetadata: modules,
+  template:
+  `
+    <sprk-flag isReversed="true">
+        <img
+          figure-slot
+          alt="Provide useful alternative text"
+          src="https://spark-assets.netlify.com/spark-logo-mark.svg"
+        />
+        <p body-slot>
+          Lorem ipsum dolor. Sit amet pede. Tempus donec et.
+          Suspendisse id inventore integer eum non enim diam habitant.
+        </p>
     </sprk-flag>
   `
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -2,7 +2,6 @@ import { storyWrapper } from '../../../../../../.storybook/helpers/storyWrapper'
 import { SprkFlagModule } from './sprk-flag.module';
 import { SprkFlagComponent } from './sprk-flag.component';
 import { markdownDocumentationLinkBuilder } from '../../../../../../../storybook-utilities/markdownDocumentationLinkBuilder';
-import { ModuleWithProviders } from '@angular/core';
 
 export default {
   title: 'Components/Flag',
@@ -28,9 +27,7 @@ const modules = {
 export const defaultStory = () => ({
   moduleMetadata: modules,
   template: `
-    <sprk-flag
-      isStacked="true"
-    >
+    <sprk-flag>
       <img
         figure-slot
         alt="Provide useful alternative text"
@@ -53,18 +50,36 @@ export const reverse = () => ({
   template:
   `
     <sprk-flag
-      isStacked="true"
       isReversed="true"
     >
-        <img
-          figure-slot
-          alt="Provide useful alternative text"
-          src="https://spark-assets.netlify.com/spark-logo-mark.svg"
-        />
-        <p body-slot>
-          Lorem ipsum dolor. Sit amet pede. Tempus donec et.
-          Suspendisse id inventore integer eum non enim diam habitant.
-        </p>
+      <img
+        figure-slot
+        alt="Provide useful alternative text"
+        src="https://spark-assets.netlify.com/spark-logo-mark.svg"
+      />
+      <p body-slot>
+        Lorem ipsum dolor. Sit amet pede. Tempus donec et.
+        Suspendisse id inventore integer eum non enim diam habitant.
+      </p>
+    </sprk-flag>
+  `
+});
+
+export const stacked = () => ({
+  moduleMetadata: modules,
+  template: `
+    <sprk-flag
+      isStacked="true"
+    >
+      <img
+        figure-slot
+        alt="Provide useful alternative text"
+        src="https://spark-assets.netlify.com/spark-logo-mark.svg"
+      />
+      <p body-slot>
+        Lorem ipsum dolor. Sit amet pede. Tempus donec et.
+        Suspendisse id inventore integer eum non enim diam habitant.
+      </p>
     </sprk-flag>
   `
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -61,7 +61,7 @@ export const reverse = () => ({
   moduleMetadata: modules,
   template: `
     <sprk-flag
-      isReversed="true"
+      [isReversed]="true"
     >
       <img
         media-slot
@@ -86,7 +86,7 @@ export const stacked = () => ({
   moduleMetadata: modules,
   template: `
     <sprk-flag
-      isStacked="true"
+      [isStacked]="true"
     >
       <img
         media-slot

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -43,6 +43,9 @@ export const defaultStory = () => ({
 
 defaultStory.story = {
   name: 'Default',
+  parameters: {
+    jest: ['sprk-flag.component'],
+  },
 };
 
 export const reverse = () => ({
@@ -65,6 +68,12 @@ export const reverse = () => ({
   `
 });
 
+reverse.story = {
+  parameters: {
+    jest: ['sprk-flag.component'],
+  },
+};
+
 export const stacked = () => ({
   moduleMetadata: modules,
   template: `
@@ -83,3 +92,9 @@ export const stacked = () => ({
     </sprk-flag>
   `
 });
+
+stacked.story = {
+  parameters: {
+    jest: ['sprk-flag.component'],
+  },
+};

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -59,8 +59,7 @@ defaultStory.story = {
 
 export const reverse = () => ({
   moduleMetadata: modules,
-  template:
-  `
+  template: `
     <sprk-flag
       isReversed="true"
     >

--- a/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-flag/sprk-flag.stories.ts
@@ -18,7 +18,7 @@ export default {
 ${markdownDocumentationLinkBuilder('flag')}
 - The Flag component has two slots to inject markup
 into the component template.
-    - \`figure-slot\`: Used for adding the media to the component.
+    - \`media-slot\`: Used for adding the media to the component.
     - \`body-slot\`: Used for adding the body content to the component.
 - If you pass something into the Flag component that is not
 in one of the slots mentioned above, it will not render.
@@ -37,7 +37,7 @@ export const defaultStory = () => ({
   template: `
     <sprk-flag>
       <img
-        figure-slot
+        media-slot
         alt="Provide useful alternative text"
         src="https://spark-assets.netlify.com/spark-logo-mark.svg"
       />
@@ -64,7 +64,7 @@ export const reverse = () => ({
       isReversed="true"
     >
       <img
-        figure-slot
+        media-slot
         alt="Provide useful alternative text"
         src="https://spark-assets.netlify.com/spark-logo-mark.svg"
       />
@@ -89,7 +89,7 @@ export const stacked = () => ({
       isStacked="true"
     >
       <img
-        figure-slot
+        media-slot
         alt="Provide useful alternative text"
         src="https://spark-assets.netlify.com/spark-logo-mark.svg"
       />

--- a/angular/projects/spark-angular/src/lib/spark-angular.module.ts
+++ b/angular/projects/spark-angular/src/lib/spark-angular.module.ts
@@ -60,6 +60,7 @@ import { SprkBoxModule } from './directives/sprk-box/sprk-box.module';
 import { SprkTextModule } from './directives/sprk-text/sprk-text.module';
 import { SprkHeadingModule } from './directives/sprk-heading/sprk-heading.module';
 import { SprkLinkDirectiveModule } from './directives/sprk-link/sprk-link.module';
+import { SprkFlagModule } from './components/sprk-flag/sprk-flag.module';
 
 @NgModule({
   exports: [
@@ -114,7 +115,8 @@ import { SprkLinkDirectiveModule } from './directives/sprk-link/sprk-link.module
     SprkBoxModule,
     SprkTextModule,
     SprkHeadingModule,
-    SprkLinkDirectiveModule
+    SprkLinkDirectiveModule,
+    SprkFlagModule,
   ]
 })
 export class SparkAngularModule {}

--- a/html/objects/_flag.scss
+++ b/html/objects/_flag.scss
@@ -102,18 +102,12 @@
 
 /// Vertically align content to the middle.
 .sprk-o-Flag--middle {
-  > .sprk-o-Flag__body,
-  > .sprk-o-Flag__figure {
-    vertical-align: middle;
-  }
+  align-items: center;
 }
 
 /// Vertically align content to the bottom.
 .sprk-o-Flag--bottom {
-  > .sprk-o-Flag__body,
-  > .sprk-o-Flag__figure {
-    vertical-align: bottom;
-  }
+  align-items: flex-end;
 }
 
 @media all and (max-width: $sprk-flag-stacked-breakpoint) {

--- a/src/pages/using-spark/components/flag.mdx
+++ b/src/pages/using-spark/components/flag.mdx
@@ -17,6 +17,7 @@ alignment and renamed the
 <ComponentPreview
   componentName="flag--default-story"
   hasHTML
+  hasAngular
 />
 
 ### Usage
@@ -45,6 +46,7 @@ Tabbing and screen readers are based on DOM order. Keep in mind that this revers
 <ComponentPreview
   componentName="flag--reverse"
   hasHTML
+  hasAngular
 />
 
 <SprkDivider

--- a/src/pages/using-spark/components/flag.mdx
+++ b/src/pages/using-spark/components/flag.mdx
@@ -49,6 +49,13 @@ Tabbing and screen readers are based on DOM order. Keep in mind that this revers
   hasAngular
 />
 
+### Stacked Modifier
+This modifier stacks the elements at the `$sprk-flag-stacked-breakpoint`
+<ComponentPreview
+  componentName="flag--stacked"
+  hasAngular
+/>
+
 <SprkDivider
  element="span"
  additionalClasses="sprk-u-Measure"


### PR DESCRIPTION
## What does this PR do?
Add sprk-flag component to Angular.
Add story file to Angular.
Add tests for sprk-flag.
Update Gatsby Documentation for sprk-flag.
Add sprk-flag to spark-angular.module.ts.

### Associated Issue
Fixes #2901 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots
![image](https://user-images.githubusercontent.com/15703773/77004101-ed611580-6934-11ea-8ad7-d1247b213aca.png)
![image](https://user-images.githubusercontent.com/15703773/77004118-f2be6000-6934-11ea-8ff7-bfc90e4f4816.png)
