### PR TITLE
Update Angular, React and HTML Toggle components

### DIFF
--- a/angular/package-lock.json
+++ b/angular/package-lock.json
@@ -12450,10 +12450,12 @@
     },
     "falafel": {
       "version": "2.1.0",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
+      "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
       "dev": true,
       "requires": {
         "acorn": "^5.0.0",
+        "foreach": "^2.0.5",
         "isarray": "0.0.1",
         "object-keys": "^1.0.6"
       },
@@ -12772,6 +12774,11 @@
       "integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw==",
       "dev": true
     },
+    "focus-visible": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/focus-visible/-/focus-visible-5.1.0.tgz",
+      "integrity": "sha512-nPer0rjtzdZ7csVIu233P2cUm/ks/4aVSI+5KUkYrYpgA7ujgC3p6J7FtFU+AIMWwnwYQOB/yeiOITxFeYIXiw=="
+    },
     "follow-redirects": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.10.0.tgz",
@@ -12894,6 +12901,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
       "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
+      "dev": true
+    },
+    "foreach": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
       "dev": true
     },
     "forever-agent": {

--- a/angular/package.json
+++ b/angular/package.json
@@ -32,6 +32,7 @@
     "@angular/platform-browser-dynamic": "~8.2.0",
     "@angular/router": "~8.2.0",
     "classlist.js": "^1.1.20150312",
+    "focus-visible": "^5.1.0",
     "replace": "^1.1.1",
     "rxjs": "~6.4.0",
     "tiny-date-picker": "github:sparkdesignsystem/tiny-date-picker#v3.2.9",

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -74,7 +74,7 @@ describe('SprkToggleComponent', () => {
     component.additionalClasses = 'sprk-u-pam sprk-u-man';
     fixture.detectChanges();
     expect(element.classList.toString()).toEqual(
-      'sprk-u-Overflow--hidden sprk-u-pam sprk-u-man'
+      'sprk-c-Toggle sprk-u-pam sprk-u-man'
     );
   });
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -27,7 +27,7 @@ describe('SprkToggleComponent', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement.querySelector('div');
     triggerElement = element.querySelector('button');
-    contentElement = element.querySelector('[data-sprk-toggle="content"]');
+    contentElement = element.querySelector('button').nextElementSibling;
   });
 
   it('should create itself', () => {

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -8,6 +8,8 @@ describe('SprkToggleComponent', () => {
   let component: SprkToggleComponent;
   let fixture: ComponentFixture<SprkToggleComponent>;
   let element: HTMLElement;
+  let triggerElement;
+  let contentElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -24,6 +26,8 @@ describe('SprkToggleComponent', () => {
     fixture = TestBed.createComponent(SprkToggleComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement.querySelector('div');
+    triggerElement = element.querySelector('button');
+    contentElement = element.querySelector('[data-sprk-toggle="content"]');
   });
 
   it('should create itself', () => {
@@ -31,7 +35,7 @@ describe('SprkToggleComponent', () => {
   });
 
   it('clicking should show body text', () => {
-    element.querySelector('a').click();
+    element.querySelector('button').click();
     fixture.detectChanges();
     expect(element.querySelector('div.sprk-u-pts.sprk-u-pbs')).toBeTruthy();
   });
@@ -40,17 +44,17 @@ describe('SprkToggleComponent', () => {
     const str = 'One';
     component.analyticsString = str;
     fixture.detectChanges();
-    expect(element.querySelector('a').getAttribute('data-analytics')).toEqual(
+    expect(element.querySelector('button').getAttribute('data-analytics')).toEqual(
       str
     );
   });
 
   it('should add icon classes to icon when toggle is opened', () => {
     component.title = 'placeholder';
-    element.querySelector('a').click();
+    element.querySelector('button').click();
     fixture.detectChanges();
     expect(
-      element.querySelector('a .sprk-c-Icon').classList.toString()
+      element.querySelector('button .sprk-c-Icon').classList.toString()
     ).toEqual(
       'sprk-c-Icon sprk-c-Icon--l sprk-u-mrs sprk-c-Icon--toggle sprk-c-Icon--open'
     );
@@ -58,11 +62,11 @@ describe('SprkToggleComponent', () => {
 
   it('should add icon classes to icon when the toggle is opened and then closed', () => {
     component.title = 'placeholder';
-    element.querySelector('a').click();
-    element.querySelector('a').click();
+    element.querySelector('button').click();
+    element.querySelector('button').click();
     fixture.detectChanges();
     expect(
-      element.querySelector('a .sprk-c-Icon').classList.toString()
+      element.querySelector('button .sprk-c-Icon').classList.toString()
     ).toEqual('sprk-c-Icon sprk-c-Icon--l sprk-u-mrs sprk-c-Icon--toggle');
   });
 
@@ -85,5 +89,53 @@ describe('SprkToggleComponent', () => {
     component.idString = null;
     fixture.detectChanges();
     expect(element.getAttribute('data-id')).toBeNull();
+  });
+
+  it('should generate values if neither aria-controls nor id is present', () => {
+    triggerElement.removeAttribute('aria-controls');
+    contentElement.removeAttribute('id');
+    fixture.detectChanges();
+
+    expect(triggerElement.hasAttribute('aria-controls')).toEqual(true);
+    expect(contentElement.hasAttribute('id')).toEqual(true);
+    expect(triggerElement.getAttribute('aria-controls')).toEqual(contentElement.getAttribute('id'));
+  });
+
+  it('should not change values if aria-controls is provided but id is missing', () => {
+    triggerElement.setAttribute('aria-controls', 'foo');
+    contentElement.removeAttribute('id');
+    fixture.detectChanges();
+
+    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
+    expect(contentElement.hasAttribute('id')).toEqual(false);
+  });
+
+  it('should use the provided value when aria-controls is missing but id is present', () => {
+    triggerElement.removeAttribute('aria-controls');
+    contentElement.setAttribute('id', 'foo');
+    expect(triggerElement.hasAttribute('aria-controls')).toEqual(false);
+    fixture.detectChanges();
+
+    expect(triggerElement.hasAttribute('aria-controls')).toEqual(true);
+    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
+    expect(contentElement.getAttribute('id')).toEqual('foo');
+  });
+
+  it('should not change values if aria-controls and are both present but have different values', () => {
+    triggerElement.setAttribute('aria-controls', 'foo');
+    contentElement.setAttribute('id', 'bar');
+    fixture.detectChanges();
+
+    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
+    expect(contentElement.getAttribute('id')).toEqual('bar');
+  });
+
+  it('should not change values if aria-controls and are both present and have correct values', () => {
+    triggerElement.setAttribute('aria-controls', 'foo');
+    contentElement.setAttribute('id', 'foo');
+    fixture.detectChanges();
+
+    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
+    expect(contentElement.getAttribute('id')).toEqual('foo');
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -78,7 +78,7 @@ export class SprkToggleComponent implements AfterViewInit {
    * This is intended for overrides.
    */
   @Input()
-  titleFontClass: 'sprk-b-TypeBodyThree';
+  titleFontClass = 'sprk-b-TypeBodyThree';
   /**
    * The value supplied will be assigned
    * to the `data-id` attribute on the

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, ElementRef } from '@angular/core';
 import { toggleAnimations } from './sprk-toggle-animations';
 import { uniqueId } from 'lodash';
 
@@ -85,6 +85,8 @@ export class SprkToggleComponent implements OnInit {
   @Input()
   idString: string;
 
+  constructor(public ref: ElementRef) {}
+
   /**
    * @ignore
    */
@@ -164,8 +166,8 @@ export class SprkToggleComponent implements OnInit {
     this.toggleState();
 
     // Get the toggle's trigger and content elements
-    const toggleTrigger = document.querySelector('[data-sprk-toggle="trigger"]');
-    const toggleContent = document.querySelector('[data-sprk-toggle="content"]');
+    const toggleTrigger = this.ref.nativeElement.querySelector('[data-sprk-toggle="trigger"]');
+    const toggleContent = this.ref.nativeElement.querySelector('[data-sprk-toggle="content"]');
     this.generateAriaControls(toggleTrigger, toggleContent);
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ElementRef } from '@angular/core';
+import { Component, Input, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
 import { toggleAnimations } from './sprk-toggle-animations';
 import { uniqueId } from 'lodash';
 
@@ -15,7 +15,7 @@ import { uniqueId } from 'lodash';
         (click)="toggle($event)"
         [attr.aria-expanded]="isOpen ? 'true' : 'false'"
         [attr.data-analytics]="analyticsString"
-        data-sprk-toggle="trigger"
+        #toggleTrigger
       >
         <sprk-icon
           iconType="chevron-down-circle-two-color"
@@ -28,7 +28,7 @@ import { uniqueId } from 'lodash';
 
       <div
         [@toggleContent]="animState"
-        data-sprk-toggle="content"
+        #toggleContent
       >
         <div class="sprk-u-pts sprk-u-pbs sprk-c-Toggle__content">
           <ng-content></ng-content>
@@ -38,7 +38,10 @@ import { uniqueId } from 'lodash';
   `,
   animations: [toggleAnimations.toggleContent]
 })
-export class SprkToggleComponent implements OnInit {
+export class SprkToggleComponent implements AfterViewInit {
+  @ViewChild('toggleTrigger', { static: true }) toggleTrigger: ElementRef;
+  @ViewChild('toggleContent', { static: true }) toggleContent: ElementRef;
+
   /**
    * The value supplied will be assigned to the
    * `data-analytics` attribute on the component.
@@ -84,8 +87,6 @@ export class SprkToggleComponent implements OnInit {
    */
   @Input()
   idString: string;
-
-  constructor(public ref: ElementRef) {}
 
   /**
    * @ignore
@@ -162,12 +163,8 @@ export class SprkToggleComponent implements OnInit {
     triggerElement.setAttribute('aria-controls', contentId);
   }
 
-  ngOnInit() {
+  ngAfterViewInit() {
     this.toggleState();
-
-    // Get the toggle's trigger and content elements
-    const toggleTrigger = this.ref.nativeElement.querySelector('[data-sprk-toggle="trigger"]');
-    const toggleContent = this.ref.nativeElement.querySelector('[data-sprk-toggle="content"]');
-    this.generateAriaControls(toggleTrigger, toggleContent);
+    this.generateAriaControls(this.toggleTrigger.nativeElement, this.toggleContent.nativeElement);
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -8,7 +8,7 @@ import { toggleAnimations } from './sprk-toggle-animations';
       class="sprk-u-Overflow--hidden {{ additionalClasses }}"
       [attr.data-id]="idString"
     >
-      <a
+      <button
         sprkLink
         variant="icon"
         [ngClass]="getClasses()"
@@ -24,7 +24,7 @@ import { toggleAnimations } from './sprk-toggle-animations';
           }} sprk-c-Icon--l sprk-u-mrs sprk-c-Icon--toggle {{ iconStateClass }}"
         ></sprk-icon>
         {{ title }}
-      </a>
+      </button>
 
       <div [@toggleContent]="animState">
         <div class="sprk-u-pts sprk-u-pbs"><ng-content></ng-content></div>
@@ -122,6 +122,7 @@ export class SprkToggleComponent implements OnInit {
     const classArray: string[] = [
       this.titleFontClass,
       'sprk-u-TextCrop--none',
+      'sprk-u-BareButton',
     ];
     return classArray.join(' ');
   }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { toggleAnimations } from './sprk-toggle-animations';
+import { generateAriaControls } from '../../../../../../../html/utilities/generateAriaControls';
 
 @Component({
   selector: 'sprk-toggle',
@@ -16,6 +17,7 @@ import { toggleAnimations } from './sprk-toggle-animations';
         [attr.aria-expanded]="isOpen ? 'true' : 'false'"
         [analyticsString]="analyticsString"
         href="#"
+        data-sprk-toggle="trigger"
       >
         <sprk-icon
           iconType="chevron-down-circle-two-color"
@@ -26,8 +28,13 @@ import { toggleAnimations } from './sprk-toggle-animations';
         {{ title }}
       </button>
 
-      <div [@toggleContent]="animState">
-        <div class="sprk-u-pts sprk-u-pbs"><ng-content></ng-content></div>
+      <div
+        [@toggleContent]="animState"
+        data-sprk-toggle="content"
+      >
+        <div class="sprk-u-pts sprk-u-pbs">
+          <ng-content></ng-content>
+        </div>
       </div>
     </div>
   `,
@@ -127,7 +134,13 @@ export class SprkToggleComponent implements OnInit {
     return classArray.join(' ');
   }
 
+
   ngOnInit() {
     this.toggleState();
+
+    // Get the toggle's trigger and content elements
+    const toggleTrigger = document.querySelector('[data-sprk-toggle="trigger"]');
+    const toggleContent = document.querySelector('[data-sprk-toggle="content"]');
+    generateAriaControls(toggleTrigger, toggleContent, 'toggle');
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, AfterViewInit, ElementRef, ViewChild } from '@angular/core';
+import { Component, Input, AfterViewInit, ElementRef, ViewChild, Renderer2 } from '@angular/core';
 import { toggleAnimations } from './sprk-toggle-animations';
 import { uniqueId } from 'lodash';
 
@@ -39,6 +39,7 @@ import { uniqueId } from 'lodash';
   animations: [toggleAnimations.toggleContent]
 })
 export class SprkToggleComponent implements AfterViewInit {
+  constructor(private renderer: Renderer2, private el: ElementRef) {}
   @ViewChild('toggleTrigger', { static: true }) toggleTrigger: ElementRef;
   @ViewChild('toggleContent', { static: true }) toggleContent: ElementRef;
 
@@ -128,8 +129,8 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   getClasses(): string {
     const classArray: string[] = [
+      'sprk-c-Toggle__trigger',
       this.titleFontClass,
-      'sprk-c-Toggle__trigger'
     ];
     return classArray.join(' ');
   }
@@ -137,7 +138,9 @@ export class SprkToggleComponent implements AfterViewInit {
   /**
    * @ignore
    */
-  generateAriaControls(triggerElement, contentElement): void {
+  generateAriaControls(): void {
+    const triggerElement = this.toggleTrigger.nativeElement;
+    const contentElement = this.toggleContent.nativeElement;
     const triggerAriaControls = triggerElement.getAttribute('aria-controls');
     let contentId = contentElement.getAttribute('id');
 
@@ -156,15 +159,17 @@ export class SprkToggleComponent implements AfterViewInit {
     // If we don't have a valid id, generate one with lodash
     if (!contentId) {
       contentId = uniqueId(`sprk_toggle_content_`);
-      contentElement.setAttribute('id', contentId);
+      this.renderer.setAttribute(contentElement, 'id', contentId);
+      // contentElement.setAttribute('id', contentId);
     }
 
     // set the value of aria-controls
-    triggerElement.setAttribute('aria-controls', contentId);
+    this.renderer.setAttribute(triggerElement, 'aria-controls', contentId);
+    // triggerElement.setAttribute('aria-controls', contentId);
   }
 
   ngAfterViewInit() {
     this.toggleState();
-    this.generateAriaControls(this.toggleTrigger.nativeElement, this.toggleContent.nativeElement);
+    this.generateAriaControls();
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { toggleAnimations } from './sprk-toggle-animations';
-import { generateAriaControls } from '../../../../../../../html/utilities/generateAriaControls';
+import { uniqueId } from 'lodash';
 
 @Component({
   selector: 'sprk-toggle',
@@ -134,6 +134,34 @@ export class SprkToggleComponent implements OnInit {
     return classArray.join(' ');
   }
 
+  /**
+   * @ignore
+   */
+  generateAriaControls(triggerElement, contentElement): void {
+    const triggerAriaControls = triggerElement.getAttribute('aria-controls');
+    let contentId = contentElement.getAttribute('id');
+
+    // Warn if aria-controls exists but the id does not
+    if (triggerAriaControls && !contentId) {
+      console.warn(`Spark Design System Warning - The component with aria-controls="${triggerAriaControls}" expects a matching id on the content element.`);
+      return;
+    }
+
+    // Warn if aria-controls and id both exist but don't match
+    if (contentId && triggerAriaControls && contentId !== triggerAriaControls) {
+      console.warn(`Spark Design System Warning - The value of aria-controls ("${triggerAriaControls}") should match the id of the content element ("${contentId}").`);
+      return;
+    }
+
+    // If we don't have a valid id, generate one with lodash
+    if (!contentId) {
+      contentId = uniqueId(`sprk_toggle_content_`);
+      contentElement.setAttribute('id', contentId);
+    }
+
+    // set the value of aria-controls
+    triggerElement.setAttribute('aria-controls', contentId);
+  }
 
   ngOnInit() {
     this.toggleState();
@@ -141,6 +169,6 @@ export class SprkToggleComponent implements OnInit {
     // Get the toggle's trigger and content elements
     const toggleTrigger = document.querySelector('[data-sprk-toggle="trigger"]');
     const toggleContent = document.querySelector('[data-sprk-toggle="content"]');
-    generateAriaControls(toggleTrigger, toggleContent, 'toggle');
+    this.generateAriaControls(toggleTrigger, toggleContent);
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -6,17 +6,14 @@ import { uniqueId } from 'lodash';
   selector: 'sprk-toggle',
   template: `
     <div
-      class="sprk-u-Overflow--hidden {{ additionalClasses }}"
+      class="sprk-c-Toggle {{ additionalClasses }}"
       [attr.data-id]="idString"
     >
       <button
-        sprkLink
         variant="icon"
         [ngClass]="getClasses()"
         (click)="toggle($event)"
         [attr.aria-expanded]="isOpen ? 'true' : 'false'"
-        [analyticsString]="analyticsString"
-        href="#"
         data-sprk-toggle="trigger"
       >
         <sprk-icon
@@ -32,7 +29,7 @@ import { uniqueId } from 'lodash';
         [@toggleContent]="animState"
         data-sprk-toggle="content"
       >
-        <div class="sprk-u-pts sprk-u-pbs">
+        <div class="sprk-u-pts sprk-u-pbs sprk-c-Toggle__content">
           <ng-content></ng-content>
         </div>
       </div>
@@ -128,8 +125,7 @@ export class SprkToggleComponent implements OnInit {
   getClasses(): string {
     const classArray: string[] = [
       this.titleFontClass,
-      'sprk-u-TextCrop--none',
-      'sprk-u-BareButton',
+      'sprk-c-Toggle__trigger'
     ];
     return classArray.join(' ');
   }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -160,12 +160,10 @@ export class SprkToggleComponent implements AfterViewInit {
     if (!contentId) {
       contentId = uniqueId(`sprk_toggle_content_`);
       this.renderer.setAttribute(contentElement, 'id', contentId);
-      // contentElement.setAttribute('id', contentId);
     }
 
     // set the value of aria-controls
     this.renderer.setAttribute(triggerElement, 'aria-controls', contentId);
-    // triggerElement.setAttribute('aria-controls', contentId);
   }
 
   ngAfterViewInit() {

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -14,6 +14,7 @@ import { uniqueId } from 'lodash';
         [ngClass]="getClasses()"
         (click)="toggle($event)"
         [attr.aria-expanded]="isOpen ? 'true' : 'false'"
+        [attr.data-analytics]="analyticsString"
         data-sprk-toggle="trigger"
       >
         <sprk-icon

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -78,7 +78,7 @@ export class SprkToggleComponent implements AfterViewInit {
    * This is intended for overrides.
    */
   @Input()
-  titleFontClass = 'sprk-b-TypeBodyThree';
+  titleFontClass: 'sprk-b-TypeBodyThree';
   /**
    * The value supplied will be assigned
    * to the `data-id` attribute on the
@@ -130,7 +130,7 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   getClasses(): string {
     const classArray: string[] = [
-      'sprk-c-Toggle__trigger',
+      'sprk-c-Toggle__trigger sprk-u-TextCrop--none',
       this.titleFontClass,
     ];
     return classArray.join(' ');

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,6 +1,7 @@
 import { Component, Input, AfterViewInit, ElementRef, ViewChild, Renderer2 } from '@angular/core';
 import { toggleAnimations } from './sprk-toggle-animations';
 import { uniqueId } from 'lodash';
+import 'focus-visible';
 
 @Component({
   selector: 'sprk-toggle',

--- a/html/components/_toggle.scss
+++ b/html/components/_toggle.scss
@@ -16,13 +16,6 @@
   text-decoration: $sprk-toggle-trigger-text-decoration;
   transition: $sprk-toggle-trigger-transition;
 
-  // Font considerations
-  color: $sprk-toggle-trigger-color;
-  font-family: $sprk-toggle-trigger-font-family;
-  font-size: $sprk-toggle-trigger-font-size;
-  font-weight: $sprk-toggle-trigger-font-weight;
-  line-height: $sprk-toggle-trigger-line-height;
-
   // Button User Agent Resets
   background-color: $sprk-toggle-trigger-background-color;
   border-top: $sprk-toggle-trigger-border-top;

--- a/html/components/masthead.js
+++ b/html/components/masthead.js
@@ -147,7 +147,7 @@ const bindUIEvents = () => {
       }
     }
 
-    generateAriaControls(element, nav);
+    generateAriaControls(element, nav, 'masthead');
 
     /*
      * Check if the mobile menu is visible

--- a/html/components/toggle.js
+++ b/html/components/toggle.js
@@ -78,7 +78,7 @@ const bindToggleUIEvents = (element) => {
   const toggleIcon = element.querySelector('[data-sprk-toggle="icon"]');
   const toggleIconUse = element.querySelector('[data-sprk-toggle="accordionIconUseElement"]');
 
-  generateAriaControls(toggleTrigger, toggleContent);
+  generateAriaControls(toggleTrigger, toggleContent, 'toggle');
 
   // Hide details content, initially shown for no-JS scenarios
   toggleContent.style.display = 'none';

--- a/html/components/toggle.stories.js
+++ b/html/components/toggle.stories.js
@@ -27,7 +27,7 @@ export const defaultStory = () => {
       data-id="toggle-1"
     >
      <button
-        class="sprk-c-Toggle__trigger"
+        class="sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-u-TextCrop--none"
         data-sprk-toggle="trigger"
       >
         <svg

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -1404,16 +1404,6 @@ $sprk-toggle-trigger-border-left: none !default;
 $sprk-toggle-trigger-text-decoration: $sprk-link-text-decoration !default;
 /// The transition for Toggle Trigger.
 $sprk-toggle-trigger-transition: $sprk-link-transition !default;
-/// The color for Toggle Trigger.
-$sprk-toggle-trigger-color: $sprk-color-body-three !default;
-/// The font family for Toggle Trigger.
-$sprk-toggle-trigger-font-family: $sprk-font-family-body-three !default;
-/// The font size for Toggle Trigger.
-$sprk-toggle-trigger-font-size: $sprk-font-size-body-three !default;
-/// The font weight for Toggle Trigger.
-$sprk-toggle-trigger-font-weight: $sprk-font-weight-body-three !default;
-/// The line height for Toggle Trigger.
-$sprk-toggle-trigger-line-height: $sprk-line-height-body-three !default;
 /// The hover border bottom style for Toggle Trigger.
 $sprk-toggle-trigger-hover-border-bottom: $sprk-link-has-icon-hover-border-bottom !default;
 /// The hover text color for Toggle Trigger.

--- a/html/utilities/generateAriaControls.js
+++ b/html/utilities/generateAriaControls.js
@@ -3,7 +3,7 @@ import { uniqueId } from 'lodash';
 // Copy the value of the id attribute on contentElement
 // into the aria-controls attribute on triggerElement.
 // Generate a unique ID if needed.
-const generateAriaControls = (triggerElement, contentElement) => {
+const generateAriaControls = (triggerElement, contentElement, componentName) => {
   let triggerAriaControls = triggerElement.getAttribute('aria-controls');
   let contentId = contentElement.getAttribute('id');
 
@@ -21,7 +21,7 @@ const generateAriaControls = (triggerElement, contentElement) => {
 
   // If we don't have a valid id, generate one with lodash
   if (!contentId) {
-    contentId = uniqueId('sprk_masthead_content_');
+    contentId = uniqueId(`sprk_${componentName}_content_`);
     contentElement.setAttribute('id', contentId);
   }
 

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -46,7 +46,7 @@ class SprkToggle extends Component {
     );
 
     const titleClasses = classnames(
-      'sprk-c-Toggle__trigger',
+      'sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-u-TextCrop--none',
       titleAddClasses,
     );
 

--- a/src/data/sass-modifiers.json
+++ b/src/data/sass-modifiers.json
@@ -1794,12 +1794,12 @@
   {
     "description": "Turns off the display of an element so that it has no effect on layout.\n",
     "commentRange": {
-      "start": 22,
-      "end": 24
+      "start": 18,
+      "end": 20
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-Display--none",
+      "name": ".sprk-u-JavaScript, .sprk-u-HideWhenJs",
       "value": "display: none !important;",
       "line": {
         "start": 26,
@@ -1818,12 +1818,12 @@
   {
     "description": "Turns off the display of an element so that it has no effect on layout.\n",
     "commentRange": {
-      "start": 18,
-      "end": 20
+      "start": 22,
+      "end": 24
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-JavaScript, .sprk-u-HideWhenJs",
+      "name": ".sprk-u-Display--none",
       "value": "display: none !important;",
       "line": {
         "start": 26,
@@ -3222,14 +3222,14 @@
     }
   },
   {
-    "description": "Sets the bottom margin to the current value of\n`$sprk-space-misc-a` (`24px`).\n",
+    "description": "Sets the margin on all sides to the current value\nof `$sprk-space-misc-d` (`80px`).\n",
     "commentRange": {
-      "start": 550,
-      "end": 553
+      "start": 560,
+      "end": 563
     },
     "context": {
       "type": "css",
-      "name": "sprk-u-MarginBottom--a",
+      "name": "sprk-u-MarginAll--d",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
         "start": 569,
@@ -3270,14 +3270,14 @@
     }
   },
   {
-    "description": "Sets the margin on all sides to the current value\nof `$sprk-space-misc-d` (`80px`).\n",
+    "description": "Sets the bottom margin to the current value of\n`$sprk-space-misc-a` (`24px`).\n",
     "commentRange": {
-      "start": 560,
-      "end": 563
+      "start": 550,
+      "end": 553
     },
     "context": {
       "type": "css",
-      "name": "sprk-u-MarginAll--d",
+      "name": "sprk-u-MarginBottom--a",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
         "start": 569,
@@ -4578,78 +4578,6 @@
     }
   },
   {
-    "description": "When placed on an item, its width will be 3/4\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 318,
-      "end": 321
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--three-fourths@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "When placed on an item, its width will be 1/2\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 313,
-      "end": 316
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--half@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "of its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 309,
-      "end": 311
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--third@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
     "description": "When placed on an item, its width will be 1/4\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
       "start": 303,
@@ -4658,30 +4586,6 @@
     "context": {
       "type": "css",
       "name": ".sprk-o-Stack__item--fourth@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "When placed on an item, its width will be 1/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 298,
-      "end": 301
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--fifth@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -4722,6 +4626,78 @@
     }
   },
   {
+    "description": "of its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 309,
+      "end": 311
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--third@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 1/2\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 313,
+      "end": 316
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--half@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 3/4\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 318,
+      "end": 321
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--three-fourths@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
     "description": "When placed on an item, its width will be 2/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
       "start": 323,
@@ -4746,14 +4722,38 @@
     }
   },
   {
-    "description": "When placed on an item, its width will be 7/10\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "description": "When placed on an item, its width will be 1/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
-      "start": 338,
-      "end": 341
+      "start": 298,
+      "end": 301
     },
     "context": {
       "type": "css",
-      "name": ".sprk-o-Stack__item--seven-tenths@xxs",
+      "name": ".sprk-o-Stack__item--fifth@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 3/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 328,
+      "end": 331
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--three-fifths@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -4794,14 +4794,14 @@
     }
   },
   {
-    "description": "When placed on an item, its width will be 3/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "description": "When placed on an item, its width will be 7/10\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
-      "start": 328,
-      "end": 331
+      "start": 338,
+      "end": 341
     },
     "context": {
       "type": "css",
-      "name": ".sprk-o-Stack__item--three-fifths@xxs",
+      "name": ".sprk-o-Stack__item--seven-tenths@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -5828,16 +5828,16 @@
   {
     "description": "A toggle with a smaller font.\n",
     "commentRange": {
-      "start": 49,
-      "end": 50
+      "start": 42,
+      "end": 43
     },
     "context": {
       "type": "css",
       "name": ".sprk-c-Toggle__trigger--small",
       "value": "font-size: $sprk-toggle-trigger-font-size-small;\n  font-weight: $sprk-toggle-trigger-font-weight-small;",
       "line": {
-        "start": 51,
-        "end": 54
+        "start": 44,
+        "end": 47
       }
     },
     "group": [
@@ -6188,12 +6188,12 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 10,
-      "end": 10
+      "start": 15,
+      "end": 15
     },
     "context": {
       "type": "css",
-      "name": "//\n// Inheriting box-sizing Probably Slightly Better Best-Practice\n// http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice\n///\nhtml",
+      "name": "html",
       "value": "box-sizing: border-box;",
       "line": {
         "start": 16,
@@ -6212,12 +6212,12 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 15,
-      "end": 15
+      "start": 10,
+      "end": 10
     },
     "context": {
       "type": "css",
-      "name": "html",
+      "name": "//\n// Inheriting box-sizing Probably Slightly Better Best-Practice\n// http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice\n///\nhtml",
       "value": "box-sizing: border-box;",
       "line": {
         "start": 16,
@@ -19421,15 +19421,15 @@
     }
   },
   {
-    "description": "The color for Toggle Trigger.\n",
+    "description": "The hover border bottom style for Toggle Trigger.\n",
     "commentRange": {
       "start": 1407,
       "end": 1407
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-color",
-      "value": "$sprk-color-body-three",
+      "name": "sprk-toggle-trigger-hover-border-bottom",
+      "value": "$sprk-link-has-icon-hover-border-bottom",
       "scope": "default",
       "line": {
         "start": 1408,
@@ -19446,15 +19446,15 @@
     }
   },
   {
-    "description": "The font family for Toggle Trigger.\n",
+    "description": "The hover text color for Toggle Trigger.\n",
     "commentRange": {
       "start": 1409,
       "end": 1409
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-font-family",
-      "value": "$sprk-font-family-body-three",
+      "name": "sprk-toggle-trigger-hover-color",
+      "value": "$sprk-link-has-icon-hover-color-text",
       "scope": "default",
       "line": {
         "start": 1410,
@@ -19471,15 +19471,15 @@
     }
   },
   {
-    "description": "The font size for Toggle Trigger.\n",
+    "description": "The background color for Toggle Trigger.\n",
     "commentRange": {
       "start": 1411,
       "end": 1411
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-font-size",
-      "value": "$sprk-font-size-body-three",
+      "name": "sprk-toggle-trigger-background-color",
+      "value": "transparent",
       "scope": "default",
       "line": {
         "start": 1412,
@@ -19496,15 +19496,15 @@
     }
   },
   {
-    "description": "The font weight for Toggle Trigger.\n",
+    "description": "The padding top for Toggle Trigger.\n",
     "commentRange": {
       "start": 1413,
       "end": 1413
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-font-weight",
-      "value": "$sprk-font-weight-body-three",
+      "name": "sprk-toggle-trigger-padding-top",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1414,
@@ -19521,15 +19521,15 @@
     }
   },
   {
-    "description": "The line height for Toggle Trigger.\n",
+    "description": "The padding right for Toggle Trigger.\n",
     "commentRange": {
       "start": 1415,
       "end": 1415
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-line-height",
-      "value": "$sprk-line-height-body-three",
+      "name": "sprk-toggle-trigger-padding-right",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1416,
@@ -19546,15 +19546,15 @@
     }
   },
   {
-    "description": "The active border bottom style for Toggle Trigger.\n",
+    "description": "The padding bottom for Toggle Trigger.\n",
     "commentRange": {
       "start": 1417,
       "end": 1417
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-hover-border-bottom",
-      "value": "$sprk-link-has-icon-hover-border-bottom",
+      "name": "sprk-toggle-trigger-padding-bottom",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1418,
@@ -19571,15 +19571,15 @@
     }
   },
   {
-    "description": "The active color for Toggle Trigger.\n",
+    "description": "The padding left for Toggle Trigger.\n",
     "commentRange": {
       "start": 1419,
       "end": 1419
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-hover-color",
-      "value": "$sprk-link-has-icon-hover-color-text",
+      "name": "sprk-toggle-trigger-padding-left",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1420,
@@ -19596,15 +19596,15 @@
     }
   },
   {
-    "description": "The background color for Toggle Trigger.\n",
+    "description": "The text alignment for Toggle Trigger.\n",
     "commentRange": {
       "start": 1421,
       "end": 1421
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-background-color",
-      "value": "transparent",
+      "name": "sprk-toggle-trigger-text-align",
+      "value": "left",
       "scope": "default",
       "line": {
         "start": 1422,
@@ -19621,15 +19621,15 @@
     }
   },
   {
-    "description": "The padding top for Toggle Trigger.\n",
+    "description": "The font size for small Toggle Trigger.\n",
     "commentRange": {
       "start": 1423,
       "end": 1423
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-padding-top",
-      "value": "0",
+      "name": "sprk-toggle-trigger-font-size-small",
+      "value": "$sprk-font-size-body-four",
       "scope": "default",
       "line": {
         "start": 1424,
@@ -19646,15 +19646,15 @@
     }
   },
   {
-    "description": "The padding right for Toggle Trigger.\n",
+    "description": "The font weight for small Toggle Trigger.\n",
     "commentRange": {
       "start": 1425,
       "end": 1425
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-padding-right",
-      "value": "0",
+      "name": "sprk-toggle-trigger-font-weight-small",
+      "value": "normal",
       "scope": "default",
       "line": {
         "start": 1426,
@@ -19671,40 +19671,15 @@
     }
   },
   {
-    "description": "The padding bottom for Toggle Trigger.\n",
+    "description": "The transition timing for the\nrotation of the icon when the Toggle is opened.\n",
     "commentRange": {
-      "start": 1427,
-      "end": 1427
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-trigger-padding-bottom",
-      "value": "0",
-      "scope": "default",
-      "line": {
-        "start": 1428,
-        "end": 1428
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding left for Toggle Trigger.\n",
-    "commentRange": {
-      "start": 1429,
+      "start": 1428,
       "end": 1429
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-padding-left",
-      "value": "0",
+      "name": "sprk-toggle-transition-timing",
+      "value": "0.3s ease",
       "scope": "default",
       "line": {
         "start": 1430,
@@ -19721,115 +19696,140 @@
     }
   },
   {
-    "description": "The text alignment for Toggle Trigger.\n",
-    "commentRange": {
-      "start": 1431,
-      "end": 1431
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-trigger-text-align",
-      "value": "left",
-      "scope": "default",
-      "line": {
-        "start": 1432,
-        "end": 1432
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size for small Toggle Trigger.\n",
-    "commentRange": {
-      "start": 1433,
-      "end": 1433
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-trigger-font-size-small",
-      "value": "$sprk-font-size-body-four",
-      "scope": "default",
-      "line": {
-        "start": 1434,
-        "end": 1434
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight for small Toggle Trigger.\n",
-    "commentRange": {
-      "start": 1435,
-      "end": 1435
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-trigger-font-weight-small",
-      "value": "normal",
-      "scope": "default",
-      "line": {
-        "start": 1436,
-        "end": 1436
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The transition timing for the\nrotation of the icon when the Toggle is opened.\n",
-    "commentRange": {
-      "start": 1438,
-      "end": 1439
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-transition-timing",
-      "value": "0.3s ease",
-      "scope": "default",
-      "line": {
-        "start": 1440,
-        "end": 1440
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "Background color of the Dropdown items that\nare active or hovered.\n",
     "commentRange": {
-      "start": 1447,
-      "end": 1448
+      "start": 1437,
+      "end": 1438
     },
     "context": {
       "type": "variable",
       "name": "sprk-dropdown-active-background-color",
       "value": "$sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1439,
+        "end": 1439
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The left border of the Dropdown item that is active.\n",
+    "commentRange": {
+      "start": 1440,
+      "end": 1440
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-active-border",
+      "value": "2.5px solid $sprk-green",
+      "scope": "default",
+      "line": {
+        "start": 1441,
+        "end": 1441
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box-shadow of the Dropdown item that is active.\n",
+    "commentRange": {
+      "start": 1442,
+      "end": 1442
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-active-box-shadow",
+      "value": "-1px 0 0 0 $sprk-green",
+      "scope": "default",
+      "line": {
+        "start": 1443,
+        "end": 1443
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The border of the Dropdown.\n",
+    "commentRange": {
+      "start": 1444,
+      "end": 1444
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-border",
+      "value": "1px solid $sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1445,
+        "end": 1445
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font size of the Dropdown.\n",
+    "commentRange": {
+      "start": 1446,
+      "end": 1446
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-font-size",
+      "value": "$sprk-font-size-body-one",
+      "scope": "default",
+      "line": {
+        "start": 1447,
+        "end": 1447
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font weight of the Dropdown.\n",
+    "commentRange": {
+      "start": 1448,
+      "end": 1448
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-font-weight",
+      "value": "400",
       "scope": "default",
       "line": {
         "start": 1449,
@@ -19846,140 +19846,140 @@
     }
   },
   {
-    "description": "The left border of the Dropdown item that is active.\n",
-    "commentRange": {
-      "start": 1450,
-      "end": 1450
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-active-border",
-      "value": "2.5px solid $sprk-green",
-      "scope": "default",
-      "line": {
-        "start": 1451,
-        "end": 1451
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box-shadow of the Dropdown item that is active.\n",
-    "commentRange": {
-      "start": 1452,
-      "end": 1452
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-active-box-shadow",
-      "value": "-1px 0 0 0 $sprk-green",
-      "scope": "default",
-      "line": {
-        "start": 1453,
-        "end": 1453
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border of the Dropdown.\n",
-    "commentRange": {
-      "start": 1454,
-      "end": 1454
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-border",
-      "value": "1px solid $sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1455,
-        "end": 1455
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size of the Dropdown.\n",
-    "commentRange": {
-      "start": 1456,
-      "end": 1456
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-font-size",
-      "value": "$sprk-font-size-body-one",
-      "scope": "default",
-      "line": {
-        "start": 1457,
-        "end": 1457
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the Dropdown.\n",
-    "commentRange": {
-      "start": 1458,
-      "end": 1458
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-font-weight",
-      "value": "400",
-      "scope": "default",
-      "line": {
-        "start": 1459,
-        "end": 1459
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The padding around the Informational Dropdown\nfooter.\n",
     "commentRange": {
-      "start": 1460,
-      "end": 1461
+      "start": 1450,
+      "end": 1451
     },
     "context": {
       "type": "variable",
       "name": "sprk-dropdown-footer-padding",
       "value": "$sprk-space-inset-short-l",
+      "scope": "default",
+      "line": {
+        "start": 1452,
+        "end": 1452
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The line height of the Dropdown.\n",
+    "commentRange": {
+      "start": 1453,
+      "end": 1453
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-line-height",
+      "value": "1",
+      "scope": "default",
+      "line": {
+        "start": 1454,
+        "end": 1454
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The max-width of the Dropdown.\n",
+    "commentRange": {
+      "start": 1455,
+      "end": 1455
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-max-width",
+      "value": "24rem",
+      "scope": "default",
+      "line": {
+        "start": 1456,
+        "end": 1456
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding around the Dropdown items.\n",
+    "commentRange": {
+      "start": 1457,
+      "end": 1457
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-padding",
+      "value": "$sprk-space-misc-a",
+      "scope": "default",
+      "line": {
+        "start": 1458,
+        "end": 1458
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Dropdown.\n",
+    "commentRange": {
+      "start": 1459,
+      "end": 1459
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-shadow",
+      "value": "0 0 40px 2px rgba(0, 0, 0, 0.1)",
+      "scope": "default",
+      "line": {
+        "start": 1460,
+        "end": 1460
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the Dropdown title.\n",
+    "commentRange": {
+      "start": 1461,
+      "end": 1461
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-title-color",
+      "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1462,
@@ -19996,15 +19996,15 @@
     }
   },
   {
-    "description": "The line height of the Dropdown.\n",
+    "description": "The font size of the Dropdown title.\n",
     "commentRange": {
       "start": 1463,
       "end": 1463
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dropdown-line-height",
-      "value": "1",
+      "name": "sprk-dropdown-title-font-size",
+      "value": "$sprk-dropdown-font-size",
       "scope": "default",
       "line": {
         "start": 1464,
@@ -20021,15 +20021,15 @@
     }
   },
   {
-    "description": "The max-width of the Dropdown.\n",
+    "description": "The font weight of the Dropdown title.\n",
     "commentRange": {
       "start": 1465,
       "end": 1465
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dropdown-max-width",
-      "value": "24rem",
+      "name": "sprk-dropdown-title-font-weight",
+      "value": "300",
       "scope": "default",
       "line": {
         "start": 1466,
@@ -20046,140 +20046,115 @@
     }
   },
   {
-    "description": "The padding around the Dropdown items.\n",
-    "commentRange": {
-      "start": 1467,
-      "end": 1467
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-padding",
-      "value": "$sprk-space-misc-a",
-      "scope": "default",
-      "line": {
-        "start": 1468,
-        "end": 1468
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box shadow of the Dropdown.\n",
-    "commentRange": {
-      "start": 1469,
-      "end": 1469
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-shadow",
-      "value": "0 0 40px 2px rgba(0, 0, 0, 0.1)",
-      "scope": "default",
-      "line": {
-        "start": 1470,
-        "end": 1470
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Dropdown title.\n",
-    "commentRange": {
-      "start": 1471,
-      "end": 1471
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-title-color",
-      "value": "$sprk-black-tint-25",
-      "scope": "default",
-      "line": {
-        "start": 1472,
-        "end": 1472
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size of the Dropdown title.\n",
-    "commentRange": {
-      "start": 1473,
-      "end": 1473
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-title-font-size",
-      "value": "$sprk-dropdown-font-size",
-      "scope": "default",
-      "line": {
-        "start": 1474,
-        "end": 1474
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the Dropdown title.\n",
-    "commentRange": {
-      "start": 1475,
-      "end": 1475
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-title-font-weight",
-      "value": "300",
-      "scope": "default",
-      "line": {
-        "start": 1476,
-        "end": 1476
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The color of the mask overlay that is shown behind the Modal.\n",
     "commentRange": {
-      "start": 1482,
-      "end": 1482
+      "start": 1472,
+      "end": 1472
     },
     "context": {
       "type": "variable",
       "name": "sprk-modal-mask-color",
       "value": "rgba(34, 34, 34, 0.35)",
+      "scope": "default",
+      "line": {
+        "start": 1473,
+        "end": 1473
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Modal.\n",
+    "commentRange": {
+      "start": 1474,
+      "end": 1474
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-modal-color",
+      "value": "$sprk-white",
+      "scope": "default",
+      "line": {
+        "start": 1475,
+        "end": 1475
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The maximum width of the Modal.\n",
+    "commentRange": {
+      "start": 1476,
+      "end": 1476
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-modal-max-width",
+      "value": "43.75rem",
+      "scope": "default",
+      "line": {
+        "start": 1477,
+        "end": 1477
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The maximum height of the Modal.\n",
+    "commentRange": {
+      "start": 1478,
+      "end": 1478
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-modal-height",
+      "value": "70%",
+      "scope": "default",
+      "line": {
+        "start": 1479,
+        "end": 1479
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "Determines how far down\nfrom the top of the page the\nModal renders at the small breakpoint.\n",
+    "commentRange": {
+      "start": 1480,
+      "end": 1482
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-modal-breakpoint-small",
+      "value": "25rem",
       "scope": "default",
       "line": {
         "start": 1483,
@@ -20196,40 +20171,15 @@
     }
   },
   {
-    "description": "The background color of the Modal.\n",
+    "description": "Determines how far down\nfrom the top of the page the\nModal renders at the medium breakpoint.\n",
     "commentRange": {
       "start": 1484,
-      "end": 1484
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-modal-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1485,
-        "end": 1485
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The maximum width of the Modal.\n",
-    "commentRange": {
-      "start": 1486,
       "end": 1486
     },
     "context": {
       "type": "variable",
-      "name": "sprk-modal-max-width",
-      "value": "43.75rem",
+      "name": "sprk-modal-breakpoint-medium",
+      "value": "37.5rem",
       "scope": "default",
       "line": {
         "start": 1487,
@@ -20246,15 +20196,15 @@
     }
   },
   {
-    "description": "The maximum height of the Modal.\n",
+    "description": "The box shadow on the Modal.\n",
     "commentRange": {
       "start": 1488,
       "end": 1488
     },
     "context": {
       "type": "variable",
-      "name": "sprk-modal-height",
-      "value": "70%",
+      "name": "sprk-modal-shadow",
+      "value": "0 4px 5px rgba(0, 0, 0, 0.6)",
       "scope": "default",
       "line": {
         "start": 1489,
@@ -20271,85 +20221,10 @@
     }
   },
   {
-    "description": "Determines how far down\nfrom the top of the page the\nModal renders at the small breakpoint.\n",
-    "commentRange": {
-      "start": 1490,
-      "end": 1492
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-modal-breakpoint-small",
-      "value": "25rem",
-      "scope": "default",
-      "line": {
-        "start": 1493,
-        "end": 1493
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "Determines how far down\nfrom the top of the page the\nModal renders at the medium breakpoint.\n",
-    "commentRange": {
-      "start": 1494,
-      "end": 1496
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-modal-breakpoint-medium",
-      "value": "37.5rem",
-      "scope": "default",
-      "line": {
-        "start": 1497,
-        "end": 1497
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box shadow on the Modal.\n",
-    "commentRange": {
-      "start": 1498,
-      "end": 1498
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-modal-shadow",
-      "value": "0 4px 5px rgba(0, 0, 0, 0.6)",
-      "scope": "default",
-      "line": {
-        "start": 1499,
-        "end": 1499
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The border radius on the Modal.\n",
     "commentRange": {
-      "start": 1500,
-      "end": 1500
+      "start": 1490,
+      "end": 1490
     },
     "context": {
       "type": "variable",
@@ -20357,8 +20232,8 @@
       "value": "8px",
       "scope": "default",
       "line": {
-        "start": 1501,
-        "end": 1501
+        "start": 1491,
+        "end": 1491
       }
     },
     "access": "public",
@@ -20373,8 +20248,8 @@
   {
     "description": "The width of the menu icon on narrow viewports in the Masthead.\n",
     "commentRange": {
-      "start": 1507,
-      "end": 1507
+      "start": 1497,
+      "end": 1497
     },
     "context": {
       "type": "variable",
@@ -20382,8 +20257,8 @@
       "value": "$sprk-icon-l",
       "scope": "default",
       "line": {
-        "start": 1508,
-        "end": 1508
+        "start": 1498,
+        "end": 1498
       }
     },
     "access": "public",
@@ -20398,13 +20273,113 @@
   {
     "description": "The height of the menu icon on narrow viewports in the Masthead.\n",
     "commentRange": {
-      "start": 1509,
-      "end": 1509
+      "start": 1499,
+      "end": 1499
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-menu-icon-height",
       "value": "$sprk-icon-l",
+      "scope": "default",
+      "line": {
+        "start": 1500,
+        "end": 1500
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Masthead.\n",
+    "commentRange": {
+      "start": 1501,
+      "end": 1501
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-bg-color",
+      "value": "$sprk-white",
+      "scope": "default",
+      "line": {
+        "start": 1502,
+        "end": 1502
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding of the Masthead content, menu, and branding sections.\n",
+    "commentRange": {
+      "start": 1503,
+      "end": 1503
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-padding",
+      "value": "$sprk-space-s",
+      "scope": "default",
+      "line": {
+        "start": 1504,
+        "end": 1504
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding top around the content items in the\ncontent section of the Masthead.\n",
+    "commentRange": {
+      "start": 1505,
+      "end": 1506
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-top",
+      "value": "$sprk-space-s",
+      "scope": "default",
+      "line": {
+        "start": 1507,
+        "end": 1507
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding bottom around the content\nitems in the content section of the Masthead.\n",
+    "commentRange": {
+      "start": 1508,
+      "end": 1509
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-bottom",
+      "value": "$sprk-space-s",
       "scope": "default",
       "line": {
         "start": 1510,
@@ -20421,110 +20396,10 @@
     }
   },
   {
-    "description": "The background color of the Masthead.\n",
-    "commentRange": {
-      "start": 1511,
-      "end": 1511
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-bg-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1512,
-        "end": 1512
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding of the Masthead content, menu, and branding sections.\n",
-    "commentRange": {
-      "start": 1513,
-      "end": 1513
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-content-padding",
-      "value": "$sprk-space-s",
-      "scope": "default",
-      "line": {
-        "start": 1514,
-        "end": 1514
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding top around the content items in the\ncontent section of the Masthead.\n",
-    "commentRange": {
-      "start": 1515,
-      "end": 1516
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-content-item-padding-top",
-      "value": "$sprk-space-s",
-      "scope": "default",
-      "line": {
-        "start": 1517,
-        "end": 1517
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding bottom around the content\nitems in the content section of the Masthead.\n",
-    "commentRange": {
-      "start": 1518,
-      "end": 1519
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-content-item-padding-bottom",
-      "value": "$sprk-space-s",
-      "scope": "default",
-      "line": {
-        "start": 1520,
-        "end": 1520
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The padding right around the content items in the\ncontent section of the Masthead.\n",
     "commentRange": {
-      "start": 1521,
-      "end": 1522
+      "start": 1511,
+      "end": 1512
     },
     "context": {
       "type": "variable",
@@ -20532,8 +20407,8 @@
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1523,
-        "end": 1523
+        "start": 1513,
+        "end": 1513
       }
     },
     "access": "public",
@@ -20548,8 +20423,8 @@
   {
     "description": "The padding around the content\nsection in the Masthead on wide viewports.\n",
     "commentRange": {
-      "start": 1527,
-      "end": 1528
+      "start": 1517,
+      "end": 1518
     },
     "context": {
       "type": "variable",
@@ -20557,8 +20432,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1529,
-        "end": 1529
+        "start": 1519,
+        "end": 1519
       }
     },
     "access": "public",
@@ -20573,8 +20448,8 @@
   {
     "description": "The padding top of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
-      "start": 1530,
-      "end": 1531
+      "start": 1520,
+      "end": 1521
     },
     "context": {
       "type": "variable",
@@ -20582,8 +20457,8 @@
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1532,
-        "end": 1532
+        "start": 1522,
+        "end": 1522
       }
     },
     "access": "public",
@@ -20598,13 +20473,113 @@
   {
     "description": "The padding bottom of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
-      "start": 1533,
-      "end": 1534
+      "start": 1523,
+      "end": 1524
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-content-item-padding-bottom-wide",
       "value": "$sprk-space-s",
+      "scope": "default",
+      "line": {
+        "start": 1525,
+        "end": 1525
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding right of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "commentRange": {
+      "start": 1526,
+      "end": 1527
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-right-wide",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1528,
+        "end": 1528
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding left of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "commentRange": {
+      "start": 1529,
+      "end": 1530
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-left-wide",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1531,
+        "end": 1531
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The visited state color of Masthead links.\n",
+    "commentRange": {
+      "start": 1532,
+      "end": 1532
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-link-visited-color",
+      "value": "$sprk-black",
+      "scope": "default",
+      "line": {
+        "start": 1533,
+        "end": 1533
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The hover state color of Masthead links.\n",
+    "commentRange": {
+      "start": 1534,
+      "end": 1534
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-link-hover-color",
+      "value": "$sprk-green",
       "scope": "default",
       "line": {
         "start": 1535,
@@ -20621,19 +20596,19 @@
     }
   },
   {
-    "description": "The padding right of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The font weight for Masthead links.\n",
     "commentRange": {
       "start": 1536,
-      "end": 1537
+      "end": 1536
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-right-wide",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-link-font-weight",
+      "value": "500",
       "scope": "default",
       "line": {
-        "start": 1538,
-        "end": 1538
+        "start": 1537,
+        "end": 1537
       }
     },
     "access": "public",
@@ -20646,15 +20621,40 @@
     }
   },
   {
-    "description": "The padding left of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The size of the bottom border on the Masthead.\n",
     "commentRange": {
-      "start": 1539,
+      "start": 1538,
+      "end": 1538
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-border-bottom-size",
+      "value": "1px",
+      "scope": "default",
+      "line": {
+        "start": 1539,
+        "end": 1539
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The bottom border on the Masthead.\n",
+    "commentRange": {
+      "start": 1540,
       "end": 1540
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-left-wide",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-border-bottom",
+      "value": "$sprk-masthead-border-bottom-size solid $sprk-gray",
       "scope": "default",
       "line": {
         "start": 1541,
@@ -20671,15 +20671,15 @@
     }
   },
   {
-    "description": "The visited state color of Masthead links.\n",
+    "description": "The bottom border on the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1542,
       "end": 1542
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-link-visited-color",
-      "value": "$sprk-black",
+      "name": "sprk-masthead-border-bottom-wide",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1543,
@@ -20696,15 +20696,15 @@
     }
   },
   {
-    "description": "The hover state color of Masthead links.\n",
+    "description": "The right border on the site links in the Masthead.\n",
     "commentRange": {
       "start": 1544,
       "end": 1544
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-link-hover-color",
-      "value": "$sprk-green",
+      "name": "sprk-masthead-site-links-border-right",
+      "value": "2px solid $sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1545,
@@ -20721,40 +20721,15 @@
     }
   },
   {
-    "description": "The font weight for Masthead links.\n",
+    "description": "The point at which the Masthead navigation switches\nfrom narrow viewport style to large viewport\nstyle.\n",
     "commentRange": {
       "start": 1546,
-      "end": 1546
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-link-font-weight",
-      "value": "500",
-      "scope": "default",
-      "line": {
-        "start": 1547,
-        "end": 1547
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The size of the bottom border on the Masthead.\n",
-    "commentRange": {
-      "start": 1548,
       "end": 1548
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-border-bottom-size",
-      "value": "1px",
+      "name": "sprk-masthead-breakpoint",
+      "value": "54rem",
       "scope": "default",
       "line": {
         "start": 1549,
@@ -20771,15 +20746,15 @@
     }
   },
   {
-    "description": "The bottom border on the Masthead.\n",
+    "description": "The maximum width of the Masthead.\n",
     "commentRange": {
       "start": 1550,
       "end": 1550
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-border-bottom",
-      "value": "$sprk-masthead-border-bottom-size solid $sprk-gray",
+      "name": "sprk-masthead-column-width",
+      "value": "89rem",
       "scope": "default",
       "line": {
         "start": 1551,
@@ -20796,15 +20771,15 @@
     }
   },
   {
-    "description": "The bottom border on the Masthead on wide viewports.\n",
+    "description": "The maximum width of the logo in the Masthead.\n",
     "commentRange": {
       "start": 1552,
       "end": 1552
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-border-bottom-wide",
-      "value": "0",
+      "name": "sprk-masthead-logo-max-width",
+      "value": "192px",
       "scope": "default",
       "line": {
         "start": 1553,
@@ -20821,15 +20796,15 @@
     }
   },
   {
-    "description": "The right border on the site links in the Masthead.\n",
+    "description": "The minimum width of the logo in the Masthead.\n",
     "commentRange": {
       "start": 1554,
       "end": 1554
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-site-links-border-right",
-      "value": "2px solid $sprk-black-tint-25",
+      "name": "sprk-masthead-logo-min-width",
+      "value": "174px",
       "scope": "default",
       "line": {
         "start": 1555,
@@ -20846,15 +20821,40 @@
     }
   },
   {
-    "description": "The point at which the Masthead navigation switches\nfrom narrow viewport style to large viewport\nstyle.\n",
+    "description": "The box shadow of the Masthead.\n",
     "commentRange": {
       "start": 1556,
+      "end": 1556
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-shadow",
+      "value": "none",
+      "scope": "default",
+      "line": {
+        "start": 1557,
+        "end": 1557
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Masthead in wide viewports.\n",
+    "commentRange": {
+      "start": 1558,
       "end": 1558
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-breakpoint",
-      "value": "54rem",
+      "name": "sprk-masthead-shadow-wide",
+      "value": "none",
       "scope": "default",
       "line": {
         "start": 1559,
@@ -20871,15 +20871,15 @@
     }
   },
   {
-    "description": "The maximum width of the Masthead.\n",
+    "description": "The Masthead shadow that gets applied when the page is scrolled.\n",
     "commentRange": {
       "start": 1560,
       "end": 1560
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-column-width",
-      "value": "89rem",
+      "name": "sprk-masthead-shadow-scroll",
+      "value": "0 0 40px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
         "start": 1561,
@@ -20896,15 +20896,15 @@
     }
   },
   {
-    "description": "The maximum width of the logo in the Masthead.\n",
+    "description": "The border of the selector in the Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1562,
       "end": 1562
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-logo-max-width",
-      "value": "192px",
+      "name": "sprk-masthead-selector-border",
+      "value": "2px solid $sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1563,
@@ -20921,135 +20921,10 @@
     }
   },
   {
-    "description": "The minimum width of the logo in the Masthead.\n",
-    "commentRange": {
-      "start": 1564,
-      "end": 1564
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-logo-min-width",
-      "value": "174px",
-      "scope": "default",
-      "line": {
-        "start": 1565,
-        "end": 1565
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box shadow of the Masthead.\n",
-    "commentRange": {
-      "start": 1566,
-      "end": 1566
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-shadow",
-      "value": "none",
-      "scope": "default",
-      "line": {
-        "start": 1567,
-        "end": 1567
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box shadow of the Masthead in wide viewports.\n",
-    "commentRange": {
-      "start": 1568,
-      "end": 1568
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-shadow-wide",
-      "value": "none",
-      "scope": "default",
-      "line": {
-        "start": 1569,
-        "end": 1569
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The Masthead shadow that gets applied when the page is scrolled.\n",
-    "commentRange": {
-      "start": 1570,
-      "end": 1570
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-shadow-scroll",
-      "value": "0 0 40px rgba(0, 0, 0, 0.1)",
-      "scope": "default",
-      "line": {
-        "start": 1571,
-        "end": 1571
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border of the selector in the Masthead with Extended Navigation.\n",
-    "commentRange": {
-      "start": 1572,
-      "end": 1572
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-selector-border",
-      "value": "2px solid $sprk-black-tint-25",
-      "scope": "default",
-      "line": {
-        "start": 1573,
-        "end": 1573
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The border radius of the selector in the Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1575,
-      "end": 1575
+      "start": 1565,
+      "end": 1565
     },
     "context": {
       "type": "variable",
@@ -21057,8 +20932,8 @@
       "value": "5px",
       "scope": "default",
       "line": {
-        "start": 1576,
-        "end": 1576
+        "start": 1566,
+        "end": 1566
       }
     },
     "access": "public",
@@ -21073,8 +20948,8 @@
   {
     "description": "The bottom border that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1577,
-      "end": 1579
+      "start": 1567,
+      "end": 1569
     },
     "context": {
       "type": "variable",
@@ -21082,8 +20957,8 @@
       "value": "2px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1580,
-        "end": 1580
+        "start": 1570,
+        "end": 1570
       }
     },
     "access": "public",
@@ -21098,8 +20973,8 @@
   {
     "description": "The box shadow that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1581,
-      "end": 1583
+      "start": 1571,
+      "end": 1573
     },
     "context": {
       "type": "variable",
@@ -21107,8 +20982,8 @@
       "value": "0 5px 10px\n  rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1584,
-        "end": 1585
+        "start": 1574,
+        "end": 1575
       }
     },
     "access": "public",
@@ -21123,8 +20998,8 @@
   {
     "description": "The border color that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1586,
-      "end": 1588
+      "start": 1576,
+      "end": 1578
     },
     "context": {
       "type": "variable",
@@ -21132,8 +21007,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1589,
-        "end": 1589
+        "start": 1579,
+        "end": 1579
       }
     },
     "access": "public",
@@ -21148,8 +21023,8 @@
   {
     "description": "The font color of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1590,
-      "end": 1591
+      "start": 1580,
+      "end": 1581
     },
     "context": {
       "type": "variable",
@@ -21157,8 +21032,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1592,
-        "end": 1592
+        "start": 1582,
+        "end": 1582
       }
     },
     "access": "public",
@@ -21173,8 +21048,8 @@
   {
     "description": "The background color of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1593,
-      "end": 1594
+      "start": 1583,
+      "end": 1584
     },
     "context": {
       "type": "variable",
@@ -21182,8 +21057,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1595,
-        "end": 1595
+        "start": 1585,
+        "end": 1585
       }
     },
     "access": "public",
@@ -21198,8 +21073,8 @@
   {
     "description": "The padding of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1596,
-      "end": 1597
+      "start": 1586,
+      "end": 1587
     },
     "context": {
       "type": "variable",
@@ -21207,8 +21082,8 @@
       "value": "$sprk-space-inset-short-m",
       "scope": "default",
       "line": {
-        "start": 1598,
-        "end": 1598
+        "start": 1588,
+        "end": 1588
       }
     },
     "access": "public",
@@ -21223,8 +21098,8 @@
   {
     "description": "The padding of the selector dropdown in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1599,
-      "end": 1600
+      "start": 1589,
+      "end": 1590
     },
     "context": {
       "type": "variable",
@@ -21232,8 +21107,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1601,
-        "end": 1601
+        "start": 1591,
+        "end": 1591
       }
     },
     "access": "public",
@@ -21248,8 +21123,8 @@
   {
     "description": "The minimum width of the selector\nin the Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1602,
-      "end": 1603
+      "start": 1592,
+      "end": 1593
     },
     "context": {
       "type": "variable",
@@ -21257,8 +21132,8 @@
       "value": "17rem",
       "scope": "default",
       "line": {
-        "start": 1604,
-        "end": 1604
+        "start": 1594,
+        "end": 1594
       }
     },
     "access": "public",
@@ -21273,8 +21148,8 @@
   {
     "description": "This is the height of the Masthead on\nnarrow viewports and is used to calculate\nhow far from the top the narrow\nnavigation items should be displayed.\n",
     "commentRange": {
-      "start": 1605,
-      "end": 1608
+      "start": 1595,
+      "end": 1598
     },
     "context": {
       "type": "variable",
@@ -21282,8 +21157,8 @@
       "value": "81px",
       "scope": "default",
       "line": {
-        "start": 1609,
-        "end": 1609
+        "start": 1599,
+        "end": 1599
       }
     },
     "access": "public",
@@ -21298,8 +21173,8 @@
   {
     "description": "The color of the mask that\ngets applied when the Masthead selector\ndropdown is open on narrow screens.\n",
     "commentRange": {
-      "start": 1610,
-      "end": 1612
+      "start": 1600,
+      "end": 1602
     },
     "context": {
       "type": "variable",
@@ -21307,8 +21182,8 @@
       "value": "rgba(0, 0, 0, 0.5)",
       "scope": "default",
       "line": {
-        "start": 1613,
-        "end": 1613
+        "start": 1603,
+        "end": 1603
       }
     },
     "access": "public",
@@ -21323,8 +21198,8 @@
   {
     "description": "The transition applied to the Masthead.\n",
     "commentRange": {
-      "start": 1614,
-      "end": 1614
+      "start": 1604,
+      "end": 1604
     },
     "context": {
       "type": "variable",
@@ -21332,8 +21207,8 @@
       "value": "all 0.3s ease-in",
       "scope": "default",
       "line": {
-        "start": 1615,
-        "end": 1615
+        "start": 1605,
+        "end": 1605
       }
     },
     "access": "public",
@@ -21348,8 +21223,8 @@
   {
     "description": "The transform length that gets applied\nwhen the Masthead scrolls out of view on narrow screens.\n",
     "commentRange": {
-      "start": 1616,
-      "end": 1617
+      "start": 1606,
+      "end": 1607
     },
     "context": {
       "type": "variable",
@@ -21357,8 +21232,8 @@
       "value": "translateY(-100%)",
       "scope": "default",
       "line": {
-        "start": 1618,
-        "end": 1618
+        "start": 1608,
+        "end": 1608
       }
     },
     "access": "public",
@@ -21373,8 +21248,8 @@
   {
     "description": "The maximum width of the\nbig navigation items in the\nnavigation bar in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1621,
-      "end": 1623
+      "start": 1611,
+      "end": 1613
     },
     "context": {
       "type": "variable",
@@ -21382,8 +21257,8 @@
       "value": "64rem",
       "scope": "default",
       "line": {
-        "start": 1624,
-        "end": 1624
+        "start": 1614,
+        "end": 1614
       }
     },
     "access": "public",
@@ -21398,8 +21273,8 @@
   {
     "description": "The background color of the big\nnavigation bar in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1625,
-      "end": 1626
+      "start": 1615,
+      "end": 1616
     },
     "context": {
       "type": "variable",
@@ -21407,8 +21282,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1627,
-        "end": 1627
+        "start": 1617,
+        "end": 1617
       }
     },
     "access": "public",
@@ -21423,8 +21298,8 @@
   {
     "description": "The font weight of the big\nnavigation link in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1628,
-      "end": 1629
+      "start": 1618,
+      "end": 1619
     },
     "context": {
       "type": "variable",
@@ -21432,8 +21307,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1630,
-        "end": 1630
+        "start": 1620,
+        "end": 1620
       }
     },
     "access": "public",
@@ -21448,8 +21323,8 @@
   {
     "description": "The padding of the big navigation\nlink in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1631,
-      "end": 1632
+      "start": 1621,
+      "end": 1622
     },
     "context": {
       "type": "variable",
@@ -21457,8 +21332,8 @@
       "value": "0 $sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1633,
-        "end": 1633
+        "start": 1623,
+        "end": 1623
       }
     },
     "access": "public",
@@ -21473,8 +21348,8 @@
   {
     "description": "The color of the big navigation link in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1634,
-      "end": 1634
+      "start": 1624,
+      "end": 1624
     },
     "context": {
       "type": "variable",
@@ -21482,8 +21357,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1635,
-        "end": 1635
+        "start": 1625,
+        "end": 1625
       }
     },
     "access": "public",
@@ -21498,8 +21373,8 @@
   {
     "description": "The text and underline color of\nthe active big navigation item in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1636,
-      "end": 1637
+      "start": 1626,
+      "end": 1627
     },
     "context": {
       "type": "variable",
@@ -21507,8 +21382,8 @@
       "value": "$sprk-big-nav-link-color",
       "scope": "default",
       "line": {
-        "start": 1638,
-        "end": 1638
+        "start": 1628,
+        "end": 1628
       }
     },
     "access": "public",
@@ -21523,13 +21398,88 @@
   {
     "description": "The line height\nof the big navigation items\nin the Masthead Extended.\n",
     "commentRange": {
-      "start": 1639,
-      "end": 1641
+      "start": 1629,
+      "end": 1631
     },
     "context": {
       "type": "variable",
       "name": "sprk-big-nav-item-line-height",
       "value": "53px",
+      "scope": "default",
+      "line": {
+        "start": 1632,
+        "end": 1632
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The left border of the active item\nin the narrow viewport Masthead Accordion.\n",
+    "commentRange": {
+      "start": 1634,
+      "end": 1635
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-active-left-border",
+      "value": "3px solid $sprk-black",
+      "scope": "default",
+      "line": {
+        "start": 1636,
+        "end": 1636
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font weight of the active item\nin the narrow viewport Masthead Accordion.\n",
+    "commentRange": {
+      "start": 1637,
+      "end": 1638
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-active-heading-font-weight",
+      "value": "400",
+      "scope": "default",
+      "line": {
+        "start": 1639,
+        "end": 1639
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the active item\nin the narrow viewport Masthead Accordion.\n",
+    "commentRange": {
+      "start": 1640,
+      "end": 1641
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-active-heading-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1642,
@@ -21546,85 +21496,10 @@
     }
   },
   {
-    "description": "The left border of the active item\nin the narrow viewport Masthead Accordion.\n",
-    "commentRange": {
-      "start": 1644,
-      "end": 1645
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-accordion-active-left-border",
-      "value": "3px solid $sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1646,
-        "end": 1646
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the active item\nin the narrow viewport Masthead Accordion.\n",
-    "commentRange": {
-      "start": 1647,
-      "end": 1648
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-accordion-active-heading-font-weight",
-      "value": "400",
-      "scope": "default",
-      "line": {
-        "start": 1649,
-        "end": 1649
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the active item\nin the narrow viewport Masthead Accordion.\n",
-    "commentRange": {
-      "start": 1650,
-      "end": 1651
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-accordion-active-heading-color",
-      "value": "$sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1652,
-        "end": 1652
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The color of the heading\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1653,
-      "end": 1654
+      "start": 1643,
+      "end": 1644
     },
     "context": {
       "type": "variable",
@@ -21632,8 +21507,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1655,
-        "end": 1655
+        "start": 1645,
+        "end": 1645
       }
     },
     "access": "public",
@@ -21648,8 +21523,8 @@
   {
     "description": "The font weight of the heading\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1656,
-      "end": 1657
+      "start": 1646,
+      "end": 1647
     },
     "context": {
       "type": "variable",
@@ -21657,8 +21532,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1658,
-        "end": 1658
+        "start": 1648,
+        "end": 1648
       }
     },
     "access": "public",
@@ -21673,8 +21548,8 @@
   {
     "description": "The font weight of the details\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1659,
-      "end": 1660
+      "start": 1649,
+      "end": 1650
     },
     "context": {
       "type": "variable",
@@ -21682,8 +21557,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 1661,
-        "end": 1661
+        "start": 1651,
+        "end": 1651
       }
     },
     "access": "public",
@@ -21698,8 +21573,8 @@
   {
     "description": "The font color of the details\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1662,
-      "end": 1663
+      "start": 1652,
+      "end": 1653
     },
     "context": {
       "type": "variable",
@@ -21707,8 +21582,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1664,
-        "end": 1664
+        "start": 1654,
+        "end": 1654
       }
     },
     "access": "public",
@@ -21723,8 +21598,8 @@
   {
     "description": "The background color of the active\nitem in the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1665,
-      "end": 1666
+      "start": 1655,
+      "end": 1656
     },
     "context": {
       "type": "variable",
@@ -21732,8 +21607,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1667,
-        "end": 1667
+        "start": 1657,
+        "end": 1657
       }
     },
     "access": "public",
@@ -21748,8 +21623,8 @@
   {
     "description": "The font color of the active\nitem in the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1668,
-      "end": 1669
+      "start": 1658,
+      "end": 1659
     },
     "context": {
       "type": "variable",
@@ -21757,8 +21632,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1670,
-        "end": 1670
+        "start": 1660,
+        "end": 1660
       }
     },
     "access": "public",
@@ -21773,8 +21648,8 @@
   {
     "description": "The font color of the text\nin items in the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1671,
-      "end": 1672
+      "start": 1661,
+      "end": 1662
     },
     "context": {
       "type": "variable",
@@ -21782,8 +21657,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1673,
-        "end": 1673
+        "start": 1663,
+        "end": 1663
       }
     },
     "access": "public",
@@ -21798,8 +21673,8 @@
   {
     "description": "The color of the line on open items\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1674,
-      "end": 1675
+      "start": 1664,
+      "end": 1665
     },
     "context": {
       "type": "variable",
@@ -21807,8 +21682,8 @@
       "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
-        "start": 1676,
-        "end": 1676
+        "start": 1666,
+        "end": 1666
       }
     },
     "access": "public",
@@ -21823,13 +21698,63 @@
   {
     "description": "The height of the line on open\nitems in the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1677,
-      "end": 1678
+      "start": 1667,
+      "end": 1668
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-accordion-item-open-line-height",
       "value": "2px",
+      "scope": "default",
+      "line": {
+        "start": 1669,
+        "end": 1669
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding of the items in the\nnarrow viewport Masthead Accordion.\n",
+    "commentRange": {
+      "start": 1670,
+      "end": 1671
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-item-padding",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1672,
+        "end": 1672
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The height and width of Spinners.\n",
+    "commentRange": {
+      "start": 1678,
+      "end": 1678
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-spinner-size",
+      "value": "1.3rem",
       "scope": "default",
       "line": {
         "start": 1679,
@@ -21846,19 +21771,19 @@
     }
   },
   {
-    "description": "The padding of the items in the\nnarrow viewport Masthead Accordion.\n",
+    "description": "The height and width of large Spinners.\n",
     "commentRange": {
       "start": 1680,
-      "end": 1681
+      "end": 1680
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-padding",
-      "value": "$sprk-space-m",
+      "name": "sprk-spinner-size-large",
+      "value": "3rem",
       "scope": "default",
       "line": {
-        "start": 1682,
-        "end": 1682
+        "start": 1681,
+        "end": 1681
       }
     },
     "access": "public",
@@ -21871,15 +21796,90 @@
     }
   },
   {
-    "description": "The height and width of Spinners.\n",
+    "description": "The speed of the animation for Spinners.\n",
+    "commentRange": {
+      "start": 1682,
+      "end": 1682
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-spinner-speed",
+      "value": "1s",
+      "scope": "default",
+      "line": {
+        "start": 1683,
+        "end": 1683
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The thickness of Spinners.\n",
+    "commentRange": {
+      "start": 1684,
+      "end": 1684
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-spinner-thickness",
+      "value": "0.18rem",
+      "scope": "default",
+      "line": {
+        "start": 1685,
+        "end": 1685
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of Spinners.\n",
+    "commentRange": {
+      "start": 1686,
+      "end": 1686
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-spinner-color",
+      "value": "$sprk-white",
+      "scope": "default",
+      "line": {
+        "start": 1687,
+        "end": 1687
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the dark Spinner.\n",
     "commentRange": {
       "start": 1688,
       "end": 1688
     },
     "context": {
       "type": "variable",
-      "name": "sprk-spinner-size",
-      "value": "1.3rem",
+      "name": "sprk-spinner-color-dark",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1689,
@@ -21896,90 +21896,15 @@
     }
   },
   {
-    "description": "The height and width of large Spinners.\n",
+    "description": "The breakpoint at which the tabs\ngo from stacked layout to side by side in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1690,
-      "end": 1690
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-spinner-size-large",
-      "value": "3rem",
-      "scope": "default",
-      "line": {
-        "start": 1691,
-        "end": 1691
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The speed of the animation for Spinners.\n",
-    "commentRange": {
-      "start": 1692,
-      "end": 1692
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-spinner-speed",
-      "value": "1s",
-      "scope": "default",
-      "line": {
-        "start": 1693,
-        "end": 1693
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The thickness of Spinners.\n",
-    "commentRange": {
-      "start": 1694,
-      "end": 1694
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-spinner-thickness",
-      "value": "0.18rem",
-      "scope": "default",
-      "line": {
-        "start": 1695,
-        "end": 1695
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of Spinners.\n",
-    "commentRange": {
-      "start": 1696,
+      "start": 1695,
       "end": 1696
     },
     "context": {
       "type": "variable",
-      "name": "sprk-spinner-color",
-      "value": "$sprk-white",
+      "name": "sprk-tab-navigation-breakpoint",
+      "value": "46rem",
       "scope": "default",
       "line": {
         "start": 1697,
@@ -21996,14 +21921,14 @@
     }
   },
   {
-    "description": "The color of the dark Spinner.\n",
+    "description": "The tab button text color in Tabbed Navigation.\n",
     "commentRange": {
       "start": 1698,
       "end": 1698
     },
     "context": {
       "type": "variable",
-      "name": "sprk-spinner-color-dark",
+      "name": "sprk-tab-navigation-btn-color",
       "value": "$sprk-black",
       "scope": "default",
       "line": {
@@ -22021,19 +21946,19 @@
     }
   },
   {
-    "description": "The breakpoint at which the tabs\ngo from stacked layout to side by side in Tabbed Navigation.\n",
+    "description": "The tab button background color in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1705,
-      "end": 1706
+      "start": 1700,
+      "end": 1700
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-breakpoint",
-      "value": "46rem",
+      "name": "sprk-tab-navigation-btn-bg-color",
+      "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1707,
-        "end": 1707
+        "start": 1701,
+        "end": 1701
       }
     },
     "access": "public",
@@ -22046,15 +21971,65 @@
     }
   },
   {
-    "description": "The tab button text color in Tabbed Navigation.\n",
+    "description": "The border on the top of the button tabs in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1708,
+      "start": 1702,
+      "end": 1702
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-tab-navigation-btn-border-top",
+      "value": "3px solid $sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1703,
+        "end": 1703
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The border on the top of the\nbutton tabs on hover in Tabbed Navigation.\n",
+    "commentRange": {
+      "start": 1704,
+      "end": 1705
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-tab-navigation-btn-hover-border-top",
+      "value": "3px solid $sprk-red",
+      "scope": "default",
+      "line": {
+        "start": 1706,
+        "end": 1706
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The button tab text color of the\ncurrently active tab in Tabbed Navigation.\n",
+    "commentRange": {
+      "start": 1707,
       "end": 1708
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-color",
-      "value": "$sprk-black",
+      "name": "sprk-tab-navigation-btn-active-color",
+      "value": "$sprk-red",
       "scope": "default",
       "line": {
         "start": 1709,
@@ -22071,115 +22046,65 @@
     }
   },
   {
-    "description": "The tab button background color in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1710,
-      "end": 1710
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-bg-color",
-      "value": "$sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1711,
-        "end": 1711
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border on the top of the button tabs in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1712,
-      "end": 1712
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-border-top",
-      "value": "3px solid $sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1713,
-        "end": 1713
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border on the top of the\nbutton tabs on hover in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1714,
-      "end": 1715
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-hover-border-top",
-      "value": "3px solid $sprk-red",
-      "scope": "default",
-      "line": {
-        "start": 1716,
-        "end": 1716
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The button tab text color of the\ncurrently active tab in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1717,
-      "end": 1718
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-color",
-      "value": "$sprk-red",
-      "scope": "default",
-      "line": {
-        "start": 1719,
-        "end": 1719
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The button tab top border of the\ncurrently active tab in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1720,
-      "end": 1721
+      "start": 1710,
+      "end": 1711
     },
     "context": {
       "type": "variable",
       "name": "sprk-tab-navigation-btn-active-border-top",
       "value": "3px solid $sprk-red",
+      "scope": "default",
+      "line": {
+        "start": 1712,
+        "end": 1712
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The button tab background color\nof the currently active tab in Tabbed Navigation.\n",
+    "commentRange": {
+      "start": 1713,
+      "end": 1714
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-tab-navigation-btn-active-bg-color",
+      "value": "$sprk-white",
+      "scope": "default",
+      "line": {
+        "start": 1715,
+        "end": 1715
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Stepper.\n",
+    "commentRange": {
+      "start": 1721,
+      "end": 1721
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-bg",
+      "value": "transparent",
       "scope": "default",
       "line": {
         "start": 1722,
@@ -22196,15 +22121,15 @@
     }
   },
   {
-    "description": "The button tab background color\nof the currently active tab in Tabbed Navigation.\n",
+    "description": "The minimum width at which the Stepper\nswitches between narrow and wide layouts.\n",
     "commentRange": {
       "start": 1723,
       "end": 1724
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-bg-color",
-      "value": "$sprk-white",
+      "name": "sprk-stepper-breakpoint",
+      "value": "$sprk-split-breakpoint-xl",
       "scope": "default",
       "line": {
         "start": 1725,
@@ -22221,65 +22146,115 @@
     }
   },
   {
-    "description": "The background color of the Stepper.\n",
-    "commentRange": {
-      "start": 1731,
-      "end": 1731
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-bg",
-      "value": "transparent",
-      "scope": "default",
-      "line": {
-        "start": 1732,
-        "end": 1732
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The minimum width at which the Stepper\nswitches between narrow and wide layouts.\n",
-    "commentRange": {
-      "start": 1733,
-      "end": 1734
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-breakpoint",
-      "value": "$sprk-split-breakpoint-xl",
-      "scope": "default",
-      "line": {
-        "start": 1735,
-        "end": 1735
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The maximum width of the Stepper.\n",
     "commentRange": {
-      "start": 1736,
-      "end": 1736
+      "start": 1726,
+      "end": 1726
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-max-width",
       "value": "480px",
+      "scope": "default",
+      "line": {
+        "start": 1727,
+        "end": 1727
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The border width of the Stepper icons.\n",
+    "commentRange": {
+      "start": 1728,
+      "end": 1728
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-border-width",
+      "value": "2px",
+      "scope": "default",
+      "line": {
+        "start": 1729,
+        "end": 1729
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the border around the Stepper icon.\n",
+    "commentRange": {
+      "start": 1730,
+      "end": 1730
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-border-color",
+      "value": "$sprk-black-tint-50",
+      "scope": "default",
+      "line": {
+        "start": 1731,
+        "end": 1731
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the step icon when the step is selected in the Stepper.\n",
+    "commentRange": {
+      "start": 1732,
+      "end": 1732
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-border-color-selected",
+      "value": "$sprk-green",
+      "scope": "default",
+      "line": {
+        "start": 1733,
+        "end": 1733
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the icon border when the\nStepper is on a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
+    "commentRange": {
+      "start": 1734,
+      "end": 1736
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-dark-icon-border-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1737,
@@ -22296,15 +22271,15 @@
     }
   },
   {
-    "description": "The border width of the Stepper icons.\n",
+    "description": "The height of the step icon in the Stepper.\n",
     "commentRange": {
       "start": 1738,
       "end": 1738
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-border-width",
-      "value": "2px",
+      "name": "sprk-stepper-icon-height",
+      "value": "16px",
       "scope": "default",
       "line": {
         "start": 1739,
@@ -22321,15 +22296,15 @@
     }
   },
   {
-    "description": "The color of the border around the Stepper icon.\n",
+    "description": "The width of the step icon in the Stepper.\n",
     "commentRange": {
       "start": 1740,
       "end": 1740
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-border-color",
-      "value": "$sprk-black-tint-50",
+      "name": "sprk-stepper-icon-width",
+      "value": "16px",
       "scope": "default",
       "line": {
         "start": 1741,
@@ -22346,15 +22321,15 @@
     }
   },
   {
-    "description": "The color of the step icon when the step is selected in the Stepper.\n",
+    "description": "The color of the step icon in the Stepper.\n",
     "commentRange": {
       "start": 1742,
       "end": 1742
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-border-color-selected",
-      "value": "$sprk-green",
+      "name": "sprk-stepper-icon-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1743,
@@ -22371,19 +22346,44 @@
     }
   },
   {
-    "description": "The color of the icon border when the\nStepper is on a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
+    "description": "The color of the step icon\nin the Stepper when hovered.\n",
     "commentRange": {
       "start": 1744,
-      "end": 1746
+      "end": 1745
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-dark-icon-border-color",
+      "name": "sprk-stepper-icon-color-hover",
+      "value": "$sprk-black-tint-50",
+      "scope": "default",
+      "line": {
+        "start": 1746,
+        "end": 1746
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the Stepper step icon when the step is selected.\n",
+    "commentRange": {
+      "start": 1747,
+      "end": 1747
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-color-selected",
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1747,
-        "end": 1747
+        "start": 1748,
+        "end": 1748
       }
     },
     "access": "public",
@@ -22396,40 +22396,15 @@
     }
   },
   {
-    "description": "The height of the step icon in the Stepper.\n",
+    "description": "The color of the step icon when the\nStepper has a dark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1748,
-      "end": 1748
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-height",
-      "value": "16px",
-      "scope": "default",
-      "line": {
-        "start": 1749,
-        "end": 1749
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The width of the step icon in the Stepper.\n",
-    "commentRange": {
-      "start": 1750,
+      "start": 1749,
       "end": 1750
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-width",
-      "value": "16px",
+      "name": "sprk-stepper-dark-icon-color",
+      "value": "$sprk-blue",
       "scope": "default",
       "line": {
         "start": 1751,
@@ -22446,110 +22421,10 @@
     }
   },
   {
-    "description": "The color of the step icon in the Stepper.\n",
-    "commentRange": {
-      "start": 1752,
-      "end": 1752
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1753,
-        "end": 1753
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the step icon\nin the Stepper when hovered.\n",
-    "commentRange": {
-      "start": 1754,
-      "end": 1755
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-color-hover",
-      "value": "$sprk-black-tint-50",
-      "scope": "default",
-      "line": {
-        "start": 1756,
-        "end": 1756
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Stepper step icon when the step is selected.\n",
-    "commentRange": {
-      "start": 1757,
-      "end": 1757
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-color-selected",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1758,
-        "end": 1758
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the step icon when the\nStepper has a dark background (sprk-c-Stepper--has-dark-bg).\n",
-    "commentRange": {
-      "start": 1759,
-      "end": 1760
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-dark-icon-color",
-      "value": "$sprk-blue",
-      "scope": "default",
-      "line": {
-        "start": 1761,
-        "end": 1761
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The color of the Stepper step icon when the step\nis selected and the Stepper has a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1762,
-      "end": 1764
+      "start": 1752,
+      "end": 1754
     },
     "context": {
       "type": "variable",
@@ -22557,8 +22432,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1765,
-        "end": 1765
+        "start": 1755,
+        "end": 1755
       }
     },
     "access": "public",
@@ -22573,8 +22448,8 @@
   {
     "description": "The color of the step icon on hover\nwhen the Stepper has a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1766,
-      "end": 1768
+      "start": 1756,
+      "end": 1758
     },
     "context": {
       "type": "variable",
@@ -22582,8 +22457,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1769,
-        "end": 1769
+        "start": 1759,
+        "end": 1759
       }
     },
     "access": "public",
@@ -22598,8 +22473,8 @@
   {
     "description": "The transition of the Stepper step icon.\n",
     "commentRange": {
-      "start": 1771,
-      "end": 1771
+      "start": 1761,
+      "end": 1761
     },
     "context": {
       "type": "variable",
@@ -22607,8 +22482,8 @@
       "value": "0.3s all ease-in-out",
       "scope": "default",
       "line": {
-        "start": 1772,
-        "end": 1772
+        "start": 1762,
+        "end": 1762
       }
     },
     "access": "public",
@@ -22623,13 +22498,88 @@
   {
     "description": "The z-index of the Stepper step icon.\n",
     "commentRange": {
-      "start": 1773,
-      "end": 1773
+      "start": 1763,
+      "end": 1763
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-icon-z-index",
       "value": "$sprk-layer-height-xs",
+      "scope": "default",
+      "line": {
+        "start": 1764,
+        "end": 1764
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The spread value of the icon box\nshadow when the Stepper step is selected.\n",
+    "commentRange": {
+      "start": 1765,
+      "end": 1766
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-box-shadow-selected-spread",
+      "value": "8px",
+      "scope": "default",
+      "line": {
+        "start": 1767,
+        "end": 1767
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Stepper step icon\nwhen the icon is selected.\n",
+    "commentRange": {
+      "start": 1768,
+      "end": 1769
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-box-shadow-selected",
+      "value": "0 0 0\n  $sprk-stepper-icon-box-shadow-selected-spread\n  $sprk-stepper-icon-border-color-selected",
+      "scope": "default",
+      "line": {
+        "start": 1770,
+        "end": 1772
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the content in the Stepper step.\n",
+    "commentRange": {
+      "start": 1773,
+      "end": 1773
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-step-content-bg",
+      "value": "transparent",
       "scope": "default",
       "line": {
         "start": 1774,
@@ -22646,15 +22596,15 @@
     }
   },
   {
-    "description": "The spread value of the icon box\nshadow when the Stepper step is selected.\n",
+    "description": "The border radius of the Stepper step\ncontent box when it has a description.\n",
     "commentRange": {
       "start": 1775,
       "end": 1776
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-box-shadow-selected-spread",
-      "value": "8px",
+      "name": "sprk-stepper-step-description-border-radius",
+      "value": "5px",
       "scope": "default",
       "line": {
         "start": 1777,
@@ -22671,19 +22621,19 @@
     }
   },
   {
-    "description": "The box shadow of the Stepper step icon\nwhen the icon is selected.\n",
+    "description": "The box shadow of the Stepper step content\nbox when it has a description.\n",
     "commentRange": {
       "start": 1778,
       "end": 1779
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-box-shadow-selected",
-      "value": "0 0 0\n  $sprk-stepper-icon-box-shadow-selected-spread\n  $sprk-stepper-icon-border-color-selected",
+      "name": "sprk-stepper-step-description-box-shadow",
+      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
         "start": 1780,
-        "end": 1782
+        "end": 1780
       }
     },
     "access": "public",
@@ -22696,19 +22646,19 @@
     }
   },
   {
-    "description": "The background color of the content in the Stepper step.\n",
+    "description": "The spacing between the\nStepper step heading and description.\n",
     "commentRange": {
-      "start": 1783,
-      "end": 1783
+      "start": 1781,
+      "end": 1782
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-content-bg",
-      "value": "transparent",
+      "name": "sprk-stepper-step-description-top-spacing",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1784,
-        "end": 1784
+        "start": 1783,
+        "end": 1783
       }
     },
     "access": "public",
@@ -22721,15 +22671,40 @@
     }
   },
   {
-    "description": "The border radius of the Stepper step\ncontent box when it has a description.\n",
+    "description": "The font weight of the Stepper step heading.\n",
     "commentRange": {
-      "start": 1785,
+      "start": 1784,
+      "end": 1784
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-step-heading-font-weight",
+      "value": "400",
+      "scope": "default",
+      "line": {
+        "start": 1785,
+        "end": 1785
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font size of the Stepper step heading.\n",
+    "commentRange": {
+      "start": 1786,
       "end": 1786
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-border-radius",
-      "value": "5px",
+      "name": "sprk-stepper-step-heading-size",
+      "value": "$sprk-font-size-display-six",
       "scope": "default",
       "line": {
         "start": 1787,
@@ -22746,19 +22721,19 @@
     }
   },
   {
-    "description": "The box shadow of the Stepper step content\nbox when it has a description.\n",
+    "description": "The color of the Stepper step heading.\n",
     "commentRange": {
       "start": 1788,
-      "end": 1789
+      "end": 1788
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-box-shadow",
-      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
+      "name": "sprk-stepper-step-heading-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1790,
-        "end": 1790
+        "start": 1789,
+        "end": 1789
       }
     },
     "access": "public",
@@ -22771,15 +22746,15 @@
     }
   },
   {
-    "description": "The spacing between the\nStepper step heading and description.\n",
+    "description": "The color of the Stepper step heading when\nthe Stepper is on a dark\nbackground (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1791,
+      "start": 1790,
       "end": 1792
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-top-spacing",
-      "value": "$sprk-space-m",
+      "name": "sprk-stepper-dark-step-heading-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1793,
@@ -22796,110 +22771,10 @@
     }
   },
   {
-    "description": "The font weight of the Stepper step heading.\n",
-    "commentRange": {
-      "start": 1794,
-      "end": 1794
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-heading-font-weight",
-      "value": "400",
-      "scope": "default",
-      "line": {
-        "start": 1795,
-        "end": 1795
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size of the Stepper step heading.\n",
-    "commentRange": {
-      "start": 1796,
-      "end": 1796
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-heading-size",
-      "value": "$sprk-font-size-display-six",
-      "scope": "default",
-      "line": {
-        "start": 1797,
-        "end": 1797
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Stepper step heading.\n",
-    "commentRange": {
-      "start": 1798,
-      "end": 1798
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-heading-color",
-      "value": "$sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1799,
-        "end": 1799
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Stepper step heading when\nthe Stepper is on a dark\nbackground (sprk-c-Stepper--has-dark-bg).\n",
-    "commentRange": {
-      "start": 1800,
-      "end": 1802
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-dark-step-heading-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1803,
-        "end": 1803
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The color of the Stepper\nstep heading when the step is selected.\n",
     "commentRange": {
-      "start": 1804,
-      "end": 1805
+      "start": 1794,
+      "end": 1795
     },
     "context": {
       "type": "variable",
@@ -22907,8 +22782,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1806,
-        "end": 1806
+        "start": 1796,
+        "end": 1796
       }
     },
     "access": "public",
@@ -22923,8 +22798,8 @@
   {
     "description": "The padding value for the Stepper step.\n",
     "commentRange": {
-      "start": 1807,
-      "end": 1807
+      "start": 1797,
+      "end": 1797
     },
     "context": {
       "type": "variable",
@@ -22932,8 +22807,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 1808,
-        "end": 1808
+        "start": 1798,
+        "end": 1798
       }
     },
     "access": "public",
@@ -22948,8 +22823,8 @@
   {
     "description": "The background color of the\nStepper step content box when the step is selected.\n",
     "commentRange": {
-      "start": 1809,
-      "end": 1810
+      "start": 1799,
+      "end": 1800
     },
     "context": {
       "type": "variable",
@@ -22957,8 +22832,8 @@
       "value": "transparent",
       "scope": "default",
       "line": {
-        "start": 1811,
-        "end": 1811
+        "start": 1801,
+        "end": 1801
       }
     },
     "access": "public",
@@ -22973,8 +22848,8 @@
   {
     "description": "The background color of the Stepper step\ncontent box when it has a\ndescription and when the step is selected.\n",
     "commentRange": {
-      "start": 1812,
-      "end": 1814
+      "start": 1802,
+      "end": 1804
     },
     "context": {
       "type": "variable",
@@ -22982,8 +22857,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1815,
-        "end": 1815
+        "start": 1805,
+        "end": 1805
       }
     },
     "access": "public",
@@ -22998,8 +22873,8 @@
   {
     "description": "The text color of a selected Stepper step's\ncontent and header when it has a\ndescription. This applies to\nsteppers with the sprk-c-Stepper--has-dark-bg class.\n",
     "commentRange": {
-      "start": 1816,
-      "end": 1819
+      "start": 1806,
+      "end": 1809
     },
     "context": {
       "type": "variable",
@@ -23007,8 +22882,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1820,
-        "end": 1820
+        "start": 1810,
+        "end": 1810
       }
     },
     "access": "public",
@@ -23023,8 +22898,8 @@
   {
     "description": "The color of the bar that connects the steps in the Stepper.\n",
     "commentRange": {
-      "start": 1821,
-      "end": 1821
+      "start": 1811,
+      "end": 1811
     },
     "context": {
       "type": "variable",
@@ -23032,8 +22907,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1822,
-        "end": 1822
+        "start": 1812,
+        "end": 1812
       }
     },
     "access": "public",
@@ -23048,8 +22923,8 @@
   {
     "description": "The color of the bar that connects\nthe steps when the Stepper is on a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1823,
-      "end": 1825
+      "start": 1813,
+      "end": 1815
     },
     "context": {
       "type": "variable",
@@ -23057,8 +22932,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1826,
-        "end": 1826
+        "start": 1816,
+        "end": 1816
       }
     },
     "access": "public",
@@ -23073,8 +22948,8 @@
   {
     "description": "The border value for the Carousel component.\n",
     "commentRange": {
-      "start": 1845,
-      "end": 1845
+      "start": 1835,
+      "end": 1835
     },
     "context": {
       "type": "variable",
@@ -23082,8 +22957,8 @@
       "value": "$sprk-stepper-icon-border-width solid\n  $sprk-stepper-dark-icon-border-color",
       "scope": "default",
       "line": {
-        "start": 1846,
-        "end": 1847
+        "start": 1836,
+        "end": 1837
       }
     },
     "access": "public",
@@ -23098,13 +22973,138 @@
   {
     "description": "The height of the dots in the Carousel component.\n",
     "commentRange": {
-      "start": 1848,
-      "end": 1848
+      "start": 1838,
+      "end": 1838
     },
     "context": {
       "type": "variable",
       "name": "sprk-carousel-dot-height",
       "value": "10px",
+      "scope": "default",
+      "line": {
+        "start": 1839,
+        "end": 1839
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The width of the dots in the Carousel component.\n",
+    "commentRange": {
+      "start": 1840,
+      "end": 1840
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-dot-width",
+      "value": "10px",
+      "scope": "default",
+      "line": {
+        "start": 1841,
+        "end": 1841
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The height of the dots in the Carousel component on wide viewports.\n",
+    "commentRange": {
+      "start": 1842,
+      "end": 1842
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-wide-dot-height",
+      "value": "10px",
+      "scope": "default",
+      "line": {
+        "start": 1843,
+        "end": 1843
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The width of the dots in the Carousel component on wide viewports.\n",
+    "commentRange": {
+      "start": 1844,
+      "end": 1844
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-wide-dot-width",
+      "value": "10px",
+      "scope": "default",
+      "line": {
+        "start": 1845,
+        "end": 1845
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The spacing between dots in the Carousel component.\n",
+    "commentRange": {
+      "start": 1846,
+      "end": 1846
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-dot-spacing",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1847,
+        "end": 1847
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The spacing between dots in the Carousel component on wide viewports.\n",
+    "commentRange": {
+      "start": 1848,
+      "end": 1848
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-wide-dot-spacing",
+      "value": "$sprk-carousel-dot-spacing",
       "scope": "default",
       "line": {
         "start": 1849,
@@ -23121,15 +23121,15 @@
     }
   },
   {
-    "description": "The width of the dots in the Carousel component.\n",
+    "description": "The box shadow of the active dot in the Carousel component.\n",
     "commentRange": {
       "start": 1850,
       "end": 1850
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-dot-width",
-      "value": "10px",
+      "name": "sprk-carousel-dot-selected",
+      "value": "$sprk-stepper-icon-box-shadow-selected",
       "scope": "default",
       "line": {
         "start": 1851,
@@ -23146,15 +23146,15 @@
     }
   },
   {
-    "description": "The height of the dots in the Carousel component on wide viewports.\n",
+    "description": "The color of the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1852,
       "end": 1852
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-wide-dot-height",
-      "value": "10px",
+      "name": "sprk-carousel-arrow-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1853,
@@ -23171,15 +23171,15 @@
     }
   },
   {
-    "description": "The width of the dots in the Carousel component on wide viewports.\n",
+    "description": "The spacing for the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1854,
       "end": 1854
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-wide-dot-width",
-      "value": "10px",
+      "name": "sprk-carousel-arrow-spacing",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
         "start": 1855,
@@ -23196,15 +23196,15 @@
     }
   },
   {
-    "description": "The spacing between dots in the Carousel component.\n",
+    "description": "The left and right values of the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1856,
       "end": 1856
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-dot-spacing",
-      "value": "$sprk-space-m",
+      "name": "sprk-carousel-arrow-edge-spacing",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1857,
@@ -23221,15 +23221,15 @@
     }
   },
   {
-    "description": "The spacing between dots in the Carousel component on wide viewports.\n",
+    "description": "The padding value of the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1858,
       "end": 1858
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-wide-dot-spacing",
-      "value": "$sprk-carousel-dot-spacing",
+      "name": "sprk-carousel-arrow-padding",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
         "start": 1859,
@@ -23246,15 +23246,15 @@
     }
   },
   {
-    "description": "The box shadow of the active dot in the Carousel component.\n",
+    "description": "The maximum width of the image in the Carousel component.\n",
     "commentRange": {
       "start": 1860,
       "end": 1860
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-dot-selected",
-      "value": "$sprk-stepper-icon-box-shadow-selected",
+      "name": "sprk-carousel-narrow-image-max-width",
+      "value": "18.75rem",
       "scope": "default",
       "line": {
         "start": 1861,
@@ -23271,15 +23271,15 @@
     }
   },
   {
-    "description": "The color of the arrows in the Carousel component.\n",
+    "description": "The breakpoint for the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1862,
       "end": 1862
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-arrow-color",
-      "value": "$sprk-white",
+      "name": "sprk-carousel-arrow-position-breakpoint",
+      "value": "31.25rem",
       "scope": "default",
       "line": {
         "start": 1863,
@@ -23296,15 +23296,15 @@
     }
   },
   {
-    "description": "The spacing for the arrows in the Carousel component.\n",
+    "description": "The padding value for the dots container in the Carousel component.\n",
     "commentRange": {
       "start": 1864,
       "end": 1864
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-arrow-spacing",
-      "value": "$sprk-space-m",
+      "name": "sprk-carousel-dot-container-padding",
+      "value": "$sprk-space-xs",
       "scope": "default",
       "line": {
         "start": 1865,
@@ -23321,15 +23321,15 @@
     }
   },
   {
-    "description": "The left and right values of the arrows in the Carousel component.\n",
+    "description": "The breakpoint for the Carousel component.\n",
     "commentRange": {
       "start": 1866,
       "end": 1866
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-arrow-edge-spacing",
-      "value": "0",
+      "name": "sprk-carousel-breakpoint",
+      "value": "$sprk-split-breakpoint-xl",
       "scope": "default",
       "line": {
         "start": 1867,
@@ -23346,140 +23346,140 @@
     }
   },
   {
-    "description": "The padding value of the arrows in the Carousel component.\n",
-    "commentRange": {
-      "start": 1868,
-      "end": 1868
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-arrow-padding",
-      "value": "$sprk-space-m",
-      "scope": "default",
-      "line": {
-        "start": 1869,
-        "end": 1869
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The maximum width of the image in the Carousel component.\n",
-    "commentRange": {
-      "start": 1870,
-      "end": 1870
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-narrow-image-max-width",
-      "value": "18.75rem",
-      "scope": "default",
-      "line": {
-        "start": 1871,
-        "end": 1871
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The breakpoint for the arrows in the Carousel component.\n",
-    "commentRange": {
-      "start": 1872,
-      "end": 1872
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-arrow-position-breakpoint",
-      "value": "31.25rem",
-      "scope": "default",
-      "line": {
-        "start": 1873,
-        "end": 1873
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding value for the dots container in the Carousel component.\n",
-    "commentRange": {
-      "start": 1874,
-      "end": 1874
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-dot-container-padding",
-      "value": "$sprk-space-xs",
-      "scope": "default",
-      "line": {
-        "start": 1875,
-        "end": 1875
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The breakpoint for the Carousel component.\n",
-    "commentRange": {
-      "start": 1876,
-      "end": 1876
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-breakpoint",
-      "value": "$sprk-split-breakpoint-xl",
-      "scope": "default",
-      "line": {
-        "start": 1877,
-        "end": 1877
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The maximum width of the Card.\n",
+    "commentRange": {
+      "start": 1873,
+      "end": 1873
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-max-width",
+      "value": "26.5625rem",
+      "scope": "default",
+      "line": {
+        "start": 1874,
+        "end": 1874
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The main Card breakpoint.\n",
+    "commentRange": {
+      "start": 1875,
+      "end": 1875
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-breakpoint",
+      "value": "$sprk-split-breakpoint-s",
+      "scope": "default",
+      "line": {
+        "start": 1876,
+        "end": 1876
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Card on narrow viewports.\n",
+    "commentRange": {
+      "start": 1877,
+      "end": 1877
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-shadow",
+      "value": "0 3px 10px 1px rgba(0, 0, 0, 0.08)",
+      "scope": "default",
+      "line": {
+        "start": 1878,
+        "end": 1878
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Card on wide viewports.\n",
+    "commentRange": {
+      "start": 1879,
+      "end": 1879
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-shadow-wide-viewport",
+      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
+      "scope": "default",
+      "line": {
+        "start": 1880,
+        "end": 1880
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Standout Card variant on narrow viewports.\n",
+    "commentRange": {
+      "start": 1881,
+      "end": 1881
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-shadow-standout",
+      "value": "0 4px 20px 2px rgba(0, 0, 0, 0.1)",
+      "scope": "default",
+      "line": {
+        "start": 1882,
+        "end": 1882
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Standout Card variant on wide viewports.\n",
     "commentRange": {
       "start": 1883,
       "end": 1883
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-max-width",
-      "value": "26.5625rem",
+      "name": "sprk-card-shadow-standout-wide-viewport",
+      "value": "0 4px 40px 2px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
         "start": 1884,
@@ -23496,15 +23496,15 @@
     }
   },
   {
-    "description": "The main Card breakpoint.\n",
+    "description": "The border radius of the Card.\n",
     "commentRange": {
       "start": 1885,
       "end": 1885
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-breakpoint",
-      "value": "$sprk-split-breakpoint-s",
+      "name": "sprk-card-border-radius",
+      "value": "8px",
       "scope": "default",
       "line": {
         "start": 1886,
@@ -23521,15 +23521,15 @@
     }
   },
   {
-    "description": "The box shadow of the Card on narrow viewports.\n",
+    "description": "The padding of the content inside the Card.\n",
     "commentRange": {
       "start": 1887,
       "end": 1887
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-shadow",
-      "value": "0 3px 10px 1px rgba(0, 0, 0, 0.08)",
+      "name": "sprk-card-content-padding",
+      "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
         "start": 1888,
@@ -23546,15 +23546,15 @@
     }
   },
   {
-    "description": "The box shadow of the Card on wide viewports.\n",
+    "description": "The background color of the header area for the Highlighted Header Card.\n",
     "commentRange": {
       "start": 1889,
       "end": 1889
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-shadow-wide-viewport",
-      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
+      "name": "sprk-card-header-bg-color",
+      "value": "$sprk-green",
       "scope": "default",
       "line": {
         "start": 1890,
@@ -23571,15 +23571,15 @@
     }
   },
   {
-    "description": "The box shadow of the Standout Card variant on narrow viewports.\n",
+    "description": "The text color for the Highlighted Header Card.\n",
     "commentRange": {
       "start": 1891,
       "end": 1891
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-shadow-standout",
-      "value": "0 4px 20px 2px rgba(0, 0, 0, 0.1)",
+      "name": "sprk-card-header-text-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1892,
@@ -23596,140 +23596,140 @@
     }
   },
   {
-    "description": "The box shadow of the Standout Card variant on wide viewports.\n",
-    "commentRange": {
-      "start": 1893,
-      "end": 1893
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-shadow-standout-wide-viewport",
-      "value": "0 4px 40px 2px rgba(0, 0, 0, 0.1)",
-      "scope": "default",
-      "line": {
-        "start": 1894,
-        "end": 1894
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border radius of the Card.\n",
-    "commentRange": {
-      "start": 1895,
-      "end": 1895
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-border-radius",
-      "value": "8px",
-      "scope": "default",
-      "line": {
-        "start": 1896,
-        "end": 1896
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding of the content inside the Card.\n",
-    "commentRange": {
-      "start": 1897,
-      "end": 1897
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-content-padding",
-      "value": "$sprk-space-misc-a",
-      "scope": "default",
-      "line": {
-        "start": 1898,
-        "end": 1898
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The background color of the header area for the Highlighted Header Card.\n",
-    "commentRange": {
-      "start": 1899,
-      "end": 1899
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-header-bg-color",
-      "value": "$sprk-green",
-      "scope": "default",
-      "line": {
-        "start": 1900,
-        "end": 1900
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The text color for the Highlighted Header Card.\n",
-    "commentRange": {
-      "start": 1901,
-      "end": 1901
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-header-text-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1902,
-        "end": 1902
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The border surrounding the Dictionary.\n",
+    "commentRange": {
+      "start": 1898,
+      "end": 1898
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-border",
+      "value": "1px solid $sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1899,
+        "end": 1899
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the key value pairs in the striped Dictionary.\n",
+    "commentRange": {
+      "start": 1900,
+      "end": 1900
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-stripe-color",
+      "value": "$sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1901,
+        "end": 1901
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The breakpoint of the Dictionary component.\n",
+    "commentRange": {
+      "start": 1902,
+      "end": 1902
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-breakpoint",
+      "value": "38.4375rem",
+      "scope": "default",
+      "line": {
+        "start": 1903,
+        "end": 1903
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font size of the labels in the Dictionary.\n",
+    "commentRange": {
+      "start": 1904,
+      "end": 1904
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-label-font-size",
+      "value": "$sprk-font-size-body-one",
+      "scope": "default",
+      "line": {
+        "start": 1905,
+        "end": 1905
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font weight of the labels in the Dictionary.\n",
+    "commentRange": {
+      "start": 1906,
+      "end": 1906
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-label-font-weight",
+      "value": "$sprk-font-weight-body-one",
+      "scope": "default",
+      "line": {
+        "start": 1907,
+        "end": 1907
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The line height of the labels in the Dictionary.\n",
     "commentRange": {
       "start": 1908,
       "end": 1908
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dictionary-border",
-      "value": "1px solid $sprk-gray",
+      "name": "sprk-dictionary-label-line-height",
+      "value": "$sprk-line-height-body-one",
       "scope": "default",
       "line": {
         "start": 1909,
@@ -23746,90 +23746,15 @@
     }
   },
   {
-    "description": "The background color of the key value pairs in the striped Dictionary.\n",
+    "description": "The Highlight Board breakpoint at which styles change\nfor padding, font size and button width.\n",
     "commentRange": {
-      "start": 1910,
-      "end": 1910
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dictionary-stripe-color",
-      "value": "$sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1911,
-        "end": 1911
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The breakpoint of the Dictionary component.\n",
-    "commentRange": {
-      "start": 1912,
-      "end": 1912
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dictionary-breakpoint",
-      "value": "38.4375rem",
-      "scope": "default",
-      "line": {
-        "start": 1913,
-        "end": 1913
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size of the labels in the Dictionary.\n",
-    "commentRange": {
-      "start": 1914,
-      "end": 1914
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dictionary-label-font-size",
-      "value": "$sprk-font-size-body-one",
-      "scope": "default",
-      "line": {
-        "start": 1915,
-        "end": 1915
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the labels in the Dictionary.\n",
-    "commentRange": {
-      "start": 1916,
+      "start": 1915,
       "end": 1916
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dictionary-label-font-weight",
-      "value": "$sprk-font-weight-body-one",
+      "name": "sprk-highlight-board-breakpoint",
+      "value": "30rem",
       "scope": "default",
       "line": {
         "start": 1917,
@@ -23846,19 +23771,19 @@
     }
   },
   {
-    "description": "The line height of the labels in the Dictionary.\n",
+    "description": "The maximum width of the content\nfor the Highlight Board when it has an image.\n",
     "commentRange": {
       "start": 1918,
-      "end": 1918
+      "end": 1919
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dictionary-label-line-height",
-      "value": "$sprk-line-height-body-one",
+      "name": "sprk-highlight-board-content-width",
+      "value": "30rem",
       "scope": "default",
       "line": {
-        "start": 1919,
-        "end": 1919
+        "start": 1920,
+        "end": 1920
       }
     },
     "access": "public",
@@ -23871,15 +23796,65 @@
     }
   },
   {
-    "description": "The Highlight Board breakpoint at which styles change\nfor padding, font size and button width.\n",
+    "description": "Percentage reduction value for the\nfont size in the Highlight Board in narrow viewports.\n",
     "commentRange": {
-      "start": 1925,
+      "start": 1921,
+      "end": 1922
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-highlight-board-type-reduction-percentage",
+      "value": "0.8",
+      "scope": "default",
+      "line": {
+        "start": 1923,
+        "end": 1923
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The height of the Highlight Board image.\n",
+    "commentRange": {
+      "start": 1924,
+      "end": 1924
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-highlight-board-height",
+      "value": "31.25rem",
+      "scope": "default",
+      "line": {
+        "start": 1925,
+        "end": 1925
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Highlight Board.\n",
+    "commentRange": {
+      "start": 1926,
       "end": 1926
     },
     "context": {
       "type": "variable",
-      "name": "sprk-highlight-board-breakpoint",
-      "value": "30rem",
+      "name": "sprk-highlight-board-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1927,
@@ -23896,110 +23871,10 @@
     }
   },
   {
-    "description": "The maximum width of the content\nfor the Highlight Board when it has an image.\n",
+    "description": "The background color of\nthe content box in the Highlight Board.\n",
     "commentRange": {
       "start": 1928,
       "end": 1929
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-content-width",
-      "value": "30rem",
-      "scope": "default",
-      "line": {
-        "start": 1930,
-        "end": 1930
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "Percentage reduction value for the\nfont size in the Highlight Board in narrow viewports.\n",
-    "commentRange": {
-      "start": 1931,
-      "end": 1932
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-type-reduction-percentage",
-      "value": "0.8",
-      "scope": "default",
-      "line": {
-        "start": 1933,
-        "end": 1933
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The height of the Highlight Board image.\n",
-    "commentRange": {
-      "start": 1934,
-      "end": 1934
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-height",
-      "value": "31.25rem",
-      "scope": "default",
-      "line": {
-        "start": 1935,
-        "end": 1935
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The background color of the Highlight Board.\n",
-    "commentRange": {
-      "start": 1936,
-      "end": 1936
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1937,
-        "end": 1937
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The background color of\nthe content box in the Highlight Board.\n",
-    "commentRange": {
-      "start": 1938,
-      "end": 1939
     },
     "context": {
       "type": "variable",
@@ -24007,8 +23882,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1940,
-        "end": 1940
+        "start": 1930,
+        "end": 1930
       }
     },
     "access": "public",

--- a/src/data/sass-vars.json
+++ b/src/data/sass-vars.json
@@ -13496,15 +13496,15 @@
     }
   },
   {
-    "description": "The color for Toggle Trigger.\n",
+    "description": "The hover border bottom style for Toggle Trigger.\n",
     "commentRange": {
       "start": 1407,
       "end": 1407
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-color",
-      "value": "$sprk-color-body-three",
+      "name": "sprk-toggle-trigger-hover-border-bottom",
+      "value": "$sprk-link-has-icon-hover-border-bottom",
       "scope": "default",
       "line": {
         "start": 1408,
@@ -13521,15 +13521,15 @@
     }
   },
   {
-    "description": "The font family for Toggle Trigger.\n",
+    "description": "The hover text color for Toggle Trigger.\n",
     "commentRange": {
       "start": 1409,
       "end": 1409
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-font-family",
-      "value": "$sprk-font-family-body-three",
+      "name": "sprk-toggle-trigger-hover-color",
+      "value": "$sprk-link-has-icon-hover-color-text",
       "scope": "default",
       "line": {
         "start": 1410,
@@ -13546,15 +13546,15 @@
     }
   },
   {
-    "description": "The font size for Toggle Trigger.\n",
+    "description": "The background color for Toggle Trigger.\n",
     "commentRange": {
       "start": 1411,
       "end": 1411
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-font-size",
-      "value": "$sprk-font-size-body-three",
+      "name": "sprk-toggle-trigger-background-color",
+      "value": "transparent",
       "scope": "default",
       "line": {
         "start": 1412,
@@ -13571,15 +13571,15 @@
     }
   },
   {
-    "description": "The font weight for Toggle Trigger.\n",
+    "description": "The padding top for Toggle Trigger.\n",
     "commentRange": {
       "start": 1413,
       "end": 1413
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-font-weight",
-      "value": "$sprk-font-weight-body-three",
+      "name": "sprk-toggle-trigger-padding-top",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1414,
@@ -13596,15 +13596,15 @@
     }
   },
   {
-    "description": "The line height for Toggle Trigger.\n",
+    "description": "The padding right for Toggle Trigger.\n",
     "commentRange": {
       "start": 1415,
       "end": 1415
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-line-height",
-      "value": "$sprk-line-height-body-three",
+      "name": "sprk-toggle-trigger-padding-right",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1416,
@@ -13621,15 +13621,15 @@
     }
   },
   {
-    "description": "The active border bottom style for Toggle Trigger.\n",
+    "description": "The padding bottom for Toggle Trigger.\n",
     "commentRange": {
       "start": 1417,
       "end": 1417
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-hover-border-bottom",
-      "value": "$sprk-link-has-icon-hover-border-bottom",
+      "name": "sprk-toggle-trigger-padding-bottom",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1418,
@@ -13646,15 +13646,15 @@
     }
   },
   {
-    "description": "The active color for Toggle Trigger.\n",
+    "description": "The padding left for Toggle Trigger.\n",
     "commentRange": {
       "start": 1419,
       "end": 1419
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-hover-color",
-      "value": "$sprk-link-has-icon-hover-color-text",
+      "name": "sprk-toggle-trigger-padding-left",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1420,
@@ -13671,15 +13671,15 @@
     }
   },
   {
-    "description": "The background color for Toggle Trigger.\n",
+    "description": "The text alignment for Toggle Trigger.\n",
     "commentRange": {
       "start": 1421,
       "end": 1421
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-background-color",
-      "value": "transparent",
+      "name": "sprk-toggle-trigger-text-align",
+      "value": "left",
       "scope": "default",
       "line": {
         "start": 1422,
@@ -13696,15 +13696,15 @@
     }
   },
   {
-    "description": "The padding top for Toggle Trigger.\n",
+    "description": "The font size for small Toggle Trigger.\n",
     "commentRange": {
       "start": 1423,
       "end": 1423
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-padding-top",
-      "value": "0",
+      "name": "sprk-toggle-trigger-font-size-small",
+      "value": "$sprk-font-size-body-four",
       "scope": "default",
       "line": {
         "start": 1424,
@@ -13721,15 +13721,15 @@
     }
   },
   {
-    "description": "The padding right for Toggle Trigger.\n",
+    "description": "The font weight for small Toggle Trigger.\n",
     "commentRange": {
       "start": 1425,
       "end": 1425
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-padding-right",
-      "value": "0",
+      "name": "sprk-toggle-trigger-font-weight-small",
+      "value": "normal",
       "scope": "default",
       "line": {
         "start": 1426,
@@ -13746,40 +13746,15 @@
     }
   },
   {
-    "description": "The padding bottom for Toggle Trigger.\n",
+    "description": "The transition timing for the\nrotation of the icon when the Toggle is opened.\n",
     "commentRange": {
-      "start": 1427,
-      "end": 1427
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-trigger-padding-bottom",
-      "value": "0",
-      "scope": "default",
-      "line": {
-        "start": 1428,
-        "end": 1428
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding left for Toggle Trigger.\n",
-    "commentRange": {
-      "start": 1429,
+      "start": 1428,
       "end": 1429
     },
     "context": {
       "type": "variable",
-      "name": "sprk-toggle-trigger-padding-left",
-      "value": "0",
+      "name": "sprk-toggle-transition-timing",
+      "value": "0.3s ease",
       "scope": "default",
       "line": {
         "start": 1430,
@@ -13796,115 +13771,140 @@
     }
   },
   {
-    "description": "The text alignment for Toggle Trigger.\n",
-    "commentRange": {
-      "start": 1431,
-      "end": 1431
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-trigger-text-align",
-      "value": "left",
-      "scope": "default",
-      "line": {
-        "start": 1432,
-        "end": 1432
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size for small Toggle Trigger.\n",
-    "commentRange": {
-      "start": 1433,
-      "end": 1433
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-trigger-font-size-small",
-      "value": "$sprk-font-size-body-four",
-      "scope": "default",
-      "line": {
-        "start": 1434,
-        "end": 1434
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight for small Toggle Trigger.\n",
-    "commentRange": {
-      "start": 1435,
-      "end": 1435
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-trigger-font-weight-small",
-      "value": "normal",
-      "scope": "default",
-      "line": {
-        "start": 1436,
-        "end": 1436
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The transition timing for the\nrotation of the icon when the Toggle is opened.\n",
-    "commentRange": {
-      "start": 1438,
-      "end": 1439
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-toggle-transition-timing",
-      "value": "0.3s ease",
-      "scope": "default",
-      "line": {
-        "start": 1440,
-        "end": 1440
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "Background color of the Dropdown items that\nare active or hovered.\n",
     "commentRange": {
-      "start": 1447,
-      "end": 1448
+      "start": 1437,
+      "end": 1438
     },
     "context": {
       "type": "variable",
       "name": "sprk-dropdown-active-background-color",
       "value": "$sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1439,
+        "end": 1439
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The left border of the Dropdown item that is active.\n",
+    "commentRange": {
+      "start": 1440,
+      "end": 1440
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-active-border",
+      "value": "2.5px solid $sprk-green",
+      "scope": "default",
+      "line": {
+        "start": 1441,
+        "end": 1441
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box-shadow of the Dropdown item that is active.\n",
+    "commentRange": {
+      "start": 1442,
+      "end": 1442
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-active-box-shadow",
+      "value": "-1px 0 0 0 $sprk-green",
+      "scope": "default",
+      "line": {
+        "start": 1443,
+        "end": 1443
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The border of the Dropdown.\n",
+    "commentRange": {
+      "start": 1444,
+      "end": 1444
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-border",
+      "value": "1px solid $sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1445,
+        "end": 1445
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font size of the Dropdown.\n",
+    "commentRange": {
+      "start": 1446,
+      "end": 1446
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-font-size",
+      "value": "$sprk-font-size-body-one",
+      "scope": "default",
+      "line": {
+        "start": 1447,
+        "end": 1447
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font weight of the Dropdown.\n",
+    "commentRange": {
+      "start": 1448,
+      "end": 1448
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-font-weight",
+      "value": "400",
       "scope": "default",
       "line": {
         "start": 1449,
@@ -13921,140 +13921,140 @@
     }
   },
   {
-    "description": "The left border of the Dropdown item that is active.\n",
-    "commentRange": {
-      "start": 1450,
-      "end": 1450
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-active-border",
-      "value": "2.5px solid $sprk-green",
-      "scope": "default",
-      "line": {
-        "start": 1451,
-        "end": 1451
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box-shadow of the Dropdown item that is active.\n",
-    "commentRange": {
-      "start": 1452,
-      "end": 1452
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-active-box-shadow",
-      "value": "-1px 0 0 0 $sprk-green",
-      "scope": "default",
-      "line": {
-        "start": 1453,
-        "end": 1453
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border of the Dropdown.\n",
-    "commentRange": {
-      "start": 1454,
-      "end": 1454
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-border",
-      "value": "1px solid $sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1455,
-        "end": 1455
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size of the Dropdown.\n",
-    "commentRange": {
-      "start": 1456,
-      "end": 1456
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-font-size",
-      "value": "$sprk-font-size-body-one",
-      "scope": "default",
-      "line": {
-        "start": 1457,
-        "end": 1457
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the Dropdown.\n",
-    "commentRange": {
-      "start": 1458,
-      "end": 1458
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-font-weight",
-      "value": "400",
-      "scope": "default",
-      "line": {
-        "start": 1459,
-        "end": 1459
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The padding around the Informational Dropdown\nfooter.\n",
     "commentRange": {
-      "start": 1460,
-      "end": 1461
+      "start": 1450,
+      "end": 1451
     },
     "context": {
       "type": "variable",
       "name": "sprk-dropdown-footer-padding",
       "value": "$sprk-space-inset-short-l",
+      "scope": "default",
+      "line": {
+        "start": 1452,
+        "end": 1452
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The line height of the Dropdown.\n",
+    "commentRange": {
+      "start": 1453,
+      "end": 1453
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-line-height",
+      "value": "1",
+      "scope": "default",
+      "line": {
+        "start": 1454,
+        "end": 1454
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The max-width of the Dropdown.\n",
+    "commentRange": {
+      "start": 1455,
+      "end": 1455
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-max-width",
+      "value": "24rem",
+      "scope": "default",
+      "line": {
+        "start": 1456,
+        "end": 1456
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding around the Dropdown items.\n",
+    "commentRange": {
+      "start": 1457,
+      "end": 1457
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-padding",
+      "value": "$sprk-space-misc-a",
+      "scope": "default",
+      "line": {
+        "start": 1458,
+        "end": 1458
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Dropdown.\n",
+    "commentRange": {
+      "start": 1459,
+      "end": 1459
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-shadow",
+      "value": "0 0 40px 2px rgba(0, 0, 0, 0.1)",
+      "scope": "default",
+      "line": {
+        "start": 1460,
+        "end": 1460
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the Dropdown title.\n",
+    "commentRange": {
+      "start": 1461,
+      "end": 1461
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-title-color",
+      "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1462,
@@ -14071,15 +14071,15 @@
     }
   },
   {
-    "description": "The line height of the Dropdown.\n",
+    "description": "The font size of the Dropdown title.\n",
     "commentRange": {
       "start": 1463,
       "end": 1463
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dropdown-line-height",
-      "value": "1",
+      "name": "sprk-dropdown-title-font-size",
+      "value": "$sprk-dropdown-font-size",
       "scope": "default",
       "line": {
         "start": 1464,
@@ -14096,15 +14096,15 @@
     }
   },
   {
-    "description": "The max-width of the Dropdown.\n",
+    "description": "The font weight of the Dropdown title.\n",
     "commentRange": {
       "start": 1465,
       "end": 1465
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dropdown-max-width",
-      "value": "24rem",
+      "name": "sprk-dropdown-title-font-weight",
+      "value": "300",
       "scope": "default",
       "line": {
         "start": 1466,
@@ -14121,140 +14121,115 @@
     }
   },
   {
-    "description": "The padding around the Dropdown items.\n",
-    "commentRange": {
-      "start": 1467,
-      "end": 1467
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-padding",
-      "value": "$sprk-space-misc-a",
-      "scope": "default",
-      "line": {
-        "start": 1468,
-        "end": 1468
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box shadow of the Dropdown.\n",
-    "commentRange": {
-      "start": 1469,
-      "end": 1469
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-shadow",
-      "value": "0 0 40px 2px rgba(0, 0, 0, 0.1)",
-      "scope": "default",
-      "line": {
-        "start": 1470,
-        "end": 1470
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Dropdown title.\n",
-    "commentRange": {
-      "start": 1471,
-      "end": 1471
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-title-color",
-      "value": "$sprk-black-tint-25",
-      "scope": "default",
-      "line": {
-        "start": 1472,
-        "end": 1472
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size of the Dropdown title.\n",
-    "commentRange": {
-      "start": 1473,
-      "end": 1473
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-title-font-size",
-      "value": "$sprk-dropdown-font-size",
-      "scope": "default",
-      "line": {
-        "start": 1474,
-        "end": 1474
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the Dropdown title.\n",
-    "commentRange": {
-      "start": 1475,
-      "end": 1475
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-title-font-weight",
-      "value": "300",
-      "scope": "default",
-      "line": {
-        "start": 1476,
-        "end": 1476
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The color of the mask overlay that is shown behind the Modal.\n",
     "commentRange": {
-      "start": 1482,
-      "end": 1482
+      "start": 1472,
+      "end": 1472
     },
     "context": {
       "type": "variable",
       "name": "sprk-modal-mask-color",
       "value": "rgba(34, 34, 34, 0.35)",
+      "scope": "default",
+      "line": {
+        "start": 1473,
+        "end": 1473
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Modal.\n",
+    "commentRange": {
+      "start": 1474,
+      "end": 1474
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-modal-color",
+      "value": "$sprk-white",
+      "scope": "default",
+      "line": {
+        "start": 1475,
+        "end": 1475
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The maximum width of the Modal.\n",
+    "commentRange": {
+      "start": 1476,
+      "end": 1476
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-modal-max-width",
+      "value": "43.75rem",
+      "scope": "default",
+      "line": {
+        "start": 1477,
+        "end": 1477
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The maximum height of the Modal.\n",
+    "commentRange": {
+      "start": 1478,
+      "end": 1478
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-modal-height",
+      "value": "70%",
+      "scope": "default",
+      "line": {
+        "start": 1479,
+        "end": 1479
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "Determines how far down\nfrom the top of the page the\nModal renders at the small breakpoint.\n",
+    "commentRange": {
+      "start": 1480,
+      "end": 1482
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-modal-breakpoint-small",
+      "value": "25rem",
       "scope": "default",
       "line": {
         "start": 1483,
@@ -14271,40 +14246,15 @@
     }
   },
   {
-    "description": "The background color of the Modal.\n",
+    "description": "Determines how far down\nfrom the top of the page the\nModal renders at the medium breakpoint.\n",
     "commentRange": {
       "start": 1484,
-      "end": 1484
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-modal-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1485,
-        "end": 1485
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The maximum width of the Modal.\n",
-    "commentRange": {
-      "start": 1486,
       "end": 1486
     },
     "context": {
       "type": "variable",
-      "name": "sprk-modal-max-width",
-      "value": "43.75rem",
+      "name": "sprk-modal-breakpoint-medium",
+      "value": "37.5rem",
       "scope": "default",
       "line": {
         "start": 1487,
@@ -14321,15 +14271,15 @@
     }
   },
   {
-    "description": "The maximum height of the Modal.\n",
+    "description": "The box shadow on the Modal.\n",
     "commentRange": {
       "start": 1488,
       "end": 1488
     },
     "context": {
       "type": "variable",
-      "name": "sprk-modal-height",
-      "value": "70%",
+      "name": "sprk-modal-shadow",
+      "value": "0 4px 5px rgba(0, 0, 0, 0.6)",
       "scope": "default",
       "line": {
         "start": 1489,
@@ -14346,85 +14296,10 @@
     }
   },
   {
-    "description": "Determines how far down\nfrom the top of the page the\nModal renders at the small breakpoint.\n",
-    "commentRange": {
-      "start": 1490,
-      "end": 1492
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-modal-breakpoint-small",
-      "value": "25rem",
-      "scope": "default",
-      "line": {
-        "start": 1493,
-        "end": 1493
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "Determines how far down\nfrom the top of the page the\nModal renders at the medium breakpoint.\n",
-    "commentRange": {
-      "start": 1494,
-      "end": 1496
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-modal-breakpoint-medium",
-      "value": "37.5rem",
-      "scope": "default",
-      "line": {
-        "start": 1497,
-        "end": 1497
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box shadow on the Modal.\n",
-    "commentRange": {
-      "start": 1498,
-      "end": 1498
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-modal-shadow",
-      "value": "0 4px 5px rgba(0, 0, 0, 0.6)",
-      "scope": "default",
-      "line": {
-        "start": 1499,
-        "end": 1499
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The border radius on the Modal.\n",
     "commentRange": {
-      "start": 1500,
-      "end": 1500
+      "start": 1490,
+      "end": 1490
     },
     "context": {
       "type": "variable",
@@ -14432,8 +14307,8 @@
       "value": "8px",
       "scope": "default",
       "line": {
-        "start": 1501,
-        "end": 1501
+        "start": 1491,
+        "end": 1491
       }
     },
     "access": "public",
@@ -14448,8 +14323,8 @@
   {
     "description": "The width of the menu icon on narrow viewports in the Masthead.\n",
     "commentRange": {
-      "start": 1507,
-      "end": 1507
+      "start": 1497,
+      "end": 1497
     },
     "context": {
       "type": "variable",
@@ -14457,8 +14332,8 @@
       "value": "$sprk-icon-l",
       "scope": "default",
       "line": {
-        "start": 1508,
-        "end": 1508
+        "start": 1498,
+        "end": 1498
       }
     },
     "access": "public",
@@ -14473,13 +14348,113 @@
   {
     "description": "The height of the menu icon on narrow viewports in the Masthead.\n",
     "commentRange": {
-      "start": 1509,
-      "end": 1509
+      "start": 1499,
+      "end": 1499
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-menu-icon-height",
       "value": "$sprk-icon-l",
+      "scope": "default",
+      "line": {
+        "start": 1500,
+        "end": 1500
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Masthead.\n",
+    "commentRange": {
+      "start": 1501,
+      "end": 1501
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-bg-color",
+      "value": "$sprk-white",
+      "scope": "default",
+      "line": {
+        "start": 1502,
+        "end": 1502
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding of the Masthead content, menu, and branding sections.\n",
+    "commentRange": {
+      "start": 1503,
+      "end": 1503
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-padding",
+      "value": "$sprk-space-s",
+      "scope": "default",
+      "line": {
+        "start": 1504,
+        "end": 1504
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding top around the content items in the\ncontent section of the Masthead.\n",
+    "commentRange": {
+      "start": 1505,
+      "end": 1506
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-top",
+      "value": "$sprk-space-s",
+      "scope": "default",
+      "line": {
+        "start": 1507,
+        "end": 1507
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding bottom around the content\nitems in the content section of the Masthead.\n",
+    "commentRange": {
+      "start": 1508,
+      "end": 1509
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-bottom",
+      "value": "$sprk-space-s",
       "scope": "default",
       "line": {
         "start": 1510,
@@ -14496,110 +14471,10 @@
     }
   },
   {
-    "description": "The background color of the Masthead.\n",
-    "commentRange": {
-      "start": 1511,
-      "end": 1511
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-bg-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1512,
-        "end": 1512
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding of the Masthead content, menu, and branding sections.\n",
-    "commentRange": {
-      "start": 1513,
-      "end": 1513
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-content-padding",
-      "value": "$sprk-space-s",
-      "scope": "default",
-      "line": {
-        "start": 1514,
-        "end": 1514
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding top around the content items in the\ncontent section of the Masthead.\n",
-    "commentRange": {
-      "start": 1515,
-      "end": 1516
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-content-item-padding-top",
-      "value": "$sprk-space-s",
-      "scope": "default",
-      "line": {
-        "start": 1517,
-        "end": 1517
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding bottom around the content\nitems in the content section of the Masthead.\n",
-    "commentRange": {
-      "start": 1518,
-      "end": 1519
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-content-item-padding-bottom",
-      "value": "$sprk-space-s",
-      "scope": "default",
-      "line": {
-        "start": 1520,
-        "end": 1520
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The padding right around the content items in the\ncontent section of the Masthead.\n",
     "commentRange": {
-      "start": 1521,
-      "end": 1522
+      "start": 1511,
+      "end": 1512
     },
     "context": {
       "type": "variable",
@@ -14607,8 +14482,8 @@
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1523,
-        "end": 1523
+        "start": 1513,
+        "end": 1513
       }
     },
     "access": "public",
@@ -14623,8 +14498,8 @@
   {
     "description": "The padding around the content\nsection in the Masthead on wide viewports.\n",
     "commentRange": {
-      "start": 1527,
-      "end": 1528
+      "start": 1517,
+      "end": 1518
     },
     "context": {
       "type": "variable",
@@ -14632,8 +14507,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1529,
-        "end": 1529
+        "start": 1519,
+        "end": 1519
       }
     },
     "access": "public",
@@ -14648,8 +14523,8 @@
   {
     "description": "The padding top of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
-      "start": 1530,
-      "end": 1531
+      "start": 1520,
+      "end": 1521
     },
     "context": {
       "type": "variable",
@@ -14657,8 +14532,8 @@
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1532,
-        "end": 1532
+        "start": 1522,
+        "end": 1522
       }
     },
     "access": "public",
@@ -14673,13 +14548,113 @@
   {
     "description": "The padding bottom of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
-      "start": 1533,
-      "end": 1534
+      "start": 1523,
+      "end": 1524
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-content-item-padding-bottom-wide",
       "value": "$sprk-space-s",
+      "scope": "default",
+      "line": {
+        "start": 1525,
+        "end": 1525
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding right of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "commentRange": {
+      "start": 1526,
+      "end": 1527
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-right-wide",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1528,
+        "end": 1528
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding left of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "commentRange": {
+      "start": 1529,
+      "end": 1530
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-left-wide",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1531,
+        "end": 1531
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The visited state color of Masthead links.\n",
+    "commentRange": {
+      "start": 1532,
+      "end": 1532
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-link-visited-color",
+      "value": "$sprk-black",
+      "scope": "default",
+      "line": {
+        "start": 1533,
+        "end": 1533
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The hover state color of Masthead links.\n",
+    "commentRange": {
+      "start": 1534,
+      "end": 1534
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-link-hover-color",
+      "value": "$sprk-green",
       "scope": "default",
       "line": {
         "start": 1535,
@@ -14696,19 +14671,19 @@
     }
   },
   {
-    "description": "The padding right of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The font weight for Masthead links.\n",
     "commentRange": {
       "start": 1536,
-      "end": 1537
+      "end": 1536
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-right-wide",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-link-font-weight",
+      "value": "500",
       "scope": "default",
       "line": {
-        "start": 1538,
-        "end": 1538
+        "start": 1537,
+        "end": 1537
       }
     },
     "access": "public",
@@ -14721,15 +14696,40 @@
     }
   },
   {
-    "description": "The padding left of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The size of the bottom border on the Masthead.\n",
     "commentRange": {
-      "start": 1539,
+      "start": 1538,
+      "end": 1538
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-border-bottom-size",
+      "value": "1px",
+      "scope": "default",
+      "line": {
+        "start": 1539,
+        "end": 1539
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The bottom border on the Masthead.\n",
+    "commentRange": {
+      "start": 1540,
       "end": 1540
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-left-wide",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-border-bottom",
+      "value": "$sprk-masthead-border-bottom-size solid $sprk-gray",
       "scope": "default",
       "line": {
         "start": 1541,
@@ -14746,15 +14746,15 @@
     }
   },
   {
-    "description": "The visited state color of Masthead links.\n",
+    "description": "The bottom border on the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1542,
       "end": 1542
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-link-visited-color",
-      "value": "$sprk-black",
+      "name": "sprk-masthead-border-bottom-wide",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1543,
@@ -14771,15 +14771,15 @@
     }
   },
   {
-    "description": "The hover state color of Masthead links.\n",
+    "description": "The right border on the site links in the Masthead.\n",
     "commentRange": {
       "start": 1544,
       "end": 1544
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-link-hover-color",
-      "value": "$sprk-green",
+      "name": "sprk-masthead-site-links-border-right",
+      "value": "2px solid $sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1545,
@@ -14796,40 +14796,15 @@
     }
   },
   {
-    "description": "The font weight for Masthead links.\n",
+    "description": "The point at which the Masthead navigation switches\nfrom narrow viewport style to large viewport\nstyle.\n",
     "commentRange": {
       "start": 1546,
-      "end": 1546
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-link-font-weight",
-      "value": "500",
-      "scope": "default",
-      "line": {
-        "start": 1547,
-        "end": 1547
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The size of the bottom border on the Masthead.\n",
-    "commentRange": {
-      "start": 1548,
       "end": 1548
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-border-bottom-size",
-      "value": "1px",
+      "name": "sprk-masthead-breakpoint",
+      "value": "54rem",
       "scope": "default",
       "line": {
         "start": 1549,
@@ -14846,15 +14821,15 @@
     }
   },
   {
-    "description": "The bottom border on the Masthead.\n",
+    "description": "The maximum width of the Masthead.\n",
     "commentRange": {
       "start": 1550,
       "end": 1550
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-border-bottom",
-      "value": "$sprk-masthead-border-bottom-size solid $sprk-gray",
+      "name": "sprk-masthead-column-width",
+      "value": "89rem",
       "scope": "default",
       "line": {
         "start": 1551,
@@ -14871,15 +14846,15 @@
     }
   },
   {
-    "description": "The bottom border on the Masthead on wide viewports.\n",
+    "description": "The maximum width of the logo in the Masthead.\n",
     "commentRange": {
       "start": 1552,
       "end": 1552
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-border-bottom-wide",
-      "value": "0",
+      "name": "sprk-masthead-logo-max-width",
+      "value": "192px",
       "scope": "default",
       "line": {
         "start": 1553,
@@ -14896,15 +14871,15 @@
     }
   },
   {
-    "description": "The right border on the site links in the Masthead.\n",
+    "description": "The minimum width of the logo in the Masthead.\n",
     "commentRange": {
       "start": 1554,
       "end": 1554
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-site-links-border-right",
-      "value": "2px solid $sprk-black-tint-25",
+      "name": "sprk-masthead-logo-min-width",
+      "value": "174px",
       "scope": "default",
       "line": {
         "start": 1555,
@@ -14921,15 +14896,40 @@
     }
   },
   {
-    "description": "The point at which the Masthead navigation switches\nfrom narrow viewport style to large viewport\nstyle.\n",
+    "description": "The box shadow of the Masthead.\n",
     "commentRange": {
       "start": 1556,
+      "end": 1556
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-shadow",
+      "value": "none",
+      "scope": "default",
+      "line": {
+        "start": 1557,
+        "end": 1557
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Masthead in wide viewports.\n",
+    "commentRange": {
+      "start": 1558,
       "end": 1558
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-breakpoint",
-      "value": "54rem",
+      "name": "sprk-masthead-shadow-wide",
+      "value": "none",
       "scope": "default",
       "line": {
         "start": 1559,
@@ -14946,15 +14946,15 @@
     }
   },
   {
-    "description": "The maximum width of the Masthead.\n",
+    "description": "The Masthead shadow that gets applied when the page is scrolled.\n",
     "commentRange": {
       "start": 1560,
       "end": 1560
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-column-width",
-      "value": "89rem",
+      "name": "sprk-masthead-shadow-scroll",
+      "value": "0 0 40px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
         "start": 1561,
@@ -14971,15 +14971,15 @@
     }
   },
   {
-    "description": "The maximum width of the logo in the Masthead.\n",
+    "description": "The border of the selector in the Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1562,
       "end": 1562
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-logo-max-width",
-      "value": "192px",
+      "name": "sprk-masthead-selector-border",
+      "value": "2px solid $sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1563,
@@ -14996,135 +14996,10 @@
     }
   },
   {
-    "description": "The minimum width of the logo in the Masthead.\n",
-    "commentRange": {
-      "start": 1564,
-      "end": 1564
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-logo-min-width",
-      "value": "174px",
-      "scope": "default",
-      "line": {
-        "start": 1565,
-        "end": 1565
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box shadow of the Masthead.\n",
-    "commentRange": {
-      "start": 1566,
-      "end": 1566
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-shadow",
-      "value": "none",
-      "scope": "default",
-      "line": {
-        "start": 1567,
-        "end": 1567
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The box shadow of the Masthead in wide viewports.\n",
-    "commentRange": {
-      "start": 1568,
-      "end": 1568
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-shadow-wide",
-      "value": "none",
-      "scope": "default",
-      "line": {
-        "start": 1569,
-        "end": 1569
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The Masthead shadow that gets applied when the page is scrolled.\n",
-    "commentRange": {
-      "start": 1570,
-      "end": 1570
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-shadow-scroll",
-      "value": "0 0 40px rgba(0, 0, 0, 0.1)",
-      "scope": "default",
-      "line": {
-        "start": 1571,
-        "end": 1571
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border of the selector in the Masthead with Extended Navigation.\n",
-    "commentRange": {
-      "start": 1572,
-      "end": 1572
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-selector-border",
-      "value": "2px solid $sprk-black-tint-25",
-      "scope": "default",
-      "line": {
-        "start": 1573,
-        "end": 1573
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The border radius of the selector in the Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1575,
-      "end": 1575
+      "start": 1565,
+      "end": 1565
     },
     "context": {
       "type": "variable",
@@ -15132,8 +15007,8 @@
       "value": "5px",
       "scope": "default",
       "line": {
-        "start": 1576,
-        "end": 1576
+        "start": 1566,
+        "end": 1566
       }
     },
     "access": "public",
@@ -15148,8 +15023,8 @@
   {
     "description": "The bottom border that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1577,
-      "end": 1579
+      "start": 1567,
+      "end": 1569
     },
     "context": {
       "type": "variable",
@@ -15157,8 +15032,8 @@
       "value": "2px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1580,
-        "end": 1580
+        "start": 1570,
+        "end": 1570
       }
     },
     "access": "public",
@@ -15173,8 +15048,8 @@
   {
     "description": "The box shadow that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1581,
-      "end": 1583
+      "start": 1571,
+      "end": 1573
     },
     "context": {
       "type": "variable",
@@ -15182,8 +15057,8 @@
       "value": "0 5px 10px\n  rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1584,
-        "end": 1585
+        "start": 1574,
+        "end": 1575
       }
     },
     "access": "public",
@@ -15198,8 +15073,8 @@
   {
     "description": "The border color that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1586,
-      "end": 1588
+      "start": 1576,
+      "end": 1578
     },
     "context": {
       "type": "variable",
@@ -15207,8 +15082,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1589,
-        "end": 1589
+        "start": 1579,
+        "end": 1579
       }
     },
     "access": "public",
@@ -15223,8 +15098,8 @@
   {
     "description": "The font color of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1590,
-      "end": 1591
+      "start": 1580,
+      "end": 1581
     },
     "context": {
       "type": "variable",
@@ -15232,8 +15107,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1592,
-        "end": 1592
+        "start": 1582,
+        "end": 1582
       }
     },
     "access": "public",
@@ -15248,8 +15123,8 @@
   {
     "description": "The background color of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1593,
-      "end": 1594
+      "start": 1583,
+      "end": 1584
     },
     "context": {
       "type": "variable",
@@ -15257,8 +15132,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1595,
-        "end": 1595
+        "start": 1585,
+        "end": 1585
       }
     },
     "access": "public",
@@ -15273,8 +15148,8 @@
   {
     "description": "The padding of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1596,
-      "end": 1597
+      "start": 1586,
+      "end": 1587
     },
     "context": {
       "type": "variable",
@@ -15282,8 +15157,8 @@
       "value": "$sprk-space-inset-short-m",
       "scope": "default",
       "line": {
-        "start": 1598,
-        "end": 1598
+        "start": 1588,
+        "end": 1588
       }
     },
     "access": "public",
@@ -15298,8 +15173,8 @@
   {
     "description": "The padding of the selector dropdown in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1599,
-      "end": 1600
+      "start": 1589,
+      "end": 1590
     },
     "context": {
       "type": "variable",
@@ -15307,8 +15182,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1601,
-        "end": 1601
+        "start": 1591,
+        "end": 1591
       }
     },
     "access": "public",
@@ -15323,8 +15198,8 @@
   {
     "description": "The minimum width of the selector\nin the Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1602,
-      "end": 1603
+      "start": 1592,
+      "end": 1593
     },
     "context": {
       "type": "variable",
@@ -15332,8 +15207,8 @@
       "value": "17rem",
       "scope": "default",
       "line": {
-        "start": 1604,
-        "end": 1604
+        "start": 1594,
+        "end": 1594
       }
     },
     "access": "public",
@@ -15348,8 +15223,8 @@
   {
     "description": "This is the height of the Masthead on\nnarrow viewports and is used to calculate\nhow far from the top the narrow\nnavigation items should be displayed.\n",
     "commentRange": {
-      "start": 1605,
-      "end": 1608
+      "start": 1595,
+      "end": 1598
     },
     "context": {
       "type": "variable",
@@ -15357,8 +15232,8 @@
       "value": "81px",
       "scope": "default",
       "line": {
-        "start": 1609,
-        "end": 1609
+        "start": 1599,
+        "end": 1599
       }
     },
     "access": "public",
@@ -15373,8 +15248,8 @@
   {
     "description": "The color of the mask that\ngets applied when the Masthead selector\ndropdown is open on narrow screens.\n",
     "commentRange": {
-      "start": 1610,
-      "end": 1612
+      "start": 1600,
+      "end": 1602
     },
     "context": {
       "type": "variable",
@@ -15382,8 +15257,8 @@
       "value": "rgba(0, 0, 0, 0.5)",
       "scope": "default",
       "line": {
-        "start": 1613,
-        "end": 1613
+        "start": 1603,
+        "end": 1603
       }
     },
     "access": "public",
@@ -15398,8 +15273,8 @@
   {
     "description": "The transition applied to the Masthead.\n",
     "commentRange": {
-      "start": 1614,
-      "end": 1614
+      "start": 1604,
+      "end": 1604
     },
     "context": {
       "type": "variable",
@@ -15407,8 +15282,8 @@
       "value": "all 0.3s ease-in",
       "scope": "default",
       "line": {
-        "start": 1615,
-        "end": 1615
+        "start": 1605,
+        "end": 1605
       }
     },
     "access": "public",
@@ -15423,8 +15298,8 @@
   {
     "description": "The transform length that gets applied\nwhen the Masthead scrolls out of view on narrow screens.\n",
     "commentRange": {
-      "start": 1616,
-      "end": 1617
+      "start": 1606,
+      "end": 1607
     },
     "context": {
       "type": "variable",
@@ -15432,8 +15307,8 @@
       "value": "translateY(-100%)",
       "scope": "default",
       "line": {
-        "start": 1618,
-        "end": 1618
+        "start": 1608,
+        "end": 1608
       }
     },
     "access": "public",
@@ -15448,8 +15323,8 @@
   {
     "description": "The maximum width of the\nbig navigation items in the\nnavigation bar in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1621,
-      "end": 1623
+      "start": 1611,
+      "end": 1613
     },
     "context": {
       "type": "variable",
@@ -15457,8 +15332,8 @@
       "value": "64rem",
       "scope": "default",
       "line": {
-        "start": 1624,
-        "end": 1624
+        "start": 1614,
+        "end": 1614
       }
     },
     "access": "public",
@@ -15473,8 +15348,8 @@
   {
     "description": "The background color of the big\nnavigation bar in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1625,
-      "end": 1626
+      "start": 1615,
+      "end": 1616
     },
     "context": {
       "type": "variable",
@@ -15482,8 +15357,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1627,
-        "end": 1627
+        "start": 1617,
+        "end": 1617
       }
     },
     "access": "public",
@@ -15498,8 +15373,8 @@
   {
     "description": "The font weight of the big\nnavigation link in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1628,
-      "end": 1629
+      "start": 1618,
+      "end": 1619
     },
     "context": {
       "type": "variable",
@@ -15507,8 +15382,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1630,
-        "end": 1630
+        "start": 1620,
+        "end": 1620
       }
     },
     "access": "public",
@@ -15523,8 +15398,8 @@
   {
     "description": "The padding of the big navigation\nlink in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1631,
-      "end": 1632
+      "start": 1621,
+      "end": 1622
     },
     "context": {
       "type": "variable",
@@ -15532,8 +15407,8 @@
       "value": "0 $sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1633,
-        "end": 1633
+        "start": 1623,
+        "end": 1623
       }
     },
     "access": "public",
@@ -15548,8 +15423,8 @@
   {
     "description": "The color of the big navigation link in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1634,
-      "end": 1634
+      "start": 1624,
+      "end": 1624
     },
     "context": {
       "type": "variable",
@@ -15557,8 +15432,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1635,
-        "end": 1635
+        "start": 1625,
+        "end": 1625
       }
     },
     "access": "public",
@@ -15573,8 +15448,8 @@
   {
     "description": "The text and underline color of\nthe active big navigation item in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1636,
-      "end": 1637
+      "start": 1626,
+      "end": 1627
     },
     "context": {
       "type": "variable",
@@ -15582,8 +15457,8 @@
       "value": "$sprk-big-nav-link-color",
       "scope": "default",
       "line": {
-        "start": 1638,
-        "end": 1638
+        "start": 1628,
+        "end": 1628
       }
     },
     "access": "public",
@@ -15598,13 +15473,88 @@
   {
     "description": "The line height\nof the big navigation items\nin the Masthead Extended.\n",
     "commentRange": {
-      "start": 1639,
-      "end": 1641
+      "start": 1629,
+      "end": 1631
     },
     "context": {
       "type": "variable",
       "name": "sprk-big-nav-item-line-height",
       "value": "53px",
+      "scope": "default",
+      "line": {
+        "start": 1632,
+        "end": 1632
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The left border of the active item\nin the narrow viewport Masthead Accordion.\n",
+    "commentRange": {
+      "start": 1634,
+      "end": 1635
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-active-left-border",
+      "value": "3px solid $sprk-black",
+      "scope": "default",
+      "line": {
+        "start": 1636,
+        "end": 1636
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font weight of the active item\nin the narrow viewport Masthead Accordion.\n",
+    "commentRange": {
+      "start": 1637,
+      "end": 1638
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-active-heading-font-weight",
+      "value": "400",
+      "scope": "default",
+      "line": {
+        "start": 1639,
+        "end": 1639
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the active item\nin the narrow viewport Masthead Accordion.\n",
+    "commentRange": {
+      "start": 1640,
+      "end": 1641
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-active-heading-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1642,
@@ -15621,85 +15571,10 @@
     }
   },
   {
-    "description": "The left border of the active item\nin the narrow viewport Masthead Accordion.\n",
-    "commentRange": {
-      "start": 1644,
-      "end": 1645
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-accordion-active-left-border",
-      "value": "3px solid $sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1646,
-        "end": 1646
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the active item\nin the narrow viewport Masthead Accordion.\n",
-    "commentRange": {
-      "start": 1647,
-      "end": 1648
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-accordion-active-heading-font-weight",
-      "value": "400",
-      "scope": "default",
-      "line": {
-        "start": 1649,
-        "end": 1649
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the active item\nin the narrow viewport Masthead Accordion.\n",
-    "commentRange": {
-      "start": 1650,
-      "end": 1651
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-accordion-active-heading-color",
-      "value": "$sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1652,
-        "end": 1652
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The color of the heading\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1653,
-      "end": 1654
+      "start": 1643,
+      "end": 1644
     },
     "context": {
       "type": "variable",
@@ -15707,8 +15582,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1655,
-        "end": 1655
+        "start": 1645,
+        "end": 1645
       }
     },
     "access": "public",
@@ -15723,8 +15598,8 @@
   {
     "description": "The font weight of the heading\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1656,
-      "end": 1657
+      "start": 1646,
+      "end": 1647
     },
     "context": {
       "type": "variable",
@@ -15732,8 +15607,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1658,
-        "end": 1658
+        "start": 1648,
+        "end": 1648
       }
     },
     "access": "public",
@@ -15748,8 +15623,8 @@
   {
     "description": "The font weight of the details\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1659,
-      "end": 1660
+      "start": 1649,
+      "end": 1650
     },
     "context": {
       "type": "variable",
@@ -15757,8 +15632,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 1661,
-        "end": 1661
+        "start": 1651,
+        "end": 1651
       }
     },
     "access": "public",
@@ -15773,8 +15648,8 @@
   {
     "description": "The font color of the details\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1662,
-      "end": 1663
+      "start": 1652,
+      "end": 1653
     },
     "context": {
       "type": "variable",
@@ -15782,8 +15657,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1664,
-        "end": 1664
+        "start": 1654,
+        "end": 1654
       }
     },
     "access": "public",
@@ -15798,8 +15673,8 @@
   {
     "description": "The background color of the active\nitem in the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1665,
-      "end": 1666
+      "start": 1655,
+      "end": 1656
     },
     "context": {
       "type": "variable",
@@ -15807,8 +15682,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1667,
-        "end": 1667
+        "start": 1657,
+        "end": 1657
       }
     },
     "access": "public",
@@ -15823,8 +15698,8 @@
   {
     "description": "The font color of the active\nitem in the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1668,
-      "end": 1669
+      "start": 1658,
+      "end": 1659
     },
     "context": {
       "type": "variable",
@@ -15832,8 +15707,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1670,
-        "end": 1670
+        "start": 1660,
+        "end": 1660
       }
     },
     "access": "public",
@@ -15848,8 +15723,8 @@
   {
     "description": "The font color of the text\nin items in the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1671,
-      "end": 1672
+      "start": 1661,
+      "end": 1662
     },
     "context": {
       "type": "variable",
@@ -15857,8 +15732,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1673,
-        "end": 1673
+        "start": 1663,
+        "end": 1663
       }
     },
     "access": "public",
@@ -15873,8 +15748,8 @@
   {
     "description": "The color of the line on open items\nin the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1674,
-      "end": 1675
+      "start": 1664,
+      "end": 1665
     },
     "context": {
       "type": "variable",
@@ -15882,8 +15757,8 @@
       "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
-        "start": 1676,
-        "end": 1676
+        "start": 1666,
+        "end": 1666
       }
     },
     "access": "public",
@@ -15898,13 +15773,63 @@
   {
     "description": "The height of the line on open\nitems in the narrow viewport Masthead Accordion.\n",
     "commentRange": {
-      "start": 1677,
-      "end": 1678
+      "start": 1667,
+      "end": 1668
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-accordion-item-open-line-height",
       "value": "2px",
+      "scope": "default",
+      "line": {
+        "start": 1669,
+        "end": 1669
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding of the items in the\nnarrow viewport Masthead Accordion.\n",
+    "commentRange": {
+      "start": 1670,
+      "end": 1671
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-item-padding",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1672,
+        "end": 1672
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The height and width of Spinners.\n",
+    "commentRange": {
+      "start": 1678,
+      "end": 1678
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-spinner-size",
+      "value": "1.3rem",
       "scope": "default",
       "line": {
         "start": 1679,
@@ -15921,19 +15846,19 @@
     }
   },
   {
-    "description": "The padding of the items in the\nnarrow viewport Masthead Accordion.\n",
+    "description": "The height and width of large Spinners.\n",
     "commentRange": {
       "start": 1680,
-      "end": 1681
+      "end": 1680
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-padding",
-      "value": "$sprk-space-m",
+      "name": "sprk-spinner-size-large",
+      "value": "3rem",
       "scope": "default",
       "line": {
-        "start": 1682,
-        "end": 1682
+        "start": 1681,
+        "end": 1681
       }
     },
     "access": "public",
@@ -15946,15 +15871,90 @@
     }
   },
   {
-    "description": "The height and width of Spinners.\n",
+    "description": "The speed of the animation for Spinners.\n",
+    "commentRange": {
+      "start": 1682,
+      "end": 1682
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-spinner-speed",
+      "value": "1s",
+      "scope": "default",
+      "line": {
+        "start": 1683,
+        "end": 1683
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The thickness of Spinners.\n",
+    "commentRange": {
+      "start": 1684,
+      "end": 1684
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-spinner-thickness",
+      "value": "0.18rem",
+      "scope": "default",
+      "line": {
+        "start": 1685,
+        "end": 1685
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of Spinners.\n",
+    "commentRange": {
+      "start": 1686,
+      "end": 1686
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-spinner-color",
+      "value": "$sprk-white",
+      "scope": "default",
+      "line": {
+        "start": 1687,
+        "end": 1687
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the dark Spinner.\n",
     "commentRange": {
       "start": 1688,
       "end": 1688
     },
     "context": {
       "type": "variable",
-      "name": "sprk-spinner-size",
-      "value": "1.3rem",
+      "name": "sprk-spinner-color-dark",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1689,
@@ -15971,90 +15971,15 @@
     }
   },
   {
-    "description": "The height and width of large Spinners.\n",
+    "description": "The breakpoint at which the tabs\ngo from stacked layout to side by side in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1690,
-      "end": 1690
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-spinner-size-large",
-      "value": "3rem",
-      "scope": "default",
-      "line": {
-        "start": 1691,
-        "end": 1691
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The speed of the animation for Spinners.\n",
-    "commentRange": {
-      "start": 1692,
-      "end": 1692
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-spinner-speed",
-      "value": "1s",
-      "scope": "default",
-      "line": {
-        "start": 1693,
-        "end": 1693
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The thickness of Spinners.\n",
-    "commentRange": {
-      "start": 1694,
-      "end": 1694
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-spinner-thickness",
-      "value": "0.18rem",
-      "scope": "default",
-      "line": {
-        "start": 1695,
-        "end": 1695
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of Spinners.\n",
-    "commentRange": {
-      "start": 1696,
+      "start": 1695,
       "end": 1696
     },
     "context": {
       "type": "variable",
-      "name": "sprk-spinner-color",
-      "value": "$sprk-white",
+      "name": "sprk-tab-navigation-breakpoint",
+      "value": "46rem",
       "scope": "default",
       "line": {
         "start": 1697,
@@ -16071,14 +15996,14 @@
     }
   },
   {
-    "description": "The color of the dark Spinner.\n",
+    "description": "The tab button text color in Tabbed Navigation.\n",
     "commentRange": {
       "start": 1698,
       "end": 1698
     },
     "context": {
       "type": "variable",
-      "name": "sprk-spinner-color-dark",
+      "name": "sprk-tab-navigation-btn-color",
       "value": "$sprk-black",
       "scope": "default",
       "line": {
@@ -16096,19 +16021,19 @@
     }
   },
   {
-    "description": "The breakpoint at which the tabs\ngo from stacked layout to side by side in Tabbed Navigation.\n",
+    "description": "The tab button background color in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1705,
-      "end": 1706
+      "start": 1700,
+      "end": 1700
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-breakpoint",
-      "value": "46rem",
+      "name": "sprk-tab-navigation-btn-bg-color",
+      "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1707,
-        "end": 1707
+        "start": 1701,
+        "end": 1701
       }
     },
     "access": "public",
@@ -16121,15 +16046,65 @@
     }
   },
   {
-    "description": "The tab button text color in Tabbed Navigation.\n",
+    "description": "The border on the top of the button tabs in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1708,
+      "start": 1702,
+      "end": 1702
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-tab-navigation-btn-border-top",
+      "value": "3px solid $sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1703,
+        "end": 1703
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The border on the top of the\nbutton tabs on hover in Tabbed Navigation.\n",
+    "commentRange": {
+      "start": 1704,
+      "end": 1705
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-tab-navigation-btn-hover-border-top",
+      "value": "3px solid $sprk-red",
+      "scope": "default",
+      "line": {
+        "start": 1706,
+        "end": 1706
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The button tab text color of the\ncurrently active tab in Tabbed Navigation.\n",
+    "commentRange": {
+      "start": 1707,
       "end": 1708
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-color",
-      "value": "$sprk-black",
+      "name": "sprk-tab-navigation-btn-active-color",
+      "value": "$sprk-red",
       "scope": "default",
       "line": {
         "start": 1709,
@@ -16146,115 +16121,65 @@
     }
   },
   {
-    "description": "The tab button background color in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1710,
-      "end": 1710
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-bg-color",
-      "value": "$sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1711,
-        "end": 1711
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border on the top of the button tabs in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1712,
-      "end": 1712
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-border-top",
-      "value": "3px solid $sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1713,
-        "end": 1713
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border on the top of the\nbutton tabs on hover in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1714,
-      "end": 1715
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-hover-border-top",
-      "value": "3px solid $sprk-red",
-      "scope": "default",
-      "line": {
-        "start": 1716,
-        "end": 1716
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The button tab text color of the\ncurrently active tab in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1717,
-      "end": 1718
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-color",
-      "value": "$sprk-red",
-      "scope": "default",
-      "line": {
-        "start": 1719,
-        "end": 1719
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The button tab top border of the\ncurrently active tab in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1720,
-      "end": 1721
+      "start": 1710,
+      "end": 1711
     },
     "context": {
       "type": "variable",
       "name": "sprk-tab-navigation-btn-active-border-top",
       "value": "3px solid $sprk-red",
+      "scope": "default",
+      "line": {
+        "start": 1712,
+        "end": 1712
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The button tab background color\nof the currently active tab in Tabbed Navigation.\n",
+    "commentRange": {
+      "start": 1713,
+      "end": 1714
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-tab-navigation-btn-active-bg-color",
+      "value": "$sprk-white",
+      "scope": "default",
+      "line": {
+        "start": 1715,
+        "end": 1715
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Stepper.\n",
+    "commentRange": {
+      "start": 1721,
+      "end": 1721
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-bg",
+      "value": "transparent",
       "scope": "default",
       "line": {
         "start": 1722,
@@ -16271,15 +16196,15 @@
     }
   },
   {
-    "description": "The button tab background color\nof the currently active tab in Tabbed Navigation.\n",
+    "description": "The minimum width at which the Stepper\nswitches between narrow and wide layouts.\n",
     "commentRange": {
       "start": 1723,
       "end": 1724
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-bg-color",
-      "value": "$sprk-white",
+      "name": "sprk-stepper-breakpoint",
+      "value": "$sprk-split-breakpoint-xl",
       "scope": "default",
       "line": {
         "start": 1725,
@@ -16296,65 +16221,115 @@
     }
   },
   {
-    "description": "The background color of the Stepper.\n",
-    "commentRange": {
-      "start": 1731,
-      "end": 1731
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-bg",
-      "value": "transparent",
-      "scope": "default",
-      "line": {
-        "start": 1732,
-        "end": 1732
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The minimum width at which the Stepper\nswitches between narrow and wide layouts.\n",
-    "commentRange": {
-      "start": 1733,
-      "end": 1734
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-breakpoint",
-      "value": "$sprk-split-breakpoint-xl",
-      "scope": "default",
-      "line": {
-        "start": 1735,
-        "end": 1735
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The maximum width of the Stepper.\n",
     "commentRange": {
-      "start": 1736,
-      "end": 1736
+      "start": 1726,
+      "end": 1726
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-max-width",
       "value": "480px",
+      "scope": "default",
+      "line": {
+        "start": 1727,
+        "end": 1727
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The border width of the Stepper icons.\n",
+    "commentRange": {
+      "start": 1728,
+      "end": 1728
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-border-width",
+      "value": "2px",
+      "scope": "default",
+      "line": {
+        "start": 1729,
+        "end": 1729
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the border around the Stepper icon.\n",
+    "commentRange": {
+      "start": 1730,
+      "end": 1730
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-border-color",
+      "value": "$sprk-black-tint-50",
+      "scope": "default",
+      "line": {
+        "start": 1731,
+        "end": 1731
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the step icon when the step is selected in the Stepper.\n",
+    "commentRange": {
+      "start": 1732,
+      "end": 1732
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-border-color-selected",
+      "value": "$sprk-green",
+      "scope": "default",
+      "line": {
+        "start": 1733,
+        "end": 1733
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the icon border when the\nStepper is on a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
+    "commentRange": {
+      "start": 1734,
+      "end": 1736
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-dark-icon-border-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1737,
@@ -16371,15 +16346,15 @@
     }
   },
   {
-    "description": "The border width of the Stepper icons.\n",
+    "description": "The height of the step icon in the Stepper.\n",
     "commentRange": {
       "start": 1738,
       "end": 1738
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-border-width",
-      "value": "2px",
+      "name": "sprk-stepper-icon-height",
+      "value": "16px",
       "scope": "default",
       "line": {
         "start": 1739,
@@ -16396,15 +16371,15 @@
     }
   },
   {
-    "description": "The color of the border around the Stepper icon.\n",
+    "description": "The width of the step icon in the Stepper.\n",
     "commentRange": {
       "start": 1740,
       "end": 1740
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-border-color",
-      "value": "$sprk-black-tint-50",
+      "name": "sprk-stepper-icon-width",
+      "value": "16px",
       "scope": "default",
       "line": {
         "start": 1741,
@@ -16421,15 +16396,15 @@
     }
   },
   {
-    "description": "The color of the step icon when the step is selected in the Stepper.\n",
+    "description": "The color of the step icon in the Stepper.\n",
     "commentRange": {
       "start": 1742,
       "end": 1742
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-border-color-selected",
-      "value": "$sprk-green",
+      "name": "sprk-stepper-icon-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1743,
@@ -16446,19 +16421,44 @@
     }
   },
   {
-    "description": "The color of the icon border when the\nStepper is on a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
+    "description": "The color of the step icon\nin the Stepper when hovered.\n",
     "commentRange": {
       "start": 1744,
-      "end": 1746
+      "end": 1745
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-dark-icon-border-color",
+      "name": "sprk-stepper-icon-color-hover",
+      "value": "$sprk-black-tint-50",
+      "scope": "default",
+      "line": {
+        "start": 1746,
+        "end": 1746
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the Stepper step icon when the step is selected.\n",
+    "commentRange": {
+      "start": 1747,
+      "end": 1747
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-color-selected",
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1747,
-        "end": 1747
+        "start": 1748,
+        "end": 1748
       }
     },
     "access": "public",
@@ -16471,40 +16471,15 @@
     }
   },
   {
-    "description": "The height of the step icon in the Stepper.\n",
+    "description": "The color of the step icon when the\nStepper has a dark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1748,
-      "end": 1748
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-height",
-      "value": "16px",
-      "scope": "default",
-      "line": {
-        "start": 1749,
-        "end": 1749
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The width of the step icon in the Stepper.\n",
-    "commentRange": {
-      "start": 1750,
+      "start": 1749,
       "end": 1750
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-width",
-      "value": "16px",
+      "name": "sprk-stepper-dark-icon-color",
+      "value": "$sprk-blue",
       "scope": "default",
       "line": {
         "start": 1751,
@@ -16521,110 +16496,10 @@
     }
   },
   {
-    "description": "The color of the step icon in the Stepper.\n",
-    "commentRange": {
-      "start": 1752,
-      "end": 1752
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1753,
-        "end": 1753
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the step icon\nin the Stepper when hovered.\n",
-    "commentRange": {
-      "start": 1754,
-      "end": 1755
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-color-hover",
-      "value": "$sprk-black-tint-50",
-      "scope": "default",
-      "line": {
-        "start": 1756,
-        "end": 1756
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Stepper step icon when the step is selected.\n",
-    "commentRange": {
-      "start": 1757,
-      "end": 1757
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-color-selected",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1758,
-        "end": 1758
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the step icon when the\nStepper has a dark background (sprk-c-Stepper--has-dark-bg).\n",
-    "commentRange": {
-      "start": 1759,
-      "end": 1760
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-dark-icon-color",
-      "value": "$sprk-blue",
-      "scope": "default",
-      "line": {
-        "start": 1761,
-        "end": 1761
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The color of the Stepper step icon when the step\nis selected and the Stepper has a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1762,
-      "end": 1764
+      "start": 1752,
+      "end": 1754
     },
     "context": {
       "type": "variable",
@@ -16632,8 +16507,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1765,
-        "end": 1765
+        "start": 1755,
+        "end": 1755
       }
     },
     "access": "public",
@@ -16648,8 +16523,8 @@
   {
     "description": "The color of the step icon on hover\nwhen the Stepper has a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1766,
-      "end": 1768
+      "start": 1756,
+      "end": 1758
     },
     "context": {
       "type": "variable",
@@ -16657,8 +16532,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1769,
-        "end": 1769
+        "start": 1759,
+        "end": 1759
       }
     },
     "access": "public",
@@ -16673,8 +16548,8 @@
   {
     "description": "The transition of the Stepper step icon.\n",
     "commentRange": {
-      "start": 1771,
-      "end": 1771
+      "start": 1761,
+      "end": 1761
     },
     "context": {
       "type": "variable",
@@ -16682,8 +16557,8 @@
       "value": "0.3s all ease-in-out",
       "scope": "default",
       "line": {
-        "start": 1772,
-        "end": 1772
+        "start": 1762,
+        "end": 1762
       }
     },
     "access": "public",
@@ -16698,13 +16573,88 @@
   {
     "description": "The z-index of the Stepper step icon.\n",
     "commentRange": {
-      "start": 1773,
-      "end": 1773
+      "start": 1763,
+      "end": 1763
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-icon-z-index",
       "value": "$sprk-layer-height-xs",
+      "scope": "default",
+      "line": {
+        "start": 1764,
+        "end": 1764
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The spread value of the icon box\nshadow when the Stepper step is selected.\n",
+    "commentRange": {
+      "start": 1765,
+      "end": 1766
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-box-shadow-selected-spread",
+      "value": "8px",
+      "scope": "default",
+      "line": {
+        "start": 1767,
+        "end": 1767
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Stepper step icon\nwhen the icon is selected.\n",
+    "commentRange": {
+      "start": 1768,
+      "end": 1769
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-box-shadow-selected",
+      "value": "0 0 0\n  $sprk-stepper-icon-box-shadow-selected-spread\n  $sprk-stepper-icon-border-color-selected",
+      "scope": "default",
+      "line": {
+        "start": 1770,
+        "end": 1772
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the content in the Stepper step.\n",
+    "commentRange": {
+      "start": 1773,
+      "end": 1773
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-step-content-bg",
+      "value": "transparent",
       "scope": "default",
       "line": {
         "start": 1774,
@@ -16721,15 +16671,15 @@
     }
   },
   {
-    "description": "The spread value of the icon box\nshadow when the Stepper step is selected.\n",
+    "description": "The border radius of the Stepper step\ncontent box when it has a description.\n",
     "commentRange": {
       "start": 1775,
       "end": 1776
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-box-shadow-selected-spread",
-      "value": "8px",
+      "name": "sprk-stepper-step-description-border-radius",
+      "value": "5px",
       "scope": "default",
       "line": {
         "start": 1777,
@@ -16746,19 +16696,19 @@
     }
   },
   {
-    "description": "The box shadow of the Stepper step icon\nwhen the icon is selected.\n",
+    "description": "The box shadow of the Stepper step content\nbox when it has a description.\n",
     "commentRange": {
       "start": 1778,
       "end": 1779
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-box-shadow-selected",
-      "value": "0 0 0\n  $sprk-stepper-icon-box-shadow-selected-spread\n  $sprk-stepper-icon-border-color-selected",
+      "name": "sprk-stepper-step-description-box-shadow",
+      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
         "start": 1780,
-        "end": 1782
+        "end": 1780
       }
     },
     "access": "public",
@@ -16771,19 +16721,19 @@
     }
   },
   {
-    "description": "The background color of the content in the Stepper step.\n",
+    "description": "The spacing between the\nStepper step heading and description.\n",
     "commentRange": {
-      "start": 1783,
-      "end": 1783
+      "start": 1781,
+      "end": 1782
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-content-bg",
-      "value": "transparent",
+      "name": "sprk-stepper-step-description-top-spacing",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1784,
-        "end": 1784
+        "start": 1783,
+        "end": 1783
       }
     },
     "access": "public",
@@ -16796,15 +16746,40 @@
     }
   },
   {
-    "description": "The border radius of the Stepper step\ncontent box when it has a description.\n",
+    "description": "The font weight of the Stepper step heading.\n",
     "commentRange": {
-      "start": 1785,
+      "start": 1784,
+      "end": 1784
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-step-heading-font-weight",
+      "value": "400",
+      "scope": "default",
+      "line": {
+        "start": 1785,
+        "end": 1785
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font size of the Stepper step heading.\n",
+    "commentRange": {
+      "start": 1786,
       "end": 1786
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-border-radius",
-      "value": "5px",
+      "name": "sprk-stepper-step-heading-size",
+      "value": "$sprk-font-size-display-six",
       "scope": "default",
       "line": {
         "start": 1787,
@@ -16821,19 +16796,19 @@
     }
   },
   {
-    "description": "The box shadow of the Stepper step content\nbox when it has a description.\n",
+    "description": "The color of the Stepper step heading.\n",
     "commentRange": {
       "start": 1788,
-      "end": 1789
+      "end": 1788
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-box-shadow",
-      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
+      "name": "sprk-stepper-step-heading-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1790,
-        "end": 1790
+        "start": 1789,
+        "end": 1789
       }
     },
     "access": "public",
@@ -16846,15 +16821,15 @@
     }
   },
   {
-    "description": "The spacing between the\nStepper step heading and description.\n",
+    "description": "The color of the Stepper step heading when\nthe Stepper is on a dark\nbackground (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1791,
+      "start": 1790,
       "end": 1792
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-top-spacing",
-      "value": "$sprk-space-m",
+      "name": "sprk-stepper-dark-step-heading-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1793,
@@ -16871,110 +16846,10 @@
     }
   },
   {
-    "description": "The font weight of the Stepper step heading.\n",
-    "commentRange": {
-      "start": 1794,
-      "end": 1794
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-heading-font-weight",
-      "value": "400",
-      "scope": "default",
-      "line": {
-        "start": 1795,
-        "end": 1795
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size of the Stepper step heading.\n",
-    "commentRange": {
-      "start": 1796,
-      "end": 1796
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-heading-size",
-      "value": "$sprk-font-size-display-six",
-      "scope": "default",
-      "line": {
-        "start": 1797,
-        "end": 1797
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Stepper step heading.\n",
-    "commentRange": {
-      "start": 1798,
-      "end": 1798
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-heading-color",
-      "value": "$sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1799,
-        "end": 1799
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Stepper step heading when\nthe Stepper is on a dark\nbackground (sprk-c-Stepper--has-dark-bg).\n",
-    "commentRange": {
-      "start": 1800,
-      "end": 1802
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-dark-step-heading-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1803,
-        "end": 1803
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The color of the Stepper\nstep heading when the step is selected.\n",
     "commentRange": {
-      "start": 1804,
-      "end": 1805
+      "start": 1794,
+      "end": 1795
     },
     "context": {
       "type": "variable",
@@ -16982,8 +16857,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1806,
-        "end": 1806
+        "start": 1796,
+        "end": 1796
       }
     },
     "access": "public",
@@ -16998,8 +16873,8 @@
   {
     "description": "The padding value for the Stepper step.\n",
     "commentRange": {
-      "start": 1807,
-      "end": 1807
+      "start": 1797,
+      "end": 1797
     },
     "context": {
       "type": "variable",
@@ -17007,8 +16882,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 1808,
-        "end": 1808
+        "start": 1798,
+        "end": 1798
       }
     },
     "access": "public",
@@ -17023,8 +16898,8 @@
   {
     "description": "The background color of the\nStepper step content box when the step is selected.\n",
     "commentRange": {
-      "start": 1809,
-      "end": 1810
+      "start": 1799,
+      "end": 1800
     },
     "context": {
       "type": "variable",
@@ -17032,8 +16907,8 @@
       "value": "transparent",
       "scope": "default",
       "line": {
-        "start": 1811,
-        "end": 1811
+        "start": 1801,
+        "end": 1801
       }
     },
     "access": "public",
@@ -17048,8 +16923,8 @@
   {
     "description": "The background color of the Stepper step\ncontent box when it has a\ndescription and when the step is selected.\n",
     "commentRange": {
-      "start": 1812,
-      "end": 1814
+      "start": 1802,
+      "end": 1804
     },
     "context": {
       "type": "variable",
@@ -17057,8 +16932,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1815,
-        "end": 1815
+        "start": 1805,
+        "end": 1805
       }
     },
     "access": "public",
@@ -17073,8 +16948,8 @@
   {
     "description": "The text color of a selected Stepper step's\ncontent and header when it has a\ndescription. This applies to\nsteppers with the sprk-c-Stepper--has-dark-bg class.\n",
     "commentRange": {
-      "start": 1816,
-      "end": 1819
+      "start": 1806,
+      "end": 1809
     },
     "context": {
       "type": "variable",
@@ -17082,8 +16957,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1820,
-        "end": 1820
+        "start": 1810,
+        "end": 1810
       }
     },
     "access": "public",
@@ -17098,8 +16973,8 @@
   {
     "description": "The color of the bar that connects the steps in the Stepper.\n",
     "commentRange": {
-      "start": 1821,
-      "end": 1821
+      "start": 1811,
+      "end": 1811
     },
     "context": {
       "type": "variable",
@@ -17107,8 +16982,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1822,
-        "end": 1822
+        "start": 1812,
+        "end": 1812
       }
     },
     "access": "public",
@@ -17123,8 +16998,8 @@
   {
     "description": "The color of the bar that connects\nthe steps when the Stepper is on a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1823,
-      "end": 1825
+      "start": 1813,
+      "end": 1815
     },
     "context": {
       "type": "variable",
@@ -17132,8 +17007,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1826,
-        "end": 1826
+        "start": 1816,
+        "end": 1816
       }
     },
     "access": "public",
@@ -17148,8 +17023,8 @@
   {
     "description": "The border value for the Carousel component.\n",
     "commentRange": {
-      "start": 1845,
-      "end": 1845
+      "start": 1835,
+      "end": 1835
     },
     "context": {
       "type": "variable",
@@ -17157,8 +17032,8 @@
       "value": "$sprk-stepper-icon-border-width solid\n  $sprk-stepper-dark-icon-border-color",
       "scope": "default",
       "line": {
-        "start": 1846,
-        "end": 1847
+        "start": 1836,
+        "end": 1837
       }
     },
     "access": "public",
@@ -17173,13 +17048,138 @@
   {
     "description": "The height of the dots in the Carousel component.\n",
     "commentRange": {
-      "start": 1848,
-      "end": 1848
+      "start": 1838,
+      "end": 1838
     },
     "context": {
       "type": "variable",
       "name": "sprk-carousel-dot-height",
       "value": "10px",
+      "scope": "default",
+      "line": {
+        "start": 1839,
+        "end": 1839
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The width of the dots in the Carousel component.\n",
+    "commentRange": {
+      "start": 1840,
+      "end": 1840
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-dot-width",
+      "value": "10px",
+      "scope": "default",
+      "line": {
+        "start": 1841,
+        "end": 1841
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The height of the dots in the Carousel component on wide viewports.\n",
+    "commentRange": {
+      "start": 1842,
+      "end": 1842
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-wide-dot-height",
+      "value": "10px",
+      "scope": "default",
+      "line": {
+        "start": 1843,
+        "end": 1843
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The width of the dots in the Carousel component on wide viewports.\n",
+    "commentRange": {
+      "start": 1844,
+      "end": 1844
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-wide-dot-width",
+      "value": "10px",
+      "scope": "default",
+      "line": {
+        "start": 1845,
+        "end": 1845
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The spacing between dots in the Carousel component.\n",
+    "commentRange": {
+      "start": 1846,
+      "end": 1846
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-dot-spacing",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1847,
+        "end": 1847
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The spacing between dots in the Carousel component on wide viewports.\n",
+    "commentRange": {
+      "start": 1848,
+      "end": 1848
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-carousel-wide-dot-spacing",
+      "value": "$sprk-carousel-dot-spacing",
       "scope": "default",
       "line": {
         "start": 1849,
@@ -17196,15 +17196,15 @@
     }
   },
   {
-    "description": "The width of the dots in the Carousel component.\n",
+    "description": "The box shadow of the active dot in the Carousel component.\n",
     "commentRange": {
       "start": 1850,
       "end": 1850
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-dot-width",
-      "value": "10px",
+      "name": "sprk-carousel-dot-selected",
+      "value": "$sprk-stepper-icon-box-shadow-selected",
       "scope": "default",
       "line": {
         "start": 1851,
@@ -17221,15 +17221,15 @@
     }
   },
   {
-    "description": "The height of the dots in the Carousel component on wide viewports.\n",
+    "description": "The color of the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1852,
       "end": 1852
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-wide-dot-height",
-      "value": "10px",
+      "name": "sprk-carousel-arrow-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1853,
@@ -17246,15 +17246,15 @@
     }
   },
   {
-    "description": "The width of the dots in the Carousel component on wide viewports.\n",
+    "description": "The spacing for the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1854,
       "end": 1854
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-wide-dot-width",
-      "value": "10px",
+      "name": "sprk-carousel-arrow-spacing",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
         "start": 1855,
@@ -17271,15 +17271,15 @@
     }
   },
   {
-    "description": "The spacing between dots in the Carousel component.\n",
+    "description": "The left and right values of the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1856,
       "end": 1856
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-dot-spacing",
-      "value": "$sprk-space-m",
+      "name": "sprk-carousel-arrow-edge-spacing",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1857,
@@ -17296,15 +17296,15 @@
     }
   },
   {
-    "description": "The spacing between dots in the Carousel component on wide viewports.\n",
+    "description": "The padding value of the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1858,
       "end": 1858
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-wide-dot-spacing",
-      "value": "$sprk-carousel-dot-spacing",
+      "name": "sprk-carousel-arrow-padding",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
         "start": 1859,
@@ -17321,15 +17321,15 @@
     }
   },
   {
-    "description": "The box shadow of the active dot in the Carousel component.\n",
+    "description": "The maximum width of the image in the Carousel component.\n",
     "commentRange": {
       "start": 1860,
       "end": 1860
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-dot-selected",
-      "value": "$sprk-stepper-icon-box-shadow-selected",
+      "name": "sprk-carousel-narrow-image-max-width",
+      "value": "18.75rem",
       "scope": "default",
       "line": {
         "start": 1861,
@@ -17346,15 +17346,15 @@
     }
   },
   {
-    "description": "The color of the arrows in the Carousel component.\n",
+    "description": "The breakpoint for the arrows in the Carousel component.\n",
     "commentRange": {
       "start": 1862,
       "end": 1862
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-arrow-color",
-      "value": "$sprk-white",
+      "name": "sprk-carousel-arrow-position-breakpoint",
+      "value": "31.25rem",
       "scope": "default",
       "line": {
         "start": 1863,
@@ -17371,15 +17371,15 @@
     }
   },
   {
-    "description": "The spacing for the arrows in the Carousel component.\n",
+    "description": "The padding value for the dots container in the Carousel component.\n",
     "commentRange": {
       "start": 1864,
       "end": 1864
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-arrow-spacing",
-      "value": "$sprk-space-m",
+      "name": "sprk-carousel-dot-container-padding",
+      "value": "$sprk-space-xs",
       "scope": "default",
       "line": {
         "start": 1865,
@@ -17396,15 +17396,15 @@
     }
   },
   {
-    "description": "The left and right values of the arrows in the Carousel component.\n",
+    "description": "The breakpoint for the Carousel component.\n",
     "commentRange": {
       "start": 1866,
       "end": 1866
     },
     "context": {
       "type": "variable",
-      "name": "sprk-carousel-arrow-edge-spacing",
-      "value": "0",
+      "name": "sprk-carousel-breakpoint",
+      "value": "$sprk-split-breakpoint-xl",
       "scope": "default",
       "line": {
         "start": 1867,
@@ -17421,140 +17421,140 @@
     }
   },
   {
-    "description": "The padding value of the arrows in the Carousel component.\n",
-    "commentRange": {
-      "start": 1868,
-      "end": 1868
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-arrow-padding",
-      "value": "$sprk-space-m",
-      "scope": "default",
-      "line": {
-        "start": 1869,
-        "end": 1869
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The maximum width of the image in the Carousel component.\n",
-    "commentRange": {
-      "start": 1870,
-      "end": 1870
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-narrow-image-max-width",
-      "value": "18.75rem",
-      "scope": "default",
-      "line": {
-        "start": 1871,
-        "end": 1871
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The breakpoint for the arrows in the Carousel component.\n",
-    "commentRange": {
-      "start": 1872,
-      "end": 1872
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-arrow-position-breakpoint",
-      "value": "31.25rem",
-      "scope": "default",
-      "line": {
-        "start": 1873,
-        "end": 1873
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding value for the dots container in the Carousel component.\n",
-    "commentRange": {
-      "start": 1874,
-      "end": 1874
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-dot-container-padding",
-      "value": "$sprk-space-xs",
-      "scope": "default",
-      "line": {
-        "start": 1875,
-        "end": 1875
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The breakpoint for the Carousel component.\n",
-    "commentRange": {
-      "start": 1876,
-      "end": 1876
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-carousel-breakpoint",
-      "value": "$sprk-split-breakpoint-xl",
-      "scope": "default",
-      "line": {
-        "start": 1877,
-        "end": 1877
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The maximum width of the Card.\n",
+    "commentRange": {
+      "start": 1873,
+      "end": 1873
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-max-width",
+      "value": "26.5625rem",
+      "scope": "default",
+      "line": {
+        "start": 1874,
+        "end": 1874
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The main Card breakpoint.\n",
+    "commentRange": {
+      "start": 1875,
+      "end": 1875
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-breakpoint",
+      "value": "$sprk-split-breakpoint-s",
+      "scope": "default",
+      "line": {
+        "start": 1876,
+        "end": 1876
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Card on narrow viewports.\n",
+    "commentRange": {
+      "start": 1877,
+      "end": 1877
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-shadow",
+      "value": "0 3px 10px 1px rgba(0, 0, 0, 0.08)",
+      "scope": "default",
+      "line": {
+        "start": 1878,
+        "end": 1878
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Card on wide viewports.\n",
+    "commentRange": {
+      "start": 1879,
+      "end": 1879
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-shadow-wide-viewport",
+      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
+      "scope": "default",
+      "line": {
+        "start": 1880,
+        "end": 1880
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Standout Card variant on narrow viewports.\n",
+    "commentRange": {
+      "start": 1881,
+      "end": 1881
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-card-shadow-standout",
+      "value": "0 4px 20px 2px rgba(0, 0, 0, 0.1)",
+      "scope": "default",
+      "line": {
+        "start": 1882,
+        "end": 1882
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Standout Card variant on wide viewports.\n",
     "commentRange": {
       "start": 1883,
       "end": 1883
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-max-width",
-      "value": "26.5625rem",
+      "name": "sprk-card-shadow-standout-wide-viewport",
+      "value": "0 4px 40px 2px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
         "start": 1884,
@@ -17571,15 +17571,15 @@
     }
   },
   {
-    "description": "The main Card breakpoint.\n",
+    "description": "The border radius of the Card.\n",
     "commentRange": {
       "start": 1885,
       "end": 1885
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-breakpoint",
-      "value": "$sprk-split-breakpoint-s",
+      "name": "sprk-card-border-radius",
+      "value": "8px",
       "scope": "default",
       "line": {
         "start": 1886,
@@ -17596,15 +17596,15 @@
     }
   },
   {
-    "description": "The box shadow of the Card on narrow viewports.\n",
+    "description": "The padding of the content inside the Card.\n",
     "commentRange": {
       "start": 1887,
       "end": 1887
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-shadow",
-      "value": "0 3px 10px 1px rgba(0, 0, 0, 0.08)",
+      "name": "sprk-card-content-padding",
+      "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
         "start": 1888,
@@ -17621,15 +17621,15 @@
     }
   },
   {
-    "description": "The box shadow of the Card on wide viewports.\n",
+    "description": "The background color of the header area for the Highlighted Header Card.\n",
     "commentRange": {
       "start": 1889,
       "end": 1889
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-shadow-wide-viewport",
-      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
+      "name": "sprk-card-header-bg-color",
+      "value": "$sprk-green",
       "scope": "default",
       "line": {
         "start": 1890,
@@ -17646,15 +17646,15 @@
     }
   },
   {
-    "description": "The box shadow of the Standout Card variant on narrow viewports.\n",
+    "description": "The text color for the Highlighted Header Card.\n",
     "commentRange": {
       "start": 1891,
       "end": 1891
     },
     "context": {
       "type": "variable",
-      "name": "sprk-card-shadow-standout",
-      "value": "0 4px 20px 2px rgba(0, 0, 0, 0.1)",
+      "name": "sprk-card-header-text-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1892,
@@ -17671,140 +17671,140 @@
     }
   },
   {
-    "description": "The box shadow of the Standout Card variant on wide viewports.\n",
-    "commentRange": {
-      "start": 1893,
-      "end": 1893
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-shadow-standout-wide-viewport",
-      "value": "0 4px 40px 2px rgba(0, 0, 0, 0.1)",
-      "scope": "default",
-      "line": {
-        "start": 1894,
-        "end": 1894
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border radius of the Card.\n",
-    "commentRange": {
-      "start": 1895,
-      "end": 1895
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-border-radius",
-      "value": "8px",
-      "scope": "default",
-      "line": {
-        "start": 1896,
-        "end": 1896
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding of the content inside the Card.\n",
-    "commentRange": {
-      "start": 1897,
-      "end": 1897
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-content-padding",
-      "value": "$sprk-space-misc-a",
-      "scope": "default",
-      "line": {
-        "start": 1898,
-        "end": 1898
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The background color of the header area for the Highlighted Header Card.\n",
-    "commentRange": {
-      "start": 1899,
-      "end": 1899
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-header-bg-color",
-      "value": "$sprk-green",
-      "scope": "default",
-      "line": {
-        "start": 1900,
-        "end": 1900
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The text color for the Highlighted Header Card.\n",
-    "commentRange": {
-      "start": 1901,
-      "end": 1901
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-card-header-text-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1902,
-        "end": 1902
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
     "description": "The border surrounding the Dictionary.\n",
+    "commentRange": {
+      "start": 1898,
+      "end": 1898
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-border",
+      "value": "1px solid $sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1899,
+        "end": 1899
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the key value pairs in the striped Dictionary.\n",
+    "commentRange": {
+      "start": 1900,
+      "end": 1900
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-stripe-color",
+      "value": "$sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1901,
+        "end": 1901
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The breakpoint of the Dictionary component.\n",
+    "commentRange": {
+      "start": 1902,
+      "end": 1902
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-breakpoint",
+      "value": "38.4375rem",
+      "scope": "default",
+      "line": {
+        "start": 1903,
+        "end": 1903
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font size of the labels in the Dictionary.\n",
+    "commentRange": {
+      "start": 1904,
+      "end": 1904
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-label-font-size",
+      "value": "$sprk-font-size-body-one",
+      "scope": "default",
+      "line": {
+        "start": 1905,
+        "end": 1905
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font weight of the labels in the Dictionary.\n",
+    "commentRange": {
+      "start": 1906,
+      "end": 1906
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dictionary-label-font-weight",
+      "value": "$sprk-font-weight-body-one",
+      "scope": "default",
+      "line": {
+        "start": 1907,
+        "end": 1907
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The line height of the labels in the Dictionary.\n",
     "commentRange": {
       "start": 1908,
       "end": 1908
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dictionary-border",
-      "value": "1px solid $sprk-gray",
+      "name": "sprk-dictionary-label-line-height",
+      "value": "$sprk-line-height-body-one",
       "scope": "default",
       "line": {
         "start": 1909,
@@ -17821,90 +17821,15 @@
     }
   },
   {
-    "description": "The background color of the key value pairs in the striped Dictionary.\n",
+    "description": "The Highlight Board breakpoint at which styles change\nfor padding, font size and button width.\n",
     "commentRange": {
-      "start": 1910,
-      "end": 1910
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dictionary-stripe-color",
-      "value": "$sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1911,
-        "end": 1911
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The breakpoint of the Dictionary component.\n",
-    "commentRange": {
-      "start": 1912,
-      "end": 1912
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dictionary-breakpoint",
-      "value": "38.4375rem",
-      "scope": "default",
-      "line": {
-        "start": 1913,
-        "end": 1913
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font size of the labels in the Dictionary.\n",
-    "commentRange": {
-      "start": 1914,
-      "end": 1914
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dictionary-label-font-size",
-      "value": "$sprk-font-size-body-one",
-      "scope": "default",
-      "line": {
-        "start": 1915,
-        "end": 1915
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the labels in the Dictionary.\n",
-    "commentRange": {
-      "start": 1916,
+      "start": 1915,
       "end": 1916
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dictionary-label-font-weight",
-      "value": "$sprk-font-weight-body-one",
+      "name": "sprk-highlight-board-breakpoint",
+      "value": "30rem",
       "scope": "default",
       "line": {
         "start": 1917,
@@ -17921,19 +17846,19 @@
     }
   },
   {
-    "description": "The line height of the labels in the Dictionary.\n",
+    "description": "The maximum width of the content\nfor the Highlight Board when it has an image.\n",
     "commentRange": {
       "start": 1918,
-      "end": 1918
+      "end": 1919
     },
     "context": {
       "type": "variable",
-      "name": "sprk-dictionary-label-line-height",
-      "value": "$sprk-line-height-body-one",
+      "name": "sprk-highlight-board-content-width",
+      "value": "30rem",
       "scope": "default",
       "line": {
-        "start": 1919,
-        "end": 1919
+        "start": 1920,
+        "end": 1920
       }
     },
     "access": "public",
@@ -17946,15 +17871,65 @@
     }
   },
   {
-    "description": "The Highlight Board breakpoint at which styles change\nfor padding, font size and button width.\n",
+    "description": "Percentage reduction value for the\nfont size in the Highlight Board in narrow viewports.\n",
     "commentRange": {
-      "start": 1925,
+      "start": 1921,
+      "end": 1922
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-highlight-board-type-reduction-percentage",
+      "value": "0.8",
+      "scope": "default",
+      "line": {
+        "start": 1923,
+        "end": 1923
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The height of the Highlight Board image.\n",
+    "commentRange": {
+      "start": 1924,
+      "end": 1924
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-highlight-board-height",
+      "value": "31.25rem",
+      "scope": "default",
+      "line": {
+        "start": 1925,
+        "end": 1925
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Highlight Board.\n",
+    "commentRange": {
+      "start": 1926,
       "end": 1926
     },
     "context": {
       "type": "variable",
-      "name": "sprk-highlight-board-breakpoint",
-      "value": "30rem",
+      "name": "sprk-highlight-board-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1927,
@@ -17971,110 +17946,10 @@
     }
   },
   {
-    "description": "The maximum width of the content\nfor the Highlight Board when it has an image.\n",
+    "description": "The background color of\nthe content box in the Highlight Board.\n",
     "commentRange": {
       "start": 1928,
       "end": 1929
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-content-width",
-      "value": "30rem",
-      "scope": "default",
-      "line": {
-        "start": 1930,
-        "end": 1930
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "Percentage reduction value for the\nfont size in the Highlight Board in narrow viewports.\n",
-    "commentRange": {
-      "start": 1931,
-      "end": 1932
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-type-reduction-percentage",
-      "value": "0.8",
-      "scope": "default",
-      "line": {
-        "start": 1933,
-        "end": 1933
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The height of the Highlight Board image.\n",
-    "commentRange": {
-      "start": 1934,
-      "end": 1934
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-height",
-      "value": "31.25rem",
-      "scope": "default",
-      "line": {
-        "start": 1935,
-        "end": 1935
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The background color of the Highlight Board.\n",
-    "commentRange": {
-      "start": 1936,
-      "end": 1936
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-color",
-      "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1937,
-        "end": 1937
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The background color of\nthe content box in the Highlight Board.\n",
-    "commentRange": {
-      "start": 1938,
-      "end": 1939
     },
     "context": {
       "type": "variable",
@@ -18082,8 +17957,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1940,
-        "end": 1940
+        "start": 1930,
+        "end": 1930
       }
     },
     "access": "public",


### PR DESCRIPTION
## What does this PR do?
- [x] Update the Angular Toggle component to use `<button>` instead of `<a>`
- [x] Add `aria-controls` to the Angular Toggle component
- [x] Update tests for Angular Toggle component
- [x] Update `generateAriaControls` function and related stories
- [x] Update _toggle.scss to remove font styles from `sprk-c-Toggle__trigger`
- [x] Update HTML story for toggle to use the font style class and `sprk-u-TextCrop--none`
- [x] Update React component for toggle to use the correct classes

### Associated Issue
Fixes #2944 

### Code
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Build Component in HTML
 - [x] Unit Testing in Angular with `npm run coverage` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)
 - [x] Unit Testing in HTML with `npm run coverage` in `html/` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
Tested all three frameworks in each browser since there were changes to all.
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots
![image](https://user-images.githubusercontent.com/15703773/78057095-28f7d880-7354-11ea-8705-0d702d07b3ec.png)
