### PR TITLE
Add aria-controls to angular masthead narrow nav, update sprk-toggle, update SprkToggle

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.spec.ts
@@ -194,4 +194,21 @@ describe('SprkMastheadComponent', () => {
     window.dispatchEvent(resizeEvent);
     expect(spyOnResize).toHaveBeenCalled();
   });
+
+  it('should add aria-controls and id to narrowNav if narrowNavAriaControls is not passed', () => {
+    component.isNarrowNavOpen = true;
+    fixture.detectChanges();
+    narrowNavElement = fixture.nativeElement.querySelector('.sprk-c-Masthead__narrow-nav');
+    expect(narrowNavElement.getAttribute('id')).toMatch(/sprk_masthead_narrow_nav_\d/);
+    expect(hamburgerIcon.getAttribute('aria-controls')).toEqual(narrowNavElement.getAttribute('id'));
+  });
+
+  it('should add correct aria-controls and id to narrowNav if narrowNavAriaControls is passed', () => {
+    component.isNarrowNavOpen = true;
+    component.narrowNavId = 'test_controls';
+    fixture.detectChanges();
+    narrowNavElement = fixture.nativeElement.querySelector('.sprk-c-Masthead__narrow-nav');
+    expect(narrowNavElement.getAttribute('id')).toEqual('test_controls');
+    expect(hamburgerIcon.getAttribute('aria-controls')).toEqual(narrowNavElement.getAttribute('id'));
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.spec.ts
@@ -195,7 +195,7 @@ describe('SprkMastheadComponent', () => {
     expect(spyOnResize).toHaveBeenCalled();
   });
 
-  it('should add aria-controls and id to narrowNav if narrowNavAriaControls is not passed', () => {
+  it('should add aria-controls and id to narrowNav if narrowNavId is not passed', () => {
     component.isNarrowNavOpen = true;
     fixture.detectChanges();
     narrowNavElement = fixture.nativeElement.querySelector('.sprk-c-Masthead__narrow-nav');
@@ -203,7 +203,7 @@ describe('SprkMastheadComponent', () => {
     expect(hamburgerIcon.getAttribute('aria-controls')).toEqual(narrowNavElement.getAttribute('id'));
   });
 
-  it('should add correct aria-controls and id to narrowNav if narrowNavAriaControls is passed', () => {
+  it('should add correct aria-controls and id to narrowNav if narrowNavId is passed', () => {
     component.isNarrowNavOpen = true;
     component.narrowNavId = 'test_controls';
     fixture.detectChanges();

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -28,7 +28,7 @@ import {
             type="button"
             [attr.aria-expanded]="isNarrowNavOpen ? true : false"
             (click)="toggleNarrowNav($event)"
-            data-sprk-mobile-nav-trigger="mobileNav"
+            [attr.aria-controls]="narrowNavAriaControls"
           >
             <span class="sprk-u-ScreenReaderText">Toggle Navigation</span>
             <svg
@@ -141,8 +141,8 @@ import {
       <nav
         *ngIf="isNarrowNavOpen"
         class="sprk-c-Masthead__narrow-nav"
-        data-sprk-mobile-nav="mobileNav"
         role="navigation"
+        [id]="narrowNavAriaControls"
       >
         <sprk-dropdown
           *ngIf="narrowSelector"
@@ -333,6 +333,12 @@ export class SprkMastheadComponent implements AfterContentInit {
    */
   @Input()
   narrowSelector: ISprkNarrowSelector;
+  /**
+   * A string that is used to set the aria-controls
+   * and associated id for the narrow navigation toggle.
+   */
+  @Input()
+  narrowNavAriaControls = _.uniqueId(`sprk_masthead_narrow_nav_content_`);
 
   /**
    * @ignore
@@ -588,5 +594,3 @@ export class SprkMastheadComponent implements AfterContentInit {
     this.isNarrowNavOpen = false;
   }
 }
-
-

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -334,7 +334,7 @@ export class SprkMastheadComponent implements AfterContentInit {
   @Input()
   narrowSelector: ISprkNarrowSelector;
   /**
-   * A string that is used to set the aria-controls
+   * A string that is used to set the `aria-controls`
    * and associated id for the narrow navigation toggle.
    */
   @Input()

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -334,8 +334,8 @@ export class SprkMastheadComponent implements AfterContentInit {
   @Input()
   narrowSelector: ISprkNarrowSelector;
   /**
-   * A string that is used to set the `aria-controls`
-   * and associated id for the narrow navigation toggle.
+   * A string that is used to set the `id` on the narrow nav
+   * and the `aria-controls` for the menu trigger button.
    */
   @Input()
   narrowNavId = _.uniqueId(`sprk_masthead_narrow_nav_`);

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.component.ts
@@ -28,7 +28,7 @@ import {
             type="button"
             [attr.aria-expanded]="isNarrowNavOpen ? true : false"
             (click)="toggleNarrowNav($event)"
-            [attr.aria-controls]="narrowNavAriaControls"
+            [attr.aria-controls]="narrowNavId"
           >
             <span class="sprk-u-ScreenReaderText">Toggle Navigation</span>
             <svg
@@ -142,7 +142,7 @@ import {
         *ngIf="isNarrowNavOpen"
         class="sprk-c-Masthead__narrow-nav"
         role="navigation"
-        [id]="narrowNavAriaControls"
+        [id]="narrowNavId"
       >
         <sprk-dropdown
           *ngIf="narrowSelector"
@@ -338,7 +338,7 @@ export class SprkMastheadComponent implements AfterContentInit {
    * and associated id for the narrow navigation toggle.
    */
   @Input()
-  narrowNavAriaControls = _.uniqueId(`sprk_masthead_narrow_nav_content_`);
+  narrowNavId = _.uniqueId(`sprk_masthead_narrow_nav_`);
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -91,51 +91,16 @@ describe('SprkToggleComponent', () => {
     expect(element.getAttribute('data-id')).toBeNull();
   });
 
-  it('should generate values if neither aria-controls nor id is present', () => {
-    triggerElement.removeAttribute('aria-controls');
-    contentElement.removeAttribute('id');
+  it('should add aria-controls and id if contentId is not passed', () => {
     fixture.detectChanges();
-
-    expect(triggerElement.hasAttribute('aria-controls')).toEqual(true);
-    expect(contentElement.hasAttribute('id')).toEqual(true);
+    expect(contentElement.getAttribute('id')).toMatch(/sprk_toggle_content_\d/);
     expect(triggerElement.getAttribute('aria-controls')).toEqual(contentElement.getAttribute('id'));
   });
 
-  it('should not change values if aria-controls is provided but id is missing', () => {
-    triggerElement.setAttribute('aria-controls', 'foo');
-    contentElement.removeAttribute('id');
+  it('should add correct aria-controls and id if contentId is passed', () => {
+    component.contentId = 'test_id';
     fixture.detectChanges();
-
-    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
-    expect(contentElement.hasAttribute('id')).toEqual(false);
-  });
-
-  it('should use the provided value when aria-controls is missing but id is present', () => {
-    triggerElement.removeAttribute('aria-controls');
-    contentElement.setAttribute('id', 'foo');
-    expect(triggerElement.hasAttribute('aria-controls')).toEqual(false);
-    fixture.detectChanges();
-
-    expect(triggerElement.hasAttribute('aria-controls')).toEqual(true);
-    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
-    expect(contentElement.getAttribute('id')).toEqual('foo');
-  });
-
-  it('should not change values if aria-controls and id are both present but have different values', () => {
-    triggerElement.setAttribute('aria-controls', 'foo');
-    contentElement.setAttribute('id', 'bar');
-    fixture.detectChanges();
-
-    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
-    expect(contentElement.getAttribute('id')).toEqual('bar');
-  });
-
-  it('should not change values if aria-controls and id are both present and have correct values', () => {
-    triggerElement.setAttribute('aria-controls', 'foo');
-    contentElement.setAttribute('id', 'foo');
-    fixture.detectChanges();
-
-    expect(triggerElement.getAttribute('aria-controls')).toEqual('foo');
-    expect(contentElement.getAttribute('id')).toEqual('foo');
+    expect(contentElement.getAttribute('id')).toEqual('test_id');
+    expect(triggerElement.getAttribute('aria-controls')).toEqual(contentElement.getAttribute('id'));
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, AfterViewInit, ElementRef, ViewChild, Renderer2 } from '@angular/core';
+import { Component, Input, AfterViewInit } from '@angular/core';
 import { toggleAnimations } from './sprk-toggle-animations';
 import { uniqueId } from 'lodash';
 import 'focus-visible';
@@ -16,7 +16,7 @@ import 'focus-visible';
         (click)="toggle($event)"
         [attr.aria-expanded]="isOpen ? 'true' : 'false'"
         [attr.data-analytics]="analyticsString"
-        #toggleTrigger
+        [attr.aria-controls]="contentId"
       >
         <sprk-icon
           iconType="chevron-down-circle-two-color"
@@ -29,7 +29,7 @@ import 'focus-visible';
 
       <div
         [@toggleContent]="animState"
-        #toggleContent
+        [id]="contentId"
       >
         <div class="sprk-u-pts sprk-u-pbs sprk-c-Toggle__content">
           <ng-content></ng-content>
@@ -40,9 +40,6 @@ import 'focus-visible';
   animations: [toggleAnimations.toggleContent]
 })
 export class SprkToggleComponent implements AfterViewInit {
-  constructor(private renderer: Renderer2, private el: ElementRef) {}
-  @ViewChild('toggleTrigger', { static: true }) toggleTrigger: ElementRef;
-  @ViewChild('toggleContent', { static: true }) toggleContent: ElementRef;
 
   /**
    * The value supplied will be assigned to the
@@ -89,6 +86,12 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   @Input()
   idString: string;
+  /**
+   * A string that is used to set the id on the content
+   * and the `aria-controls` for the toggle trigger button.
+   */
+  @Input()
+  contentId = uniqueId(`sprk_toggle_content_`);
 
   /**
    * @ignore
@@ -136,39 +139,7 @@ export class SprkToggleComponent implements AfterViewInit {
     return classArray.join(' ');
   }
 
-  /**
-   * @ignore
-   */
-  generateAriaControls(): void {
-    const triggerElement = this.toggleTrigger.nativeElement;
-    const contentElement = this.toggleContent.nativeElement;
-    const triggerAriaControls = triggerElement.getAttribute('aria-controls');
-    let contentId = contentElement.getAttribute('id');
-
-    // Warn if aria-controls exists but the id does not
-    if (triggerAriaControls && !contentId) {
-      console.warn(`Spark Design System Warning - The component with aria-controls="${triggerAriaControls}" expects a matching id on the content element.`);
-      return;
-    }
-
-    // Warn if aria-controls and id both exist but don't match
-    if (contentId && triggerAriaControls && contentId !== triggerAriaControls) {
-      console.warn(`Spark Design System Warning - The value of aria-controls ("${triggerAriaControls}") should match the id of the content element ("${contentId}").`);
-      return;
-    }
-
-    // If we don't have a valid id, generate one with lodash
-    if (!contentId) {
-      contentId = uniqueId(`sprk_toggle_content_`);
-      this.renderer.setAttribute(contentElement, 'id', contentId);
-    }
-
-    // set the value of aria-controls
-    this.renderer.setAttribute(triggerElement, 'aria-controls', contentId);
-  }
-
   ngAfterViewInit() {
     this.toggleState();
-    this.generateAriaControls();
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -87,7 +87,7 @@ export class SprkToggleComponent implements AfterViewInit {
   @Input()
   idString: string;
   /**
-   * A string that is used to set the id on the content
+   * A string that is used to set the `id` on the content
    * and the `aria-controls` for the toggle trigger button.
    */
   @Input()

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -35,7 +35,7 @@ class SprkToggle extends Component {
       titleAddClasses,
       iconAddClasses,
       toggleIconName,
-      ariaControls,
+      contentId,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
@@ -63,7 +63,7 @@ class SprkToggle extends Component {
           data-analytics={analyticsString}
           onClick={this.toggleOpen}
           aria-expanded={isOpen ? 'true' : 'false'}
-          aria-controls={ariaControls}
+          aria-controls={contentId}
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
           {title}
@@ -72,7 +72,7 @@ class SprkToggle extends Component {
           duration={300}
           height={height}
           className='sprk-c-Toggle__content'
-          id={ariaControls}
+          id={contentId}
         >
           <div>{children}</div>
         </AnimateHeight>
@@ -83,7 +83,7 @@ class SprkToggle extends Component {
 
 SprkToggle.defaultProps = {
   toggleIconName: 'chevron-down-circle-two-color',
-  ariaControls: uniqueId('sprk_toggle_content_'),
+  contentId: uniqueId('sprk_toggle_content_'),
 };
 
 SprkToggle.propTypes = {
@@ -113,8 +113,11 @@ SprkToggle.propTypes = {
   titleAddClasses: PropTypes.string,
   /** Additional classes for the toggle icon. */
   iconAddClasses: PropTypes.string,
-  /** A string that is used to set the aria-controls and associated id for the component. */
-  ariaControls: PropTypes.string,
+  /**
+   * A string that is used to set the `id` on the content
+   * and the `aria-controls` for the toggle trigger button.
+   */
+  contentId: PropTypes.string,
 };
 
 export default SprkToggle;

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -52,15 +52,15 @@ describe('SprkToggle:', () => {
     expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
   });
 
-  it('should add aria-controls="custom_control" and id="custom_control" when the ariaControls is passed', () => {
+  it('should add aria-controls="custom_control" and id="custom_control" when the contentId is passed', () => {
     const wrapper = mount(
-      <SprkToggle title="Toggle title" ariaControls="custom_control">Body text</SprkToggle>,
+      <SprkToggle title="Toggle title" contentId="custom_control">Body text</SprkToggle>,
     );
     expect(wrapper.find('[aria-controls="custom_control"]').length).toBe(1);
     expect(wrapper.find('div#custom_control').length).toBe(1);
   });
 
-  it('should add aria-controls and id when the ariaControls is not passed', () => {
+  it('should add aria-controls and id when the contentId is not passed', () => {
     const wrapper = mount(
       <SprkToggle title="Toggle title">Body text</SprkToggle>,
     );


### PR DESCRIPTION
## What does this PR do?
- [x] Add an input for the Angular Masthead for the narrow nav toggle that adds aria-controls and id
- [x] Update tests for new input
- [x] Add an input for the Angular Toggle that adds aria-controls and id
- [x] Update tests for new input
- [x] Update `SprkToggle` for React 

### Associated Issue
Fixes #2948 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)

### Screenshots
Coverage before:
![image](https://user-images.githubusercontent.com/15703773/79001556-a83b9800-7b1c-11ea-89eb-cb42b2d21e52.png)

Coverage after:
![image](https://user-images.githubusercontent.com/15703773/79012811-34f25000-7b35-11ea-9a8a-998eda21bc81.png)
