### PR TITLE
HTML Masthead Accordion

### DIFF
--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -249,8 +249,7 @@ export const defaultStory = () => {
             class="sprk-c-MastheadAccordion__item"
             data-sprk-toggle="container"
           >
-            <a
-              aria-controls="details1"
+            <button
               class="sprk-c-MastheadAccordion__summary"
               data-sprk-toggle="trigger"
               data-sprk-toggle-type="masthead-accordion"
@@ -276,10 +275,9 @@ export const defaultStory = () => {
               >
                 <use xlink:href="#chevron-down"></use>
               </svg>
-            </a>
+            </button>
 
             <ul
-              id="details1"
               class="
                 sprk-b-List
                 sprk-b-List--bare
@@ -1039,8 +1037,7 @@ export const extended = () => {
             class="sprk-c-MastheadAccordion__item"
             data-sprk-toggle="container"
           >
-            <a
-              aria-controls="details1"
+            <button
               class="sprk-c-MastheadAccordion__summary"
               data-sprk-toggle="trigger"
               data-sprk-toggle-type="masthead-accordion"
@@ -1064,10 +1061,9 @@ export const extended = () => {
               >
                 <use xlink:href="#chevron-down"></use>
               </svg>
-            </a>
+            </button>
 
             <ul
-              id="details1"
               class="
                 sprk-b-List
                 sprk-b-List--bare

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -253,7 +253,6 @@ export const defaultStory = () => {
               class="sprk-c-MastheadAccordion__summary"
               data-sprk-toggle="trigger"
               data-sprk-toggle-type="masthead-accordion"
-              href="#nogo"
             >
               <span
                 class="
@@ -1041,7 +1040,6 @@ export const extended = () => {
               class="sprk-c-MastheadAccordion__summary"
               data-sprk-toggle="trigger"
               data-sprk-toggle-type="masthead-accordion"
-              href="#nogo"
               aria-expanded="false"
             >
               <span class="sprk-c-MastheadAccordion__heading">


### PR DESCRIPTION
## What does this PR do?
- In the HTML Masthead stories, change `<a>` to `<button>` for the masthead accordion summary examples.
- Remove `aria-controls` from these nodes so those values will be auto-generated by `toggle.js`
- Note: all behavior and tests for `aria-controls` and `aria-expanded` on the accordions are part of the HTML Toggle component, not the HTML Masthead.

### Associated Issue
Fixes https://github.com/sparkdesignsystem/spark-design-system/issues/3045

### Code
 - [X] Build Component in HTML
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
