### PR TITLE
HTML Masthead - add aria-controls and aria-expanded

### DIFF
--- a/html/components/masthead.js
+++ b/html/components/masthead.js
@@ -1,11 +1,12 @@
 /* global document window */
-import { throttle } from 'lodash';
+import { throttle, uniqueId } from 'lodash';
 import getElements from '../utilities/getElements';
 import { focusFirstEl } from '../utilities/elementState';
 import { isEscPressed } from '../utilities/keypress';
 import isElementVisible from '../utilities/isElementVisible';
 import scrollYDirection from '../utilities/scrollYDirection';
 import { hideDropDown, showDropDown } from './dropdown';
+import { toggleAriaExpanded } from './toggle';
 
 const addClassOnScroll = (element, scrollPos, scrollPoint, classToToggle) => {
   // If user scrolls past the scrollPoint then add class
@@ -82,6 +83,8 @@ const toggleMobileNav = (iconContainer, nav, masthead) => {
     .querySelector('svg')
     .classList.toggle('sprk-c-Menu__icon--open');
   nav.classList.toggle('sprk-u-Display--none');
+
+  toggleAriaExpanded(iconContainer);
 };
 
 const focusTrap = (isOpen, nav) => {
@@ -130,6 +133,38 @@ const bindUIEvents = () => {
         'data-sprk-mobile-nav-trigger',
       )}"]`,
     );
+
+    // init aria-expanded
+    if (!element.hasAttribute('aria-expanded')) {
+      // If it doesn't have it then set it to the initial value
+      const isOpen = !nav.classList.contains('sprk-u-Display--none');
+
+      if (isOpen) {
+        element.setAttribute('aria-expanded', 'true');
+      } else {
+        element.setAttribute('aria-expanded', 'false');
+      }
+    }
+
+    // if aria-controls doesn't exist
+    // or it does exist but the ids don't match
+      // init aria-controls
+    if (!element.hasAttribute('aria-controls')
+      || element.getAttribute('aria-controls') != nav.getAttribute('id')) {
+
+      var contentId;
+      // if we already have an ID, use that
+      if (nav.hasAttribute('id')){
+        contentId = nav.getAttribute('id');
+      } else {
+        // if the content doesn't have an ID, generate one and set it
+        contentId = uniqueId('sprk_masthead_content_');
+        nav.setAttribute('id', contentId);
+      }
+
+      element.setAttribute('aria-controls', contentId);
+    }
+
     /*
      * Check if the mobile menu is visible
      * on page and set scroll event

--- a/html/components/masthead.js
+++ b/html/components/masthead.js
@@ -6,7 +6,8 @@ import { isEscPressed } from '../utilities/keypress';
 import isElementVisible from '../utilities/isElementVisible';
 import scrollYDirection from '../utilities/scrollYDirection';
 import { hideDropDown, showDropDown } from './dropdown';
-import { toggleAriaExpanded } from './toggle';
+import { toggleAriaExpanded } from '../utilities/toggleAriaExpanded';
+import { generateAriaControls } from '../utilities/generateAriaControls';
 
 const addClassOnScroll = (element, scrollPos, scrollPoint, classToToggle) => {
   // If user scrolls past the scrollPoint then add class
@@ -146,24 +147,7 @@ const bindUIEvents = () => {
       }
     }
 
-    // if aria-controls doesn't exist
-    // or it does exist but the ids don't match
-      // init aria-controls
-    if (!element.hasAttribute('aria-controls')
-      || element.getAttribute('aria-controls') != nav.getAttribute('id')) {
-
-      let contentId;
-      // if we already have an ID, use that
-      if (nav.hasAttribute('id')) {
-        contentId = nav.getAttribute('id');
-      } else {
-        // if the content doesn't have an ID, generate one and set it
-        contentId = uniqueId('sprk_masthead_content_');
-        nav.setAttribute('id', contentId);
-      }
-
-      element.setAttribute('aria-controls', contentId);
-    }
+    generateAriaControls(element, nav);
 
     /*
      * Check if the mobile menu is visible

--- a/html/components/masthead.js
+++ b/html/components/masthead.js
@@ -1,5 +1,5 @@
 /* global document window */
-import { throttle, uniqueId } from 'lodash';
+import { throttle } from 'lodash';
 import getElements from '../utilities/getElements';
 import { focusFirstEl } from '../utilities/elementState';
 import { isEscPressed } from '../utilities/keypress';

--- a/html/components/masthead.js
+++ b/html/components/masthead.js
@@ -152,9 +152,9 @@ const bindUIEvents = () => {
     if (!element.hasAttribute('aria-controls')
       || element.getAttribute('aria-controls') != nav.getAttribute('id')) {
 
-      var contentId;
+      let contentId;
       // if we already have an ID, use that
-      if (nav.hasAttribute('id')){
+      if (nav.hasAttribute('id')) {
         contentId = nav.getAttribute('id');
       } else {
         // if the content doesn't have an ID, generate one and set it

--- a/html/components/toggle.js
+++ b/html/components/toggle.js
@@ -22,6 +22,7 @@ const toggleIconType = (toggleIcon, toggleIconUse, openIcon, closeIcon) => {
 };
 
 // Toggle the aria expanded attribute
+// TODO - deprecate this and use the one in html/utilities
 const toggleAriaExpanded = (toggleTrigger) => {
   // If the trigger has the attr then determine toggle state
   if (toggleTrigger.hasAttribute('aria-expanded')) {

--- a/html/spark-exports.js
+++ b/html/spark-exports.js
@@ -136,6 +136,8 @@ import {
 } from './components/stepper';
 import { carousel } from './components/carousel';
 import { highlightBoard } from './components/highlight-board';
+import { toggleAriaExpanded as toggleAriaExpandedAttribute } from './utilities/toggleAriaExpanded';
+import { generateAriaControls } from './utilities/generateAriaControls';
 import isElementVisible from './utilities/isElementVisible';
 import scrollYDirection from './utilities/scrollYDirection';
 
@@ -243,4 +245,6 @@ export {
   bindUIEventsHugeInputOld,
   addClassIfNotEmpty,
   toggleClassWithValue,
+  toggleAriaExpandedAttribute,
+  generateAriaControls,
 };

--- a/html/tests/generateAriaControls.tests.js
+++ b/html/tests/generateAriaControls.tests.js
@@ -1,0 +1,66 @@
+/* global document describe it */
+import { generateAriaControls } from '../utilities/generateAriaControls';
+
+describe('generateAriaControls tests', () => {
+  let triggerElement;
+  let contentElement;
+
+  beforeEach(() => {
+    triggerElement = document.createElement('button');
+    contentElement = document.createElement('div');
+  })
+
+  it('should generate values if neither aria-controls nor id is present', () => {
+    triggerElement.removeAttribute('aria-controls');
+    contentElement.removeAttribute('id');
+    generateAriaControls(triggerElement, contentElement);
+
+    // expect a console warn
+    expect(triggerElement.hasAttribute('aria-controls')).toEqual(true);
+    expect(contentElement.hasAttribute('id')).toEqual(true);
+    expect(triggerElement.getAttribute('aria-controls')).toEqual(contentElement.getAttribute('id'));
+  });
+
+  it('should not change values if aria-controls is provided but id is missing', () => {
+    triggerElement.setAttribute('aria-controls', 'foo');
+    contentElement.removeAttribute('id');
+    generateAriaControls(triggerElement, contentElement);
+
+    // expect a console warn
+    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
+    expect(contentElement.hasAttribute('id')).toEqual(false);
+  });
+
+  it('should use the provided value when aria-controls is missing but id is present', () => {
+    triggerElement.removeAttribute('aria-controls');
+    contentElement.setAttribute('id', 'foo');
+    expect(triggerElement.hasAttribute('aria-controls')).toEqual(false);
+
+    generateAriaControls(triggerElement, contentElement);
+
+    // expect a console warn
+    expect(triggerElement.hasAttribute('aria-controls')).toEqual(true);
+    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
+    expect(contentElement.getAttribute('id')).toEqual('foo');
+  });
+
+  it('should not change values if aria-controls and are both present but have different values', () => {
+    triggerElement.setAttribute('aria-controls', 'foo');
+    contentElement.setAttribute('id', 'bar');
+    generateAriaControls(triggerElement, contentElement);
+
+    // expect a console warn
+    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
+    expect(contentElement.getAttribute('id')).toEqual('bar');
+  });
+
+  it('should not change values if aria-controls and are both present and have correct values', () => {
+    triggerElement.setAttribute('aria-controls', 'foo');
+    contentElement.setAttribute('id', 'foo');
+    generateAriaControls(triggerElement, contentElement);
+
+    // expect no console warn
+    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
+    expect(contentElement.getAttribute('id')).toEqual('foo');
+  });
+});

--- a/html/tests/generateAriaControls.tests.js
+++ b/html/tests/generateAriaControls.tests.js
@@ -15,7 +15,6 @@ describe('generateAriaControls tests', () => {
     contentElement.removeAttribute('id');
     generateAriaControls(triggerElement, contentElement);
 
-    // expect a console warn
     expect(triggerElement.hasAttribute('aria-controls')).toEqual(true);
     expect(contentElement.hasAttribute('id')).toEqual(true);
     expect(triggerElement.getAttribute('aria-controls')).toEqual(contentElement.getAttribute('id'));
@@ -26,7 +25,6 @@ describe('generateAriaControls tests', () => {
     contentElement.removeAttribute('id');
     generateAriaControls(triggerElement, contentElement);
 
-    // expect a console warn
     expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
     expect(contentElement.hasAttribute('id')).toEqual(false);
   });
@@ -38,7 +36,6 @@ describe('generateAriaControls tests', () => {
 
     generateAriaControls(triggerElement, contentElement);
 
-    // expect a console warn
     expect(triggerElement.hasAttribute('aria-controls')).toEqual(true);
     expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
     expect(contentElement.getAttribute('id')).toEqual('foo');
@@ -49,7 +46,6 @@ describe('generateAriaControls tests', () => {
     contentElement.setAttribute('id', 'bar');
     generateAriaControls(triggerElement, contentElement);
 
-    // expect a console warn
     expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
     expect(contentElement.getAttribute('id')).toEqual('bar');
   });

--- a/html/tests/masthead.tests.js
+++ b/html/tests/masthead.tests.js
@@ -99,7 +99,6 @@ describe('masthead init', () => {
     masthead();
 
     // it should NOT make them match
-    // expect a console warn
     expect(nav.getAttribute('id')).toEqual('foo');
     expect(iconContainer.getAttribute('aria-controls')).toEqual('bar');
   });
@@ -110,7 +109,6 @@ describe('masthead init', () => {
 
     masthead();
 
-    // expect a console warn
     expect(nav.getAttribute('id')).toEqual(null);
     expect(iconContainer.getAttribute('aria-controls')).toEqual('bar');
   });

--- a/html/tests/masthead.tests.js
+++ b/html/tests/masthead.tests.js
@@ -71,13 +71,23 @@ describe('masthead init', () => {
     expect(document.querySelectorAll.getCall(0).args[0]).toBe('[data-sprk-mobile-nav-trigger]');
   });
 
-  it('should add aria-expanded if it is missing', () => {
+  it('should init aria-expanded as closed correctly', () => {
     expect(iconContainer.getAttribute('aria-expanded')).toBe(null);
 
     masthead();
 
     expect(iconContainer.hasAttribute('aria-expanded')).toBeTruthy();
     expect(iconContainer.getAttribute('aria-expanded')).toEqual('false');
+  });
+
+  it('should init aria-expanded as open correctly', () => {
+    expect(iconContainer.getAttribute('aria-expanded')).toBe(null);
+    nav.classList.remove('sprk-u-Display--none');
+
+    masthead();
+
+    expect(iconContainer.hasAttribute('aria-expanded')).toBeTruthy();
+    expect(iconContainer.getAttribute('aria-expanded')).toEqual('true');
   });
 
   it('should generate a content id and add it to aria-controls when both values are missing', () => {

--- a/html/tests/masthead.tests.js
+++ b/html/tests/masthead.tests.js
@@ -1,3 +1,7 @@
+const mockDOMSliderStub = {};
+
+jest.mock('dom-slider', () => mockDOMSliderStub);
+
 /* global window beforeEach afterEach document describe before it */
 import {
   masthead,
@@ -12,8 +16,53 @@ import {
 import { dropdowns } from '../components/dropdown';
 
 describe('masthead init', () => {
+  let main;
+  let nav;
+  let mastheadDiv;
+  let iconContainer;
+  let iconContainerDiv;
+
+  beforeEach(() => {
+    main = document.createElement('div');
+    main.setAttribute('data-sprk-main', null);
+
+    // Create the main Masthead element
+    mastheadDiv = document.createElement('div');
+    mastheadDiv.classList.add('sprk-c-Masthead');
+    mastheadDiv.setAttribute('data-sprk-masthead', null);
+
+    // Create narrow nav
+    nav = document.createElement('nav');
+    nav.classList.add('sprk-u-Display--none');
+    nav.classList.add('sprk-c-Masthead__narrow-nav');
+    nav.setAttribute('data-sprk-mobile-nav', 'mobileNav');
+
+    // Add nav to masthead
+    mastheadDiv.appendChild(nav);
+
+    // Create a menu button container for icon
+    iconContainer = document.createElement('button');
+    iconContainer.setAttribute('data-sprk-mobile-nav-trigger', 'mobileNav');
+
+    // Create a container div for icon
+    iconContainerDiv = document.createElement('div');
+    iconContainerDiv.classList.add('sprk-c-Masthead__menu');
+
+    // Add iconContainer to iconContainerDiv
+    iconContainerDiv.appendChild(iconContainer);
+
+    // Add iconContainerDiv to mastheadDiv
+    mastheadDiv.appendChild(iconContainerDiv);
+    main.appendChild(mastheadDiv);
+    document.body.appendChild(main);
+  })
+
   afterEach(() => {
-    document.querySelectorAll.restore();
+    if (document.querySelectorAll.restore) {
+      document.querySelectorAll.restore();
+    }
+
+    document.body.innerHTML = '';
   });
 
   it('should call getElements once with the correct selector', () => {
@@ -21,6 +70,59 @@ describe('masthead init', () => {
     masthead();
     expect(document.querySelectorAll.getCall(0).args[0]).toBe('[data-sprk-mobile-nav-trigger]');
   });
+
+  it('should add aria-expanded if it is missing', () => {
+    expect(iconContainer.getAttribute('aria-expanded')).toBe(null);
+
+    masthead();
+
+    expect(iconContainer.hasAttribute('aria-expanded')).toBeTruthy();
+    expect(iconContainer.getAttribute('aria-expanded')).toEqual('false');
+  });
+
+  it('should generate a content id and add it to aria-controls when both values are missing', () => {
+
+    expect(nav.getAttribute('id')).toBe(null);
+    expect(iconContainer.getAttribute('aria-controls')).toBe(null);
+
+    masthead();
+
+    expect(nav.hasAttribute('id')).toBeTruthy();
+    expect(iconContainer.hasAttribute('aria-controls')).toBeTruthy();
+    expect(nav.getAttribute('id')).toEqual(iconContainer.getAttribute('aria-controls'));
+  });
+
+  it('should override aria-controls if the value doesnt match the id on the content', () => {
+    nav.setAttribute('id', 'foo');
+    iconContainer.setAttribute('aria-controls', 'bar');
+
+    masthead();
+
+    // it should make them match
+    expect(nav.getAttribute('id')).toEqual(iconContainer.getAttribute('aria-controls'));
+  });
+
+  it('should use the provided content id for aria-controls when aria-controls is missing and the id is available', () => {
+    nav.setAttribute('id', 'foo');
+    expect(iconContainer.getAttribute('aria-conrols')).toBe(null);
+
+    masthead();
+
+    expect(iconContainer.getAttribute('aria-controls')).toEqual('foo');
+  })
+
+  it('should not change content id or aria-controls if both are valid', () => {
+    nav.setAttribute('id', 'foo');
+    iconContainer.setAttribute('aria-controls', 'foo');
+
+    expect(nav.getAttribute('id')).toEqual('foo');
+    expect(iconContainer.getAttribute('aria-controls')).toEqual('foo');
+
+    masthead();
+
+    expect(nav.getAttribute('id')).toEqual('foo');
+    expect(iconContainer.getAttribute('aria-controls')).toEqual('foo');
+  })
 });
 
 describe('masthead UI Events tests', () => {
@@ -353,6 +455,14 @@ describe('toggleMobileNav tests', () => {
     ).toBe(false);
     expect(nav.classList.contains('sprk-u-Display--none')).toBe(true);
     expect(icon.classList.contains('sprk-c-Menu__icon--open')).toBe(false);
+  });
+
+  it('should toggle the aria-expanded property on the trigger element', () => {
+    iconContainer.setAttribute('aria-expanded', false);
+    toggleMobileNav(iconContainer, nav, mastheadDiv);
+    expect(iconContainer.getAttribute('aria-expanded')).toEqual('true');
+    toggleMobileNav(iconContainer, nav, mastheadDiv);
+    expect(iconContainer.getAttribute('aria-expanded')).toEqual('false');
   });
 
   it('should add sprk-u-Height--100 to the html element', () => {

--- a/html/tests/masthead.tests.js
+++ b/html/tests/masthead.tests.js
@@ -92,14 +92,27 @@ describe('masthead init', () => {
     expect(nav.getAttribute('id')).toEqual(iconContainer.getAttribute('aria-controls'));
   });
 
-  it('should override aria-controls if the value doesnt match the id on the content', () => {
+  it('should NOT override aria-controls if the value doesnt match the id on the content', () => {
     nav.setAttribute('id', 'foo');
     iconContainer.setAttribute('aria-controls', 'bar');
 
     masthead();
 
-    // it should make them match
-    expect(nav.getAttribute('id')).toEqual(iconContainer.getAttribute('aria-controls'));
+    // it should NOT make them match
+    // expect a console warn
+    expect(nav.getAttribute('id')).toEqual('foo');
+    expect(iconContainer.getAttribute('aria-controls')).toEqual('bar');
+  });
+
+  it('should log a console warning if aria-controls has a value but content ID is blank', () => {
+    nav.removeAttribute('id');
+    iconContainer.setAttribute('aria-controls', 'bar');
+
+    masthead();
+
+    // expect a console warn
+    expect(nav.getAttribute('id')).toEqual(null);
+    expect(iconContainer.getAttribute('aria-controls')).toEqual('bar');
   });
 
   it('should use the provided content id for aria-controls when aria-controls is missing and the id is available', () => {

--- a/html/tests/toggleAriaExpanded.tests.js
+++ b/html/tests/toggleAriaExpanded.tests.js
@@ -1,0 +1,34 @@
+/* global document describe it */
+import { toggleAriaExpanded } from '../utilities/toggleAriaExpanded';
+
+describe('toggleAriaExpanded tests', () => {
+  let element;
+
+  it('should toggle true to false', () => {
+    element = document.createElement('div');
+    element.setAttribute('aria-expanded', 'true');
+
+    expect(element.getAttribute('aria-expanded')).toEqual('true')
+
+    toggleAriaExpanded(element);
+
+    expect(element.getAttribute('aria-expanded')).toEqual('false');
+  });
+
+  it('should toggle false to true', () => {
+    element = document.createElement('div');
+    element.setAttribute('aria-expanded', 'false');
+
+    expect(element.getAttribute('aria-expanded')).toEqual('false')
+
+    toggleAriaExpanded(element);
+
+    expect(element.getAttribute('aria-expanded')).toEqual('true');
+  });
+
+  it('should not add aria-expanded if it does not exist', () => {
+    element = document.createElement('div');
+
+    expect(element.hasAttribute('aria-expanded')).toEqual(false)
+  });
+});

--- a/html/utilities/generateAriaControls.js
+++ b/html/utilities/generateAriaControls.js
@@ -4,31 +4,29 @@ import { uniqueId } from 'lodash';
 // into the aria-controls attribute on triggerElement.
 // Generate a unique ID if needed.
 const generateAriaControls = (triggerElement, contentElement) => {
-  const toggleTriggerAriaControls = triggerElement.getAttribute('aria-controls');
-  const toggleContentId = contentElement.getAttribute('id');
+  let triggerAriaControls = triggerElement.getAttribute('aria-controls');
+  let contentId = contentElement.getAttribute('id');
 
-  // If neither attribute has a value, generate an ID with lodash
-  if (!toggleContentId && !toggleTriggerAriaControls) {
-    const ariaToggleId = uniqueId('sprk_masthead_content_');
-    contentElement.setAttribute('id', ariaToggleId);
-    triggerElement.setAttribute('aria-controls', ariaToggleId);
+  // Warn if aria-controls exists but the id does not
+  if (triggerAriaControls && !contentId) {
+    console.warn('Spark Design System Warning - The component with aria-controls="' + triggerAriaControls + '" expects a matching id on the content element.');
+    return;
   }
 
-  // If content has an ID but trigger doesn't have aria-controls,
-  // add the ID to the trigger
-  if (toggleContentId && !toggleTriggerAriaControls) {
-    triggerElement.setAttribute('aria-controls', toggleContentId);
+  // Warn if aria-controls and id both exist but don't match
+  if (contentId && triggerAriaControls && contentId !== triggerAriaControls) {
+    console.warn('Spark Design System Warning - The value of aria-controls ("' + triggerAriaControls + '") should match the id of the content element ("' + contentId + '").');
+    return;
   }
 
-  // Warn if aria-controls and id don't match
-  if (toggleContentId !== toggleTriggerAriaControls) {
-    console.warn("Spark Design System Warning - these should have the same value");
+  // If we don't have a valid id, generate one with lodash
+  if (!contentId) {
+    contentId = uniqueId('sprk_masthead_content_');
+    contentElement.setAttribute('id', contentId);
   }
 
-  // Warn if aria-controls exists but the ids don't match
-  if (toggleTriggerAriaControls && !toggleContentId) {
-    console.warn("Spark Design System Warning - aria-controls exists but id is missing")
-  }
+  // set the value of aria-controls
+  triggerElement.setAttribute('aria-controls', contentId);
 };
 
 export { generateAriaControls };

--- a/html/utilities/generateAriaControls.js
+++ b/html/utilities/generateAriaControls.js
@@ -1,0 +1,34 @@
+import { uniqueId } from 'lodash';
+
+// Copy the value of the id attribute on contentElement
+// into the aria-controls attribute on triggerElement.
+// Generate a unique ID if needed.
+const generateAriaControls = (triggerElement, contentElement) => {
+  const toggleTriggerAriaControls = triggerElement.getAttribute('aria-controls');
+  const toggleContentId = contentElement.getAttribute('id');
+
+  // If neither attribute has a value, generate an ID with lodash
+  if (!toggleContentId && !toggleTriggerAriaControls) {
+    const ariaToggleId = uniqueId('sprk_masthead_content_');
+    contentElement.setAttribute('id', ariaToggleId);
+    triggerElement.setAttribute('aria-controls', ariaToggleId);
+  }
+
+  // If content has an ID but trigger doesn't have aria-controls,
+  // add the ID to the trigger
+  if (toggleContentId && !toggleTriggerAriaControls) {
+    triggerElement.setAttribute('aria-controls', toggleContentId);
+  }
+
+  // Warn if aria-controls and id don't match
+  if (toggleContentId !== toggleTriggerAriaControls) {
+    console.warn("Spark Design System Warning - these should have the same value");
+  }
+
+  // Warn if aria-controls exists but the ids don't match
+  if (toggleTriggerAriaControls && !toggleContentId) {
+    console.warn("Spark Design System Warning - aria-controls exists but id is missing")
+  }
+};
+
+export { generateAriaControls };

--- a/html/utilities/toggleAriaExpanded.js
+++ b/html/utilities/toggleAriaExpanded.js
@@ -1,0 +1,13 @@
+// Toggle the aria expanded attribute
+const toggleAriaExpanded = (toggleTrigger) => {
+  // If the trigger has the attr then determine toggle state
+  if (toggleTrigger.hasAttribute('aria-expanded')) {
+    const isExpanded = toggleTrigger.getAttribute('aria-expanded');
+    toggleTrigger.setAttribute('aria-expanded', isExpanded === 'false' ? 'true' : 'false');
+  } else {
+    // If it doesn't have it then set it to false initially
+    toggleTrigger.setAttribute('aria-expanded', 'false');
+  }
+};
+
+export { toggleAriaExpanded };


### PR DESCRIPTION
## What does this PR do?
- adds `aria-controls` functionality to the mobile navigation menu in the HTML Spark Masthead
- adds `aria-expanded` functionality to the mobile navigation menu in the HTML Spark Masthead
- adds new HTML utility functions for `toggleAriaExpanded` and `generateAriaControls` with unit tests

### Associated Issue
Fixes https://github.com/sparkdesignsystem/spark-design-system/issues/2957

### Code
 - [X] Build Component in HTML
 - [X] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)

### Accessibility
- [X] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [X] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)