### PR TITLE
HTML Accordion

### DIFF
--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -34,7 +34,6 @@ export const defaultStory = () => {
 <ul class="sprk-c-Accordion sprk-o-VerticalList">
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
-      aria-controls="details-one"
       class="sprk-c-Accordion__summary"
       data-id="accordion-item-1"
       data-analytics="analytics_string_goes_here"
@@ -59,9 +58,7 @@ export const defaultStory = () => {
         </svg>
     </button>
 
-    <div
-      data-sprk-toggle="content"
-      id="details-one">
+    <div data-sprk-toggle="content">
       <div class="sprk-c-Accordion__content sprk-o-Stack sprk-o-Stack--medium">
         <p class="sprk-b-TypeBodyTwo sprk-o-Stack__item">
           This is an example of multiple HTML
@@ -87,7 +84,6 @@ export const defaultStory = () => {
 
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
-      aria-controls="details-two"
       class="sprk-c-Accordion__summary"
       data-id="accordion-item-2"
       data-analytics="analytics_string_goes_here"
@@ -113,9 +109,7 @@ export const defaultStory = () => {
         </svg>
     </button>
 
-    <div
-      data-sprk-toggle="content"
-      id="details-two">
+    <div data-sprk-toggle="content">
       <div class="sprk-c-Accordion__content sprk-b-TypeBodyTwo">
         This is an example of accordion content.
         This is an example of accordion content.
@@ -127,7 +121,6 @@ export const defaultStory = () => {
 
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
-      aria-controls="details-three"
       class="sprk-c-Accordion__summary"
       data-id="accordion-item-3"
       data-analytics="analytics_string_goes_here"
@@ -151,9 +144,7 @@ export const defaultStory = () => {
         </svg>
     </button>
 
-    <div
-      data-sprk-toggle="content"
-      id="details-three">
+    <div data-sprk-toggle="content">
       <div class="sprk-c-Accordion__content sprk-b-TypeBodyTwo">
         This is an example of accordion content.
         This is an example of accordion content.

--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -35,7 +35,7 @@ export const defaultStory = () => {
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
       aria-controls="details-one"
-      class="sprk-c-Accordion__summary sprk-u-Width-100"
+      class="sprk-c-Accordion__summary"
       data-id="accordion-item-1"
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
@@ -88,7 +88,7 @@ export const defaultStory = () => {
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
       aria-controls="details-two"
-      class="sprk-c-Accordion__summary sprk-u-Width-100"
+      class="sprk-c-Accordion__summary"
       data-id="accordion-item-2"
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
@@ -128,7 +128,7 @@ export const defaultStory = () => {
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
       aria-controls="details-three"
-      class="sprk-c-Accordion__summary sprk-u-Width-100"
+      class="sprk-c-Accordion__summary"
       data-id="accordion-item-3"
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
@@ -141,7 +141,7 @@ export const defaultStory = () => {
         <svg
           class="
             sprk-c-Icon sprk-c-Icon--toggle
-            sprk-c-Icon--l sprk-c-Accordion__icon 
+            sprk-c-Icon--l sprk-c-Accordion__icon
           "
           data-sprk-toggle="icon"
           viewBox="0 0 64 64">

--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -33,7 +33,7 @@ export const defaultStory = () => {
   return `
 <ul class="sprk-c-Accordion sprk-o-VerticalList">
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
-    <a
+    <button
       aria-controls="details-one"
       class="sprk-c-Accordion__summary"
       data-id="accordion-item-1"
@@ -57,7 +57,7 @@ export const defaultStory = () => {
             xlink:href="#chevron-up-circle-two-color"
             data-sprk-toggle="accordionIconUseElement"></use>
         </svg>
-    </a>
+    </button>
 
     <div
       data-sprk-toggle="content"
@@ -86,7 +86,7 @@ export const defaultStory = () => {
   </li>
 
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
-    <a
+    <button
       aria-controls="details-two"
       class="sprk-c-Accordion__summary"
       data-id="accordion-item-2"
@@ -111,7 +111,7 @@ export const defaultStory = () => {
             xlink:href="#chevron-up-circle-two-color"
             data-sprk-toggle="accordionIconUseElement"></use>
         </svg>
-    </a>
+    </button>
 
     <div
       data-sprk-toggle="content"
@@ -126,7 +126,7 @@ export const defaultStory = () => {
   </li>
 
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
-    <a
+    <button
       aria-controls="details-three"
       class="sprk-c-Accordion__summary"
       data-id="accordion-item-3"
@@ -149,7 +149,7 @@ export const defaultStory = () => {
             xlink:href="#chevron-up-circle-two-color"
             data-sprk-toggle="accordionIconUseElement"></use>
         </svg>
-    </a>
+    </button>
 
     <div
       data-sprk-toggle="content"

--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -39,7 +39,7 @@ export const defaultStory = () => {
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
       data-sprk-toggle-type="accordion"
-      href="#">
+      >
         <h3 class="sprk-c-Accordion__heading sprk-b-TypeDisplaySeven">
           This is an accordion heading
         </h3>
@@ -89,7 +89,7 @@ export const defaultStory = () => {
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
       data-sprk-toggle-type="accordion"
-      href="#">
+      >
         <h3 class="sprk-c-Accordion__heading sprk-b-TypeDisplaySeven">
           This is an accordion heading
         </h3>
@@ -126,7 +126,7 @@ export const defaultStory = () => {
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
       data-sprk-toggle-type="accordion"
-      href="#">
+      >
         <h3 class="sprk-c-Accordion__heading sprk-b-TypeDisplaySeven">
           This is an accordion heading
         </h3>

--- a/html/components/accordion.stories.js
+++ b/html/components/accordion.stories.js
@@ -35,7 +35,7 @@ export const defaultStory = () => {
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
       aria-controls="details-one"
-      class="sprk-c-Accordion__summary"
+      class="sprk-c-Accordion__summary sprk-u-Width-100"
       data-id="accordion-item-1"
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
@@ -88,7 +88,7 @@ export const defaultStory = () => {
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
       aria-controls="details-two"
-      class="sprk-c-Accordion__summary"
+      class="sprk-c-Accordion__summary sprk-u-Width-100"
       data-id="accordion-item-2"
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
@@ -128,7 +128,7 @@ export const defaultStory = () => {
   <li class="sprk-c-Accordion__item" data-sprk-toggle="container">
     <button
       aria-controls="details-three"
-      class="sprk-c-Accordion__summary"
+      class="sprk-c-Accordion__summary sprk-u-Width-100"
       data-id="accordion-item-3"
       data-analytics="analytics_string_goes_here"
       data-sprk-toggle="trigger"
@@ -141,7 +141,7 @@ export const defaultStory = () => {
         <svg
           class="
             sprk-c-Icon sprk-c-Icon--toggle
-            sprk-c-Icon--l sprk-c-Accordion__icon
+            sprk-c-Icon--l sprk-c-Accordion__icon 
           "
           data-sprk-toggle="icon"
           viewBox="0 0 64 64">


### PR DESCRIPTION
## What does this PR do?
- Change `<a>` to `<button>`
- remove `aria-controls` and `id` from the stories, as these will be autogenerated by `generateAriaControls`.
- CSS changes are all in other PRs. (https://github.com/sparkdesignsystem/spark-design-system/pull/2970)
- Tests are all in toggle

### Associated Issue
Fixes https://github.com/sparkdesignsystem/spark-design-system/issues/2946

### Code
 - [x] Build Component in HTML
 - [X] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)

### Accessibility
- [X] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [X] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)