### PR TITLE
update spinner for secondary buttons in angular

### DIFF
--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
@@ -57,6 +57,8 @@ describe('Spark Button Directive', () => {
   });
 
   it('should add the dark spinner class when isSpinning is true on a secondary button', () => {
+    const spinnerNotThere = button3Element.querySelector('.sprk-c-Spinner');
+    expect(spinnerNotThere).toBeNull();
     component.spinnerVal = true;
     fixture.detectChanges();
     const spinner = button3Element.querySelector('.sprk-c-Spinner');

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
@@ -16,6 +16,7 @@ import { SprkButtonDirective } from './sprk-button.directive';
       Test 3
     </button>
     <button class="sprk-c-Button--tertiary" sprkButton>Test 4</button>
+    <button variant="tertiary" sprkButton>Test 5</button>
   `
 })
 class TestComponent {
@@ -29,6 +30,7 @@ describe('Spark Button Directive', () => {
   let button2Element: HTMLElement;
   let button3Element: HTMLElement;
   let button4Element: HTMLElement;
+  let button5Element: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -43,6 +45,7 @@ describe('Spark Button Directive', () => {
     button2Element = fixture.nativeElement.querySelectorAll('button')[1];
     button3Element = fixture.nativeElement.querySelectorAll('button')[2];
     button4Element = fixture.nativeElement.querySelectorAll('button')[3];
+    button5Element = fixture.nativeElement.querySelectorAll('button')[4];
   }));
 
   it('should create itself', () => {
@@ -58,6 +61,18 @@ describe('Spark Button Directive', () => {
     fixture.detectChanges();
     const spinner = button3Element.querySelector('.sprk-c-Spinner');
     expect(spinner.classList.contains('sprk-c-Spinner--dark')).toBe(true);
+  });
+
+  it('should add the default button class when variant is not set', () => {
+    expect(button1Element.classList.contains('sprk-c-Button')).toBe(true);
+  });
+
+  it('should add the secondary button class when variant is tertiary', () => {
+    expect(button3Element.classList.contains('sprk-c-Button--secondary')).toBe(true);
+  });
+
+  it('should add the tertiary button class when variant is tertiary', () => {
+    expect(button5Element.classList.contains('sprk-c-Button--tertiary')).toBe(true);
   });
 
   it('should add the value of analyticsString to data-analytics', () => {

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
@@ -20,7 +20,7 @@ import { SprkButtonDirective } from './sprk-button.directive';
   `
 })
 class TestComponent {
- spinnerVal = false;
+  spinnerVal = false;
 }
 
 describe('Spark Button Directive', () => {

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.spec.ts
@@ -5,17 +5,30 @@ import { SprkButtonDirective } from './sprk-button.directive';
 @Component({
   selector: 'sprk-test',
   template: `
-    <button sprkButton></button>
-    <button sprkButton [isSpinning]="true"></button>
+    <button sprkButton>Test 1</button>
+    <button sprkButton [isSpinning]="true">Test 2</button>
+    <button
+      sprkButton
+      variant="secondary"
+      analyticsString="test"
+      idString="id-test"
+      [isSpinning]="spinnerVal">
+      Test 3
+    </button>
+    <button class="sprk-c-Button--tertiary" sprkButton>Test 4</button>
   `
 })
-class TestComponent {}
+class TestComponent {
+ spinnerVal = false;
+}
 
 describe('Spark Button Directive', () => {
   let component: TestComponent;
   let fixture: ComponentFixture<TestComponent>;
   let button1Element: HTMLElement;
   let button2Element: HTMLElement;
+  let button3Element: HTMLElement;
+  let button4Element: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -28,6 +41,8 @@ describe('Spark Button Directive', () => {
     fixture.detectChanges();
     button1Element = fixture.nativeElement.querySelectorAll('button')[0];
     button2Element = fixture.nativeElement.querySelectorAll('button')[1];
+    button3Element = fixture.nativeElement.querySelectorAll('button')[2];
+    button4Element = fixture.nativeElement.querySelectorAll('button')[3];
   }));
 
   it('should create itself', () => {
@@ -36,5 +51,35 @@ describe('Spark Button Directive', () => {
 
   it('should contain a spinner if isSpinning is true', () => {
     expect(button2Element.querySelectorAll('.sprk-c-Spinner').length).toBe(1);
+  });
+
+  it('should add the dark spinner class when isSpinning is true on a secondary button', () => {
+    component.spinnerVal = true;
+    fixture.detectChanges();
+    const spinner = button3Element.querySelector('.sprk-c-Spinner');
+    expect(spinner.classList.contains('sprk-c-Spinner--dark')).toBe(true);
+  });
+
+  it('should add the value of analyticsString to data-analytics', () => {
+    expect(button3Element.getAttribute('data-analytics')).toBe('test');
+  });
+
+  it('should add the value of idString to data-id', () => {
+    expect(button3Element.getAttribute('data-id')).toBe('id-test');
+  });
+
+  // This test makes sure the new variant @Input isn't a breaking change
+  it('should still add the correct button class if variant is not used', () => {
+    expect(button4Element.classList.contains('sprk-c-Button')).toBe(true);
+    expect(button4Element.classList.contains('sprk-c-Button--tertiary')).toBe(true);
+  });
+
+  it('should fire setSpinning if isSpinning input is changed after first load', () => {
+    const spinnerEl = button3Element.querySelector('.sprk-c-Spinner');
+    expect(spinnerEl).toBeNull();
+    component.spinnerVal = true;
+    fixture.detectChanges();
+    const spinner = button3Element.querySelector('.sprk-c-Spinner');
+    expect(spinner).toBeTruthy();
   });
 });

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.ts
@@ -93,12 +93,27 @@ export class SprkButtonDirective implements OnInit, OnChanges, AfterViewInit {
     const el = element;
     const width = element.offsetWidth;
     let spinnerClass = 'sprk-c-Spinner sprk-c-Spinner--circle';
-    if (el.classList.contains('sprk-c-Button--secondary') || this.variant === 'secondary') {
+    if (
+        el.classList.contains('sprk-c-Button--secondary') ||
+        this.variant === 'secondary') {
       spinnerClass += ' sprk-c-Spinner--dark';
     }
-    el.setAttribute('data-sprk-spinner-text', el.textContent);
+    this.renderer.setAttribute(
+      el,
+      'data-sprk-spinner-text',
+      el.textContent,
+    );
     el.innerHTML = `<div class="${spinnerClass}"></div>`;
     el.setAttribute('data-sprk-has-spinner', 'true');
-    el.setAttribute('style', `width: ${width}px`);
+    this.renderer.setAttribute(
+      el,
+      'data-sprk-has-spinner',
+      'true',
+    );
+    this.renderer.setAttribute(
+      el,
+      'style',
+      `width: ${width}px`,
+    );
   }
 }

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.ts
@@ -1,13 +1,21 @@
-import { Directive, ElementRef, OnInit, Input } from '@angular/core';
+import {
+  Directive,
+  ElementRef,
+  OnInit,
+  Input,
+  HostBinding,
+  OnChanges,
+  Renderer2,
+} from '@angular/core';
 
 @Directive({
   selector: '[sprkButton]'
 })
-export class SprkButtonDirective implements OnInit {
+export class SprkButtonDirective implements OnInit, OnChanges {
   /**
    * @ignore
    */
-  constructor(public ref: ElementRef) {}
+  constructor(public ref: ElementRef, private renderer: Renderer2) {}
 
   /**
    * Will show a spinner inside the
@@ -16,18 +24,49 @@ export class SprkButtonDirective implements OnInit {
   @Input() isSpinning = false;
 
   /**
-   * @ignore
+   *  Determines the coresponding button style.
    */
-  getClasses(): string[] {
-    const classArray: string[] = [];
-    classArray.push('sprk-c-Button');
-    return classArray;
-  }
+  @Input() variant: 'primary'| 'secondary' | 'tertiary' = 'primary';
+
+  // Always set the button class on the element
+  @HostBinding('class.sprk-c-Button') true;
+
+  /**
+   * The value supplied will be assigned
+   * to the `data-id` attribute on the
+   * component. This is intended to be
+   * used as a selector for automated
+   * tools. This value should be unique
+   * per page.
+   */
+  @HostBinding('attr.data-id')
+  @Input() idString: string;
+
+  /**
+   * The value supplied will be assigned to the
+   * `data-analytics` attribute on the element.
+   * Intended for an outside
+   * library to capture data.
+   */
+  @HostBinding('attr.data-analytics')
+  @Input() analyticsString: string;
 
   ngOnInit(): void {
-    this.getClasses().forEach(item => {
-      this.ref.nativeElement.classList.add(item);
-    });
+    if (this.variant === 'secondary') {
+      this.renderer.addClass(
+        this.ref.nativeElement,
+        'sprk-c-Button--secondary'
+      );
+    }
+    if (this.variant === 'tertiary') {
+      this.renderer.addClass(
+        this.ref.nativeElement,
+        'sprk-c-Button--tertiary'
+      );
+    }
+  }
+
+  ngOnChanges(): void {
     if (this.isSpinning) {
       this.setSpinning(this.ref.nativeElement);
     }
@@ -38,8 +77,12 @@ export class SprkButtonDirective implements OnInit {
   setSpinning = (element) => {
     const el = element;
     const width = element.offsetWidth;
+    let spinnerClass = 'sprk-c-Spinner sprk-c-Spinner--circle';
+    if (el.classList.contains('sprk-c-Button--secondary') || this.variant === 'secondary') {
+      spinnerClass += ' sprk-c-Spinner--dark';
+    }
     el.setAttribute('data-sprk-spinner-text', el.textContent);
-    el.innerHTML = `<div class="sprk-c-Spinner sprk-c-Spinner--circle"></div>`;
+    el.innerHTML = `<div class="${spinnerClass}"></div>`;
     el.setAttribute('data-sprk-has-spinner', 'true');
     el.setAttribute('style', `width: ${width}px`);
   }

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.directive.ts
@@ -6,12 +6,14 @@ import {
   HostBinding,
   OnChanges,
   Renderer2,
+  AfterViewInit,
+  SimpleChanges,
 } from '@angular/core';
 
 @Directive({
   selector: '[sprkButton]'
 })
-export class SprkButtonDirective implements OnInit, OnChanges {
+export class SprkButtonDirective implements OnInit, OnChanges, AfterViewInit {
   /**
    * @ignore
    */
@@ -66,11 +68,24 @@ export class SprkButtonDirective implements OnInit, OnChanges {
     }
   }
 
-  ngOnChanges(): void {
+  /**
+   * Add spinner only after view has loaded.
+   * This is to allow time for the text
+   * content of the button to load so that
+   * the width value accounts for that text.
+   */
+  ngAfterViewInit() {
     if (this.isSpinning) {
       this.setSpinning(this.ref.nativeElement);
     }
   }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (this.isSpinning && !changes['isSpinning'].isFirstChange()) {
+      this.setSpinning(this.ref.nativeElement);
+    }
+  }
+
   /**
    * @ignore
    */

--- a/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/inputs/sprk-button/sprk-button.stories.ts
@@ -56,7 +56,7 @@ export const primary = () => ({
   moduleMetadata: modules,
   template: `
     <button
-      data-id="button-primary"
+      idString="button-primary"
       sprkButton
     >
       Button
@@ -76,8 +76,8 @@ export const secondary = () => ({
   moduleMetadata: modules,
   template: `
     <button
-      class="sprk-c-Button--secondary"
-      data-id="button-secondary"
+      variant="secondary"
+      idString="button-secondary"
       sprkButton
     >
       Button
@@ -97,8 +97,8 @@ export const tertiary = () => ({
   moduleMetadata: modules,
   template: `
     <button
-      class="sprk-c-Button--tertiary"
-      data-id="button-tertiary"
+      variant="tertiary"
+      idString="button-tertiary"
       sprkButton
     >
       Button
@@ -119,7 +119,7 @@ export const disabled = () => ({
   template: `
     <button
       disabled
-      data-id="button-disabled"
+      idString="button-disabled"
       sprkButton
     >
       Button
@@ -140,7 +140,8 @@ export const loading = () => {
     moduleMetadata: modules,
     template: `
       <button
-        data-id="button-loading"
+        idString="button-loading"
+        analyticsString="loading"
         sprkButton
         [isSpinning]="true"
       >
@@ -158,13 +159,37 @@ loading.story = {
   },
 };
 
+export const loadingSecondary = () => {
+  return {
+    moduleMetadata: modules,
+    template: `
+      <button
+        variant="secondary"
+        idString="button-loading-secondary"
+        sprkButton
+        [isSpinning]="true"
+      >
+        Button
+      </button>
+    `,
+  };
+};
+
+loadingSecondary.story = {
+  parameters: {
+    jest: [
+      'sprk-button.directive',
+    ],
+  },
+};
+
 export const fullWidthAtSmallViewport = () => {
   return {
     moduleMetadata: modules,
     template: `
       <button
         class="sprk-c-Button--full@s"
-        data-id="button-full-width-at-small"
+        idString="button-full-width-at-small"
         sprkButton
       >
         Button
@@ -188,7 +213,7 @@ export const fullWidthAtExtraSmallViewport = () => {
     template: `
       <button
         class="sprk-c-Button--full@xs"
-        data-id="button-full-width-at-extra-small"
+        idString="button-full-width-at-extra-small"
         sprkButton
       >
         Button

--- a/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.directive.spec.ts
@@ -57,7 +57,6 @@ describe('SprkLink Directive', () => {
   });
 
   it('should apply correct Spark classes for simple variant', () => {
-    console.log(linkSimple, 'kasjfklasjdf;kds clases')
     expect(linkSimple.classList.contains('sprk-b-Link')).toBe(true);
     expect(linkSimple.classList.contains('sprk-b-Link--simple')).toBe(true);
   });


### PR DESCRIPTION
## What does this PR do?
Updates the button directive to add the spinner dark modifier class to secondary button spinners when they have a spinner. This also adds an input of idString, variant, and analyticsString. This new code also ensures that If sprkButtons are currently being used still with "class="sprk-c-Button--secondary" instead of using the new variant input they will not break. A unit test was added to check this. This also adds a new story to the Angular Storybook that showcases the secondary button with a spinner, "Loading Secondary".

### Associated Issue
Fixes #2912 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs

### Code
 - [ ] Build Component in HTML
 - [x] Build Component in Angular
 - [ ] Build Component in React
 - [ ] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [ ] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Accessibility
- [ ] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
<img width="732" alt="Screen Shot 2020-03-18 at 11 55 59 AM" src="https://user-images.githubusercontent.com/2117593/76980372-7bc2a080-690f-11ea-86f4-ce261bb5876e.png">
