### PR TITLE
Link Deprecation Docs and Warning

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.component.ts
@@ -4,23 +4,23 @@ import { Router } from '@angular/router';
   selector: 'sprk-link',
   template: `
     <a
-      (click)="handleClick($event)"
-      [ngClass]="getClasses()"
-      [href]="href"
-      [attr.data-analytics]="analyticsString"
-      [attr.target]="target"
-      [attr.data-id]="idString"
-      [attr.disabled]="isDisabled"
-      [attr.aria-controls]="ariaControls"
-      [attr.aria-label]="ariaLabel"
-      [attr.aria-labelledby]="ariaLabelledby"
-      [attr.aria-haspopup]="ariaHasPopUp"
-      [attr.role]="role"
-      [attr.id]="id"
-      [attr.aria-current]="ariaCurrent"
-      [attr.aria-expanded]="ariaExpanded"
-      [attr.aria-hidden]="ariaHidden"
-      [attr.aria-selected]="ariaSelected"
+      (click)='handleClick($event)'
+      [ngClass]='getClasses()'
+      [href]='href'
+      [attr.data-analytics]='analyticsString'
+      [attr.target]='target'
+      [attr.data-id]='idString'
+      [attr.disabled]='isDisabled'
+      [attr.aria-controls]='ariaControls'
+      [attr.aria-label]='ariaLabel'
+      [attr.aria-labelledby]='ariaLabelledby'
+      [attr.aria-haspopup]='ariaHasPopUp'
+      [attr.role]='role'
+      [attr.id]='id'
+      [attr.aria-current]='ariaCurrent'
+      [attr.aria-expanded]='ariaExpanded'
+      [attr.aria-hidden]='ariaHidden'
+      [attr.aria-selected]='ariaSelected'
     >
       <ng-content></ng-content>
     </a>
@@ -170,12 +170,12 @@ export class SprkLinkComponent implements OnInit {
     // This message is split up like this so that we can keep the line
     // length down in the editor while also logging a single unformatted
     // line of text in the console.
-    const message = "Spark Design System Warning: Spark Link has been " +
-    "refactored to be an Angular Directive. The old Angular Component " +
-    "version has been deprecated. This version will be permanently removed " +
-    "from Spark in our Summer 2020 release. To update to the new version, " +
-    "replace any instance of the <sprk-link> component in your codebase with " +
-    "the new Directive syntax.";
+    const message = 'Spark Design System Warning: Spark Link has been ' +
+    'refactored to be an Angular Directive. The old Angular Component ' +
+    'version has been deprecated. This version will be permanently removed ' +
+    'from Spark in our Summer 2020 release. To update to the new version, ' +
+    'replace any instance of the <sprk-link> component in your codebase with ' +
+    'the new Directive syntax.';
 
     console.warn(message);
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.component.ts
@@ -177,7 +177,7 @@ export class SprkLinkComponent implements OnInit {
     "replace any instance of the <sprk-link> component in your codebase with " +
     "the new Directive syntax.";
 
-    console.log(message);
+    console.warn(message);
 
     // Sets the default href if none provided
     if (this.href === '' || this.href === null || this.href === undefined) {

--- a/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.component.ts
@@ -166,6 +166,19 @@ export class SprkLinkComponent implements OnInit {
   isExternal = false;
 
   ngOnInit() {
+
+    // This message is split up like this so that we can keep the line
+    // length down in the editor while also logging a single unformatted
+    // line of text in the console.
+    const message = "Spark Design System Warning: Spark Link has been " +
+    "refactored to be an Angular Directive. The old Angular Component " +
+    "version has been deprecated. This version will be permanently removed " +
+    "from Spark in our Summer 2020 release. To update to the new version, " +
+    "replace any instance of the <sprk-link> component in your codebase with " +
+    "the new Directive syntax.";
+
+    console.log(message);
+
     // Sets the default href if none provided
     if (this.href === '' || this.href === null || this.href === undefined) {
       this.href = '#';

--- a/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
@@ -140,9 +140,9 @@ export const deprecated = () => ({
   moduleMetadata: modules,
   template: `
     <sprk-link
-      href="#"
-      idString="link-5"
-      analyticsString="object.action.event"
+      href='#'
+      idString='link-5'
+      analyticsString='object.action.event'
     >
       Deprecated Web Component Link
     </sprk-link>
@@ -150,7 +150,7 @@ export const deprecated = () => ({
 });
 
 deprecated.story = {
-  name: "Component (Deprecated)",
+  name: 'Component (Deprecated)',
   parameters: {
     jest: ['sprk-link.directive'],
   }

--- a/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
@@ -152,7 +152,7 @@ export const deprecated = () => ({
 deprecated.story = {
   name: 'Component (Deprecated)',
   parameters: {
-    jest: ['sprk-link.directive'],
+    jest: ['sprk-link.component'],
   }
 };
 

--- a/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
@@ -2,6 +2,11 @@ import { storyWrapper } from '../../../../../../.storybook/helpers/storyWrapper'
 import { SprkLinkDirective } from './sprk-link.directive';
 import { SprkIconModule } from '../../components/sprk-icon/sprk-icon.module';
 import { SprkLinkDirectiveModule } from './sprk-link.module';
+import { SprkLinkModule } from '../../components/sprk-link/sprk-link.module';
+import { SprkLinkComponent } from '../../components/sprk-link/sprk-link.component';
+import { RouterModule } from '@angular/router';
+import { APP_BASE_HREF } from '@angular/common';
+
 import { markdownDocumentationLinkBuilder } from '../../../../../../../storybook-utilities/markdownDocumentationLinkBuilder';
 
 export default {
@@ -11,8 +16,13 @@ export default {
   parameters: {
     info: `
 ${markdownDocumentationLinkBuilder('link')}
-- Spark Link styles are for text-based links.
-Images that are links should not use Spark classes.
+- Spark Link styles are for text-based links. Images that are links should not
+use Spark classes.
+- Spark Link has been refactored to be an Angular Directive. The old Angular
+Component version has been deprecated. This version will be permanently
+removed from Spark in our Summer 2020 release. To update to the new version,
+replace any instance of the <code><sprk-link></code> component in your codebase
+with the new Directive syntax.
 `,
     docs: { iframeHeight: 60 },
   },
@@ -22,7 +32,13 @@ const modules = {
   imports: [
     SprkLinkDirectiveModule,
     SprkIconModule,
+    SprkLinkModule,
+    RouterModule.forRoot([{
+      path: 'iframe.html',
+      component: SprkLinkComponent,
+    }]),
   ],
+  providers: [{ provide: APP_BASE_HREF, useValue: '/' }]
 };
 
 export const defaultStory = () => ({
@@ -115,6 +131,26 @@ export const disabled = () => ({
 });
 
 disabled.story = {
+  parameters: {
+    jest: ['sprk-link.directive'],
+  }
+};
+
+export const deprecated = () => ({
+  moduleMetadata: modules,
+  template: `
+    <sprk-link
+      href="#"
+      idString="link-5"
+      analyticsString="object.action.event"
+    >
+      Deprecated Web Component Link
+    </sprk-link>
+  `,
+});
+
+deprecated.story = {
+  name: "Component (Deprecated)",
   parameters: {
     jest: ['sprk-link.directive'],
   }


### PR DESCRIPTION
## What does this PR do?
- Adds a new story to the Angular Storybook for the deprecated Link Component.
- Adds a line to the Links documentation explaining the deprecation strategy.
- When the deprecated component is used in an application (including Storybook), it logs a warning.

![image](https://user-images.githubusercontent.com/1424560/77113939-0daad600-6a02-11ea-9e0f-9445f87db2b6.png)

### Associated Issue
Fixes 2920

### Documentation
 - [X] Update Spark Docs

### Code
 - [X] Build Component in Angular

### Browser Testing (current version and 1 prior)
  - [X] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
