### PR TITLE
Add max-width: 100% utility and inputs modifier

### DIFF
--- a/html/base/inputs/_input-container.scss
+++ b/html/base/inputs/_input-container.scss
@@ -12,6 +12,11 @@
   position: relative;
 }
 
+/// Increases the max-width of the input container to 100%.
+.sprk-b-InputContainer--full {
+  max-width: $sprk-input-max-width-full;
+}
+
 .sprk-b-InputContainer__visibility-toggle {
   margin: $sprk-visibility-control-margin;
 }

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -813,6 +813,9 @@ $sprk-input-container-margin: 0 0 $sprk-space-l 0 !default;
 $sprk-input-container-narrow-max-width: 6.5rem !default;
 /// The value used as a maximum width for Input containers.
 $sprk-input-max-width: 27.5rem !default;
+/// The value used for the maximum width of an Input
+/// container using the .sprk-b-InputContainer--full modifier.
+$sprk-input-max-width-full: 100% !default;
 
 //
 // Huge Inputs

--- a/html/utilities/_utilities.scss
+++ b/html/utilities/_utilities.scss
@@ -151,6 +151,16 @@
   height: 100% !important;
 }
 
+//
+// Width
+///
+
+/// Changes the max-width of the element to 100 percent.
+/// @group width
+.sprk-u-MaxWidth--100 {
+  max-width: 100% !important;
+}
+
 /* stylelint-enable selector-class-pattern */
 
 //

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -76,7 +76,7 @@ const date = new Date();
 const year = date.getFullYear();
 const paragraphs = [
   {
-    text: `©2000 – ${year} Quicken Loans Inc. All rights reserved.`,
+    text: `©2000 – ${year} Quicken Loans LLC. All rights reserved.`,
   },
 ];
 

--- a/src/data/sass-modifiers.json
+++ b/src/data/sass-modifiers.json
@@ -1794,12 +1794,12 @@
   {
     "description": "Turns off the display of an element so that it has no effect on layout.\n",
     "commentRange": {
-      "start": 22,
-      "end": 24
+      "start": 18,
+      "end": 20
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-Display--none",
+      "name": ".sprk-u-JavaScript, .sprk-u-HideWhenJs",
       "value": "display: none !important;",
       "line": {
         "start": 26,
@@ -1818,12 +1818,12 @@
   {
     "description": "Turns off the display of an element so that it has no effect on layout.\n",
     "commentRange": {
-      "start": 18,
-      "end": 20
+      "start": 22,
+      "end": 24
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-JavaScript, .sprk-u-HideWhenJs",
+      "name": ".sprk-u-Display--none",
       "value": "display: none !important;",
       "line": {
         "start": 26,
@@ -2430,14 +2430,14 @@
     }
   },
   {
-    "description": "Adds the styles for the Stacked Highlight Board variant.\n",
+    "description": "A Spark utility class that can be used on\nthe Highlight Board to make it become 100% width.\n",
     "commentRange": {
-      "start": 49,
-      "end": 50
+      "start": 52,
+      "end": 54
     },
     "context": {
       "type": "css",
-      "name": ".sprk-c-HighlightBoard--stacked",
+      "name": ".sprk-u-FullWidth",
       "value": "position: absolute;\n  bottom: $sprk-space-l;\n  left: $sprk-space-l;\n  max-width: $sprk-highlight-board-content-width;\n  right: $sprk-space-l;\n  text-align: left;",
       "line": {
         "start": 59,
@@ -2454,14 +2454,14 @@
     }
   },
   {
-    "description": "A Spark utility class that can be used on\nthe Highlight Board to make it become 100% width.\n",
+    "description": "Adds the styles for the Stacked Highlight Board variant.\n",
     "commentRange": {
-      "start": 52,
-      "end": 54
+      "start": 49,
+      "end": 50
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-FullWidth",
+      "name": ".sprk-c-HighlightBoard--stacked",
       "value": "position: absolute;\n  bottom: $sprk-space-l;\n  left: $sprk-space-l;\n  max-width: $sprk-highlight-board-content-width;\n  right: $sprk-space-l;\n  text-align: left;",
       "line": {
         "start": 59,
@@ -2694,18 +2694,42 @@
     }
   },
   {
+    "description": "Increases the max-width of the input container to 100%.\n",
+    "commentRange": {
+      "start": 15,
+      "end": 15
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-b-InputContainer--full",
+      "value": "max-width: $sprk-input-max-width-full;",
+      "line": {
+        "start": 16,
+        "end": 366
+      }
+    },
+    "group": [
+      "input"
+    ],
+    "access": "public",
+    "file": {
+      "path": "base/inputs/_input-container.scss",
+      "name": "_input-container.scss"
+    }
+  },
+  {
     "description": "Trigger the floating label state on huge inputs.\n",
     "commentRange": {
-      "start": 48,
-      "end": 49
+      "start": 53,
+      "end": 54
     },
     "context": {
       "type": "css",
       "name": ".sprk-b-Input--has-floating-label",
       "value": "font-size: $sprk-input-huge-font-size;",
       "line": {
-        "start": 57,
-        "end": 361
+        "start": 62,
+        "end": 366
       }
     },
     "group": [
@@ -2720,16 +2744,16 @@
   {
     "description": "Adjust styling and hide label on huge inputs.\n",
     "commentRange": {
-      "start": 105,
-      "end": 106
+      "start": 110,
+      "end": 111
     },
     "context": {
       "type": "css",
       "name": ".sprk-b-TextInput--label-hidden",
       "value": "opacity: $sprk-input-huge-placeholder-active-opacity;\n  transition-delay: $sprk-input-huge-placeholder-transition-delay;\n  transition-property: $sprk-input-huge-placeholder-transition-property;",
       "line": {
-        "start": 119,
-        "end": 361
+        "start": 124,
+        "end": 366
       }
     },
     "group": [
@@ -3222,6 +3246,30 @@
     }
   },
   {
+    "description": "Sets the margin on all sides to the current value\nof `$sprk-space-misc-d` (`80px`).\n",
+    "commentRange": {
+      "start": 570,
+      "end": 573
+    },
+    "context": {
+      "type": "css",
+      "name": "sprk-u-MarginAll--d",
+      "value": "padding-top: $sprk-space-misc-a !important;",
+      "line": {
+        "start": 579,
+        "end": 839
+      }
+    },
+    "group": [
+      "misc-spacing"
+    ],
+    "access": "public",
+    "file": {
+      "path": "utilities/_utilities.scss",
+      "name": "_utilities.scss"
+    }
+  },
+  {
     "description": "Sets the padding on the left and right (horizontal)\nto `$sprk-space-misc-b` (`40px`).\n",
     "commentRange": {
       "start": 565,
@@ -3254,30 +3302,6 @@
     "context": {
       "type": "css",
       "name": "sprk-u-MarginBottom--a",
-      "value": "padding-top: $sprk-space-misc-a !important;",
-      "line": {
-        "start": 579,
-        "end": 839
-      }
-    },
-    "group": [
-      "misc-spacing"
-    ],
-    "access": "public",
-    "file": {
-      "path": "utilities/_utilities.scss",
-      "name": "_utilities.scss"
-    }
-  },
-  {
-    "description": "Sets the margin on all sides to the current value\nof `$sprk-space-misc-d` (`80px`).\n",
-    "commentRange": {
-      "start": 570,
-      "end": 573
-    },
-    "context": {
-      "type": "css",
-      "name": "sprk-u-MarginAll--d",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
         "start": 579,
@@ -4554,30 +4578,6 @@
     }
   },
   {
-    "description": "When placed on an item, its width will be 3/10\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 333,
-      "end": 336
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--three-tenths@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
     "description": "When placed on an item, its width will be 1/4\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
       "start": 303,
@@ -4586,30 +4586,6 @@
     "context": {
       "type": "css",
       "name": ".sprk-o-Stack__item--fourth@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "When placed on an item, its width will be 1/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 298,
-      "end": 301
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--fifth@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -4650,38 +4626,14 @@
     }
   },
   {
-    "description": "When placed on an item, its width will be 2/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "description": "of its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
-      "start": 323,
-      "end": 326
+      "start": 309,
+      "end": 311
     },
     "context": {
       "type": "css",
-      "name": ".sprk-o-Stack__item--two-fifths@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "When placed on an item, its width will be 3/4\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 318,
-      "end": 321
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--three-fourths@xxs",
+      "name": ".sprk-o-Stack__item--third@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -4722,14 +4674,62 @@
     }
   },
   {
-    "description": "of its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "description": "When placed on an item, its width will be 3/4\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
-      "start": 309,
-      "end": 311
+      "start": 318,
+      "end": 321
     },
     "context": {
       "type": "css",
-      "name": ".sprk-o-Stack__item--third@xxs",
+      "name": ".sprk-o-Stack__item--three-fourths@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 2/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 323,
+      "end": 326
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--two-fifths@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 1/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 298,
+      "end": 301
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--fifth@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -4754,6 +4754,30 @@
     "context": {
       "type": "css",
       "name": ".sprk-o-Stack__item--three-fifths@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 3/10\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 333,
+      "end": 336
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--three-tenths@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -5178,14 +5202,14 @@
     }
   },
   {
-    "description": "Adds the needed styles for\nwhen the Stepper has\na dark background color.\n",
+    "description": "Adds the selected styles to the step that\nis selected.\n",
     "commentRange": {
-      "start": 48,
-      "end": 50
+      "start": 44,
+      "end": 46
     },
     "context": {
       "type": "css",
-      "name": ".sprk-c-Stepper--has-dark-bg",
+      "name": ".sprk-c-Stepper__step--selected",
       "value": ".sprk-c-Stepper__step-heading,\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-heading {\n    color: $sprk-stepper-dark-step-heading-color;\n  }\n\n  .sprk-c-Stepper__step::before {\n    background-color: $sprk-stepper-dark-bar-color;\n  }\n\n  .sprk-c-Stepper__step-icon {\n    background-color: $sprk-stepper-dark-icon-color;\n    border-color: $sprk-stepper-dark-icon-border-color;\n  }\n\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-content--has-description\n  .sprk-c-Stepper__step-heading {\n    color: $sprk-stepper-dark-step-description-selected;\n  }\n\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-icon,\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-header:hover\n  .sprk-c-Stepper__step-icon {\n    background-color: $sprk-stepper-dark-icon-color-selected;\n  }\n\n  .sprk-c-Stepper__step-header:hover\n  .sprk-c-Stepper__step-icon {\n    background-color: $sprk-stepper-dark-icon-color-hover;\n  }\n\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-content--hidden {\n    background-color: transparent;\n    box-shadow: none;\n  }",
       "line": {
         "start": 51,
@@ -5202,14 +5226,14 @@
     }
   },
   {
-    "description": "Adds the selected styles to the step that\nis selected.\n",
+    "description": "Adds the needed styles for\nwhen the Stepper has\na dark background color.\n",
     "commentRange": {
-      "start": 44,
-      "end": 46
+      "start": 48,
+      "end": 50
     },
     "context": {
       "type": "css",
-      "name": ".sprk-c-Stepper__step--selected",
+      "name": ".sprk-c-Stepper--has-dark-bg",
       "value": ".sprk-c-Stepper__step-heading,\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-heading {\n    color: $sprk-stepper-dark-step-heading-color;\n  }\n\n  .sprk-c-Stepper__step::before {\n    background-color: $sprk-stepper-dark-bar-color;\n  }\n\n  .sprk-c-Stepper__step-icon {\n    background-color: $sprk-stepper-dark-icon-color;\n    border-color: $sprk-stepper-dark-icon-border-color;\n  }\n\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-content--has-description\n  .sprk-c-Stepper__step-heading {\n    color: $sprk-stepper-dark-step-description-selected;\n  }\n\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-icon,\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-header:hover\n  .sprk-c-Stepper__step-icon {\n    background-color: $sprk-stepper-dark-icon-color-selected;\n  }\n\n  .sprk-c-Stepper__step-header:hover\n  .sprk-c-Stepper__step-icon {\n    background-color: $sprk-stepper-dark-icon-color-hover;\n  }\n\n  .sprk-c-Stepper__step--selected\n  .sprk-c-Stepper__step-content--hidden {\n    background-color: transparent;\n    box-shadow: none;\n  }",
       "line": {
         "start": 51,
@@ -6164,12 +6188,12 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 10,
-      "end": 10
+      "start": 15,
+      "end": 15
     },
     "context": {
       "type": "css",
-      "name": "//\n// Inheriting box-sizing Probably Slightly Better Best-Practice\n// http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice\n///\nhtml",
+      "name": "html",
       "value": "box-sizing: border-box;",
       "line": {
         "start": 16,
@@ -6188,12 +6212,12 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 15,
-      "end": 15
+      "start": 10,
+      "end": 10
     },
     "context": {
       "type": "css",
-      "name": "html",
+      "name": "//\n// Inheriting box-sizing Probably Slightly Better Best-Practice\n// http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice\n///\nhtml",
       "value": "box-sizing: border-box;",
       "line": {
         "start": 16,
@@ -13722,19 +13746,19 @@
     }
   },
   {
-    "description": "The max-width setting for Huge Inputs.\n",
+    "description": "The value used for the maximum width of an Input\ncontainer using the .sprk-b-InputContainer--full modifier.\n",
     "commentRange": {
-      "start": 821,
-      "end": 821
+      "start": 816,
+      "end": 817
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-container-huge-max-width",
-      "value": "37.5rem",
+      "name": "sprk-input-max-width-full",
+      "value": "100%",
       "scope": "default",
       "line": {
-        "start": 822,
-        "end": 822
+        "start": 818,
+        "end": 818
       }
     },
     "access": "public",
@@ -13747,15 +13771,15 @@
     }
   },
   {
-    "description": "The height value for Huge Inputs.\n",
+    "description": "The max-width setting for Huge Inputs.\n",
     "commentRange": {
       "start": 824,
       "end": 824
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-height",
-      "value": "$sprk-text-input-huge-height",
+      "name": "sprk-input-container-huge-max-width",
+      "value": "37.5rem",
       "scope": "default",
       "line": {
         "start": 825,
@@ -13772,15 +13796,15 @@
     }
   },
   {
-    "description": "The font size for Huge Inputs.\n",
+    "description": "The height value for Huge Inputs.\n",
     "commentRange": {
       "start": 827,
       "end": 827
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-font-size",
-      "value": "$sprk-text-input-huge-font-size",
+      "name": "sprk-input-huge-height",
+      "value": "$sprk-text-input-huge-height",
       "scope": "default",
       "line": {
         "start": 828,
@@ -13797,15 +13821,15 @@
     }
   },
   {
-    "description": "The label font size for Huge Inputs.\n",
+    "description": "The font size for Huge Inputs.\n",
     "commentRange": {
       "start": 830,
       "end": 830
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-label-font-size",
-      "value": "$sprk-text-input-huge-label-font-size",
+      "name": "sprk-input-huge-font-size",
+      "value": "$sprk-text-input-huge-font-size",
       "scope": "default",
       "line": {
         "start": 831,
@@ -13822,15 +13846,15 @@
     }
   },
   {
-    "description": "The border width for Huge Inputs.\n",
+    "description": "The label font size for Huge Inputs.\n",
     "commentRange": {
       "start": 833,
       "end": 833
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-border-width",
-      "value": "$sprk-text-input-huge-border-width",
+      "name": "sprk-input-huge-label-font-size",
+      "value": "$sprk-text-input-huge-label-font-size",
       "scope": "default",
       "line": {
         "start": 834,
@@ -13847,15 +13871,15 @@
     }
   },
   {
-    "description": "The padding for Huge Inputs.\n",
+    "description": "The border width for Huge Inputs.\n",
     "commentRange": {
       "start": 836,
       "end": 836
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-padding",
-      "value": "$sprk-text-input-huge-padding",
+      "name": "sprk-input-huge-border-width",
+      "value": "$sprk-text-input-huge-border-width",
       "scope": "default",
       "line": {
         "start": 837,
@@ -13872,10 +13896,35 @@
     }
   },
   {
+    "description": "The padding for Huge Inputs.\n",
+    "commentRange": {
+      "start": 839,
+      "end": 839
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-input-huge-padding",
+      "value": "$sprk-text-input-huge-padding",
+      "scope": "default",
+      "line": {
+        "start": 840,
+        "end": 840
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
     "description": "The padding right value for Huge Inputs.\n",
     "commentRange": {
-      "start": 838,
-      "end": 838
+      "start": 841,
+      "end": 841
     },
     "context": {
       "type": "variable",
@@ -13883,8 +13932,8 @@
       "value": "45px",
       "scope": "default",
       "line": {
-        "start": 839,
-        "end": 839
+        "start": 842,
+        "end": 842
       }
     },
     "access": "public",
@@ -13899,8 +13948,8 @@
   {
     "description": "The label padding value for Huge Inputs.\n",
     "commentRange": {
-      "start": 840,
-      "end": 840
+      "start": 843,
+      "end": 843
     },
     "context": {
       "type": "variable",
@@ -13908,8 +13957,8 @@
       "value": "0\n  ($sprk-space-misc-a + $sprk-input-huge-border-width)",
       "scope": "default",
       "line": {
-        "start": 841,
-        "end": 842
+        "start": 844,
+        "end": 845
       }
     },
     "access": "public",
@@ -13924,38 +13973,13 @@
   {
     "description": "The border width for Huge Inputs on focus.\n",
     "commentRange": {
-      "start": 844,
-      "end": 844
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-input-huge-focus-border-width",
-      "value": "$sprk-text-input-huge-focus-border-width",
-      "scope": "default",
-      "line": {
-        "start": 845,
-        "end": 845
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The transition value for Huge Inputs.\n",
-    "commentRange": {
       "start": 847,
       "end": 847
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-transition",
-      "value": "$sprk-text-input-huge-transition",
+      "name": "sprk-input-huge-focus-border-width",
+      "value": "$sprk-text-input-huge-focus-border-width",
       "scope": "default",
       "line": {
         "start": 848,
@@ -13972,15 +13996,15 @@
     }
   },
   {
-    "description": "The transition delay value for Huge Inputs.\n",
+    "description": "The transition value for Huge Inputs.\n",
     "commentRange": {
       "start": 850,
       "end": 850
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-transition-delay",
-      "value": "$sprk-text-input-huge-transition-delay",
+      "name": "sprk-input-huge-transition",
+      "value": "$sprk-text-input-huge-transition",
       "scope": "default",
       "line": {
         "start": 851,
@@ -13997,15 +14021,15 @@
     }
   },
   {
-    "description": "The transition placeholder delay value for Huge Inputs.\n",
+    "description": "The transition delay value for Huge Inputs.\n",
     "commentRange": {
       "start": 853,
       "end": 853
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-placeholder-transition-delay",
-      "value": "$sprk-text-input-huge-placeholder-transition-delay",
+      "name": "sprk-input-huge-transition-delay",
+      "value": "$sprk-text-input-huge-transition-delay",
       "scope": "default",
       "line": {
         "start": 854,
@@ -14022,15 +14046,15 @@
     }
   },
   {
-    "description": "The transition placeholder value for Huge Inputs.\n",
+    "description": "The transition placeholder delay value for Huge Inputs.\n",
     "commentRange": {
       "start": 856,
       "end": 856
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-placeholder-transition-property",
-      "value": "$sprk-text-input-huge-placeholder-transition-property",
+      "name": "sprk-input-huge-placeholder-transition-delay",
+      "value": "$sprk-text-input-huge-placeholder-transition-delay",
       "scope": "default",
       "line": {
         "start": 857,
@@ -14047,15 +14071,15 @@
     }
   },
   {
-    "description": "The placeholder opacity for Huge Inputs.\n",
+    "description": "The transition placeholder value for Huge Inputs.\n",
     "commentRange": {
       "start": 859,
       "end": 859
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-placeholder-opacity",
-      "value": "$sprk-text-input-huge-placeholder-opacity",
+      "name": "sprk-input-huge-placeholder-transition-property",
+      "value": "$sprk-text-input-huge-placeholder-transition-property",
       "scope": "default",
       "line": {
         "start": 860,
@@ -14072,15 +14096,15 @@
     }
   },
   {
-    "description": "The placeholder opacity for Huge Inputs when they are active.\n",
+    "description": "The placeholder opacity for Huge Inputs.\n",
     "commentRange": {
       "start": 862,
       "end": 862
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-placeholder-active-opacity",
-      "value": "$sprk-text-input-huge-placeholder-active-opacity",
+      "name": "sprk-input-huge-placeholder-opacity",
+      "value": "$sprk-text-input-huge-placeholder-opacity",
       "scope": "default",
       "line": {
         "start": 863,
@@ -14097,10 +14121,35 @@
     }
   },
   {
-    "description": "The top value for Huge Input labels.\nThis adjusts how far the label is from the top of the container.\n",
+    "description": "The placeholder opacity for Huge Inputs when they are active.\n",
     "commentRange": {
       "start": 865,
-      "end": 866
+      "end": 865
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-input-huge-placeholder-active-opacity",
+      "value": "$sprk-text-input-huge-placeholder-active-opacity",
+      "scope": "default",
+      "line": {
+        "start": 866,
+        "end": 866
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The top value for Huge Input labels.\nThis adjusts how far the label is from the top of the container.\n",
+    "commentRange": {
+      "start": 868,
+      "end": 869
     },
     "context": {
       "type": "variable",
@@ -14108,8 +14157,8 @@
       "value": "$sprk-text-input-huge-label-top",
       "scope": "default",
       "line": {
-        "start": 867,
-        "end": 867
+        "start": 870,
+        "end": 870
       }
     },
     "access": "public",
@@ -14124,38 +14173,13 @@
   {
     "description": "The top value for Huge Input labels when they are active.\nThis adjusts how far the label is from the top of the container.\n",
     "commentRange": {
-      "start": 869,
-      "end": 870
+      "start": 872,
+      "end": 873
     },
     "context": {
       "type": "variable",
       "name": "sprk-input-huge-label-active-top",
       "value": "$sprk-text-input-huge-label-active-top",
-      "scope": "default",
-      "line": {
-        "start": 871,
-        "end": 871
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding top value of active Huge Inputs.\n",
-    "commentRange": {
-      "start": 873,
-      "end": 873
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-input-huge-active-padding-top",
-      "value": "$sprk-text-input-huge-active-padding-top",
       "scope": "default",
       "line": {
         "start": 874,
@@ -14172,15 +14196,15 @@
     }
   },
   {
-    "description": "The label color value of Huge Inputs on focus.\n",
+    "description": "The padding top value of active Huge Inputs.\n",
     "commentRange": {
       "start": 876,
       "end": 876
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-focus-label-color",
-      "value": "$sprk-text-input-huge-focus-label-color",
+      "name": "sprk-input-huge-active-padding-top",
+      "value": "$sprk-text-input-huge-active-padding-top",
       "scope": "default",
       "line": {
         "start": 877,
@@ -14197,15 +14221,15 @@
     }
   },
   {
-    "description": "The label color value of Huge Inputs when they have an error.\n",
+    "description": "The label color value of Huge Inputs on focus.\n",
     "commentRange": {
       "start": 879,
       "end": 879
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-error-focus-label-color",
-      "value": "$sprk-text-input-huge-error-focus-label-color",
+      "name": "sprk-input-huge-focus-label-color",
+      "value": "$sprk-text-input-huge-focus-label-color",
       "scope": "default",
       "line": {
         "start": 880,
@@ -14222,10 +14246,35 @@
     }
   },
   {
-    "description": "The label color when the Huge Input has a value\nand is not focused.\n",
+    "description": "The label color value of Huge Inputs when they have an error.\n",
     "commentRange": {
       "start": 882,
-      "end": 883
+      "end": 882
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-input-huge-error-focus-label-color",
+      "value": "$sprk-text-input-huge-error-focus-label-color",
+      "scope": "default",
+      "line": {
+        "start": 883,
+        "end": 883
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The label color when the Huge Input has a value\nand is not focused.\n",
+    "commentRange": {
+      "start": 885,
+      "end": 886
     },
     "context": {
       "type": "variable",
@@ -14233,8 +14282,8 @@
       "value": "$sprk-text-input-huge-complete-label-color",
       "scope": "default",
       "line": {
-        "start": 884,
-        "end": 884
+        "start": 887,
+        "end": 887
       }
     },
     "access": "public",
@@ -14249,8 +14298,8 @@
   {
     "description": "The box shadow value on Huge Inputs.\n",
     "commentRange": {
-      "start": 885,
-      "end": 885
+      "start": 888,
+      "end": 888
     },
     "context": {
       "type": "variable",
@@ -14258,8 +14307,8 @@
       "value": "0 3px 10px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
-        "start": 886,
-        "end": 886
+        "start": 889,
+        "end": 889
       }
     },
     "access": "public",
@@ -14274,8 +14323,8 @@
   {
     "description": "The margin-top value for icons in Huge Inputs.\n",
     "commentRange": {
-      "start": 887,
-      "end": 887
+      "start": 890,
+      "end": 890
     },
     "context": {
       "type": "variable",
@@ -14283,8 +14332,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 888,
-        "end": 888
+        "start": 891,
+        "end": 891
       }
     },
     "access": "public",
@@ -14299,8 +14348,8 @@
   {
     "description": "The top value for icons in Huge Inputs.\n",
     "commentRange": {
-      "start": 889,
-      "end": 889
+      "start": 892,
+      "end": 892
     },
     "context": {
       "type": "variable",
@@ -14308,8 +14357,8 @@
       "value": "50%",
       "scope": "default",
       "line": {
-        "start": 890,
-        "end": 890
+        "start": 893,
+        "end": 893
       }
     },
     "access": "public",
@@ -14324,8 +14373,8 @@
   {
     "description": "The margin-top value for icons in Huge Select Inputs.\n",
     "commentRange": {
-      "start": 891,
-      "end": 891
+      "start": 894,
+      "end": 894
     },
     "context": {
       "type": "variable",
@@ -14333,8 +14382,8 @@
       "value": "-((\n  $sprk-input-huge-height - $sprk-icon-m\n) / 2 + $sprk-icon-m)",
       "scope": "default",
       "line": {
-        "start": 892,
-        "end": 894
+        "start": 895,
+        "end": 897
       }
     },
     "access": "public",
@@ -14349,8 +14398,8 @@
   {
     "description": "The padding value for Huge Inputs with icons.\n",
     "commentRange": {
-      "start": 895,
-      "end": 895
+      "start": 898,
+      "end": 898
     },
     "context": {
       "type": "variable",
@@ -14358,8 +14407,8 @@
       "value": "0 40px",
       "scope": "default",
       "line": {
-        "start": 896,
-        "end": 896
+        "start": 899,
+        "end": 899
       }
     },
     "access": "public",
@@ -14374,8 +14423,8 @@
   {
     "description": "The font family for Inputs.\n",
     "commentRange": {
-      "start": 902,
-      "end": 902
+      "start": 905,
+      "end": 905
     },
     "context": {
       "type": "variable",
@@ -14383,8 +14432,8 @@
       "value": "$sprk-font-family-body-two",
       "scope": "default",
       "line": {
-        "start": 903,
-        "end": 903
+        "start": 906,
+        "end": 906
       }
     },
     "access": "public",
@@ -14399,8 +14448,8 @@
   {
     "description": "The font size for Inputs.\n",
     "commentRange": {
-      "start": 904,
-      "end": 904
+      "start": 907,
+      "end": 907
     },
     "context": {
       "type": "variable",
@@ -14408,8 +14457,8 @@
       "value": "1rem",
       "scope": "default",
       "line": {
-        "start": 905,
-        "end": 905
+        "start": 908,
+        "end": 908
       }
     },
     "access": "public",
@@ -14424,8 +14473,8 @@
   {
     "description": "The font weight for Inputs.\n",
     "commentRange": {
-      "start": 906,
-      "end": 906
+      "start": 909,
+      "end": 909
     },
     "context": {
       "type": "variable",
@@ -14433,8 +14482,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 907,
-        "end": 907
+        "start": 910,
+        "end": 910
       }
     },
     "access": "public",
@@ -14449,8 +14498,8 @@
   {
     "description": "The height setting for Inputs.\n",
     "commentRange": {
-      "start": 908,
-      "end": 908
+      "start": 911,
+      "end": 911
     },
     "context": {
       "type": "variable",
@@ -14458,8 +14507,8 @@
       "value": "48px",
       "scope": "default",
       "line": {
-        "start": 909,
-        "end": 909
+        "start": 912,
+        "end": 912
       }
     },
     "access": "public",
@@ -14474,8 +14523,8 @@
   {
     "description": "The line height setting for Inputs.\n",
     "commentRange": {
-      "start": 910,
-      "end": 910
+      "start": 913,
+      "end": 913
     },
     "context": {
       "type": "variable",
@@ -14483,8 +14532,8 @@
       "value": "1.3",
       "scope": "default",
       "line": {
-        "start": 911,
-        "end": 911
+        "start": 914,
+        "end": 914
       }
     },
     "access": "public",
@@ -14499,8 +14548,8 @@
   {
     "description": "The outline setting for Inputs.\n",
     "commentRange": {
-      "start": 912,
-      "end": 912
+      "start": 915,
+      "end": 915
     },
     "context": {
       "type": "variable",
@@ -14508,8 +14557,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 913,
-        "end": 913
+        "start": 916,
+        "end": 916
       }
     },
     "access": "public",
@@ -14524,8 +14573,8 @@
   {
     "description": "The color setting for Inputs.\n",
     "commentRange": {
-      "start": 914,
-      "end": 914
+      "start": 917,
+      "end": 917
     },
     "context": {
       "type": "variable",
@@ -14533,8 +14582,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 915,
-        "end": 915
+        "start": 918,
+        "end": 918
       }
     },
     "access": "public",
@@ -14549,8 +14598,8 @@
   {
     "description": "The border setting for Inputs.\n",
     "commentRange": {
-      "start": 916,
-      "end": 916
+      "start": 919,
+      "end": 919
     },
     "context": {
       "type": "variable",
@@ -14558,8 +14607,8 @@
       "value": "2px solid $sprk-gray-dark",
       "scope": "default",
       "line": {
-        "start": 917,
-        "end": 917
+        "start": 920,
+        "end": 920
       }
     },
     "access": "public",
@@ -14574,8 +14623,8 @@
   {
     "description": "The border radius for Inputs.\n",
     "commentRange": {
-      "start": 918,
-      "end": 918
+      "start": 921,
+      "end": 921
     },
     "context": {
       "type": "variable",
@@ -14583,8 +14632,8 @@
       "value": "4px",
       "scope": "default",
       "line": {
-        "start": 919,
-        "end": 919
+        "start": 922,
+        "end": 922
       }
     },
     "access": "public",
@@ -14599,8 +14648,8 @@
   {
     "description": "The box shadow for Inputs.\n",
     "commentRange": {
-      "start": 920,
-      "end": 920
+      "start": 923,
+      "end": 923
     },
     "context": {
       "type": "variable",
@@ -14608,8 +14657,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 921,
-        "end": 921
+        "start": 924,
+        "end": 924
       }
     },
     "access": "public",
@@ -14624,8 +14673,8 @@
   {
     "description": "The padding for Inputs.\n",
     "commentRange": {
-      "start": 922,
-      "end": 922
+      "start": 925,
+      "end": 925
     },
     "context": {
       "type": "variable",
@@ -14633,8 +14682,8 @@
       "value": "0 $sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 923,
-        "end": 923
+        "start": 926,
+        "end": 926
       }
     },
     "access": "public",
@@ -14649,8 +14698,8 @@
   {
     "description": "The border color on Inputs when focused.\n",
     "commentRange": {
-      "start": 924,
-      "end": 924
+      "start": 927,
+      "end": 927
     },
     "context": {
       "type": "variable",
@@ -14658,8 +14707,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 925,
-        "end": 925
+        "start": 928,
+        "end": 928
       }
     },
     "access": "public",
@@ -14674,8 +14723,8 @@
   {
     "description": "The border color on Inputs when there is an error.\n",
     "commentRange": {
-      "start": 926,
-      "end": 926
+      "start": 929,
+      "end": 929
     },
     "context": {
       "type": "variable",
@@ -14683,8 +14732,8 @@
       "value": "$sprk-yellow",
       "scope": "default",
       "line": {
-        "start": 927,
-        "end": 927
+        "start": 930,
+        "end": 930
       }
     },
     "access": "public",
@@ -14699,8 +14748,8 @@
   {
     "description": "The border color on disabled Inputs.\n",
     "commentRange": {
-      "start": 928,
-      "end": 928
+      "start": 931,
+      "end": 931
     },
     "context": {
       "type": "variable",
@@ -14708,8 +14757,8 @@
       "value": "$sprk-gray-dark",
       "scope": "default",
       "line": {
-        "start": 929,
-        "end": 929
+        "start": 932,
+        "end": 932
       }
     },
     "access": "public",
@@ -14724,8 +14773,8 @@
   {
     "description": "The background color on disabled Inputs.\n",
     "commentRange": {
-      "start": 930,
-      "end": 930
+      "start": 933,
+      "end": 933
     },
     "context": {
       "type": "variable",
@@ -14733,8 +14782,8 @@
       "value": "$sprk-gray-dark",
       "scope": "default",
       "line": {
-        "start": 931,
-        "end": 931
+        "start": 934,
+        "end": 934
       }
     },
     "access": "public",
@@ -14749,8 +14798,8 @@
   {
     "description": "The box shadow on disabled Inputs.\n",
     "commentRange": {
-      "start": 932,
-      "end": 932
+      "start": 935,
+      "end": 935
     },
     "context": {
       "type": "variable",
@@ -14758,8 +14807,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 933,
-        "end": 933
+        "start": 936,
+        "end": 936
       }
     },
     "access": "public",
@@ -14774,8 +14823,8 @@
   {
     "description": "The color setting on disabled Inputs.\n",
     "commentRange": {
-      "start": 934,
-      "end": 934
+      "start": 937,
+      "end": 937
     },
     "context": {
       "type": "variable",
@@ -14783,8 +14832,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 935,
-        "end": 935
+        "start": 938,
+        "end": 938
       }
     },
     "access": "public",
@@ -14799,8 +14848,8 @@
   {
     "description": "The border color setting on readonly Inputs.\n",
     "commentRange": {
-      "start": 936,
-      "end": 936
+      "start": 939,
+      "end": 939
     },
     "context": {
       "type": "variable",
@@ -14808,8 +14857,8 @@
       "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
-        "start": 937,
-        "end": 937
+        "start": 940,
+        "end": 940
       }
     },
     "access": "public",
@@ -14824,8 +14873,8 @@
   {
     "description": "The color setting on readonly Inputs.\n",
     "commentRange": {
-      "start": 938,
-      "end": 938
+      "start": 941,
+      "end": 941
     },
     "context": {
       "type": "variable",
@@ -14833,8 +14882,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 939,
-        "end": 939
+        "start": 942,
+        "end": 942
       }
     },
     "access": "public",
@@ -14849,8 +14898,8 @@
   {
     "description": "The transition setting Inputs.\n",
     "commentRange": {
-      "start": 940,
-      "end": 940
+      "start": 943,
+      "end": 943
     },
     "context": {
       "type": "variable",
@@ -14858,8 +14907,8 @@
       "value": "border-color 0.15s ease",
       "scope": "default",
       "line": {
-        "start": 941,
-        "end": 941
+        "start": 944,
+        "end": 944
       }
     },
     "access": "public",
@@ -14874,8 +14923,8 @@
   {
     "description": "The value for the appearance property for Selects.\n",
     "commentRange": {
-      "start": 947,
-      "end": 947
+      "start": 950,
+      "end": 950
     },
     "context": {
       "type": "variable",
@@ -14883,8 +14932,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 948,
-        "end": 948
+        "start": 951,
+        "end": 951
       }
     },
     "access": "public",
@@ -14899,8 +14948,8 @@
   {
     "description": "The background setting for Selects.\n",
     "commentRange": {
-      "start": 949,
-      "end": 949
+      "start": 952,
+      "end": 952
     },
     "context": {
       "type": "variable",
@@ -14908,8 +14957,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 950,
-        "end": 950
+        "start": 953,
+        "end": 953
       }
     },
     "access": "public",
@@ -14924,8 +14973,8 @@
   {
     "description": "The border setting for Selects.\n",
     "commentRange": {
-      "start": 951,
-      "end": 951
+      "start": 954,
+      "end": 954
     },
     "context": {
       "type": "variable",
@@ -14933,8 +14982,8 @@
       "value": "$sprk-text-input-border",
       "scope": "default",
       "line": {
-        "start": 952,
-        "end": 952
+        "start": 955,
+        "end": 955
       }
     },
     "access": "public",
@@ -14949,8 +14998,8 @@
   {
     "description": "The border color setting for Selects on focus.\n",
     "commentRange": {
-      "start": 953,
-      "end": 953
+      "start": 956,
+      "end": 956
     },
     "context": {
       "type": "variable",
@@ -14958,8 +15007,8 @@
       "value": "$sprk-text-input-focus-border-color",
       "scope": "default",
       "line": {
-        "start": 954,
-        "end": 954
+        "start": 957,
+        "end": 957
       }
     },
     "access": "public",
@@ -14974,8 +15023,8 @@
   {
     "description": "The border color setting for Selects when they have an error.\n",
     "commentRange": {
-      "start": 955,
-      "end": 955
+      "start": 958,
+      "end": 958
     },
     "context": {
       "type": "variable",
@@ -14983,8 +15032,8 @@
       "value": "$sprk-text-input-error-border-color",
       "scope": "default",
       "line": {
-        "start": 956,
-        "end": 956
+        "start": 959,
+        "end": 959
       }
     },
     "access": "public",
@@ -14999,8 +15048,8 @@
   {
     "description": "The border radius setting for Selects.\n",
     "commentRange": {
-      "start": 957,
-      "end": 957
+      "start": 960,
+      "end": 960
     },
     "context": {
       "type": "variable",
@@ -15008,8 +15057,8 @@
       "value": "$sprk-text-input-border-radius",
       "scope": "default",
       "line": {
-        "start": 958,
-        "end": 958
+        "start": 961,
+        "end": 961
       }
     },
     "access": "public",
@@ -15024,8 +15073,8 @@
   {
     "description": "The box shadow setting for Selects.\n",
     "commentRange": {
-      "start": 959,
-      "end": 959
+      "start": 962,
+      "end": 962
     },
     "context": {
       "type": "variable",
@@ -15033,8 +15082,8 @@
       "value": "$sprk-text-input-box-shadow",
       "scope": "default",
       "line": {
-        "start": 960,
-        "end": 960
+        "start": 963,
+        "end": 963
       }
     },
     "access": "public",
@@ -15049,8 +15098,8 @@
   {
     "description": "The value for the color property for Selects.\n",
     "commentRange": {
-      "start": 961,
-      "end": 961
+      "start": 964,
+      "end": 964
     },
     "context": {
       "type": "variable",
@@ -15058,8 +15107,8 @@
       "value": "$sprk-text-input-color",
       "scope": "default",
       "line": {
-        "start": 962,
-        "end": 962
+        "start": 965,
+        "end": 965
       }
     },
     "access": "public",
@@ -15074,8 +15123,8 @@
   {
     "description": "The font size of Selects.\n",
     "commentRange": {
-      "start": 963,
-      "end": 963
+      "start": 966,
+      "end": 966
     },
     "context": {
       "type": "variable",
@@ -15083,8 +15132,8 @@
       "value": "$sprk-text-input-font-size",
       "scope": "default",
       "line": {
-        "start": 964,
-        "end": 964
+        "start": 967,
+        "end": 967
       }
     },
     "access": "public",
@@ -15099,8 +15148,8 @@
   {
     "description": "The font family of Selects.\n",
     "commentRange": {
-      "start": 965,
-      "end": 965
+      "start": 968,
+      "end": 968
     },
     "context": {
       "type": "variable",
@@ -15108,8 +15157,8 @@
       "value": "$sprk-text-input-font-family",
       "scope": "default",
       "line": {
-        "start": 966,
-        "end": 966
+        "start": 969,
+        "end": 969
       }
     },
     "access": "public",
@@ -15124,8 +15173,8 @@
   {
     "description": "The font weight of Selects.\n",
     "commentRange": {
-      "start": 967,
-      "end": 967
+      "start": 970,
+      "end": 970
     },
     "context": {
       "type": "variable",
@@ -15133,8 +15182,8 @@
       "value": "$sprk-text-input-font-weight",
       "scope": "default",
       "line": {
-        "start": 968,
-        "end": 968
+        "start": 971,
+        "end": 971
       }
     },
     "access": "public",
@@ -15149,8 +15198,8 @@
   {
     "description": "The line height of Selects.\n",
     "commentRange": {
-      "start": 969,
-      "end": 969
+      "start": 972,
+      "end": 972
     },
     "context": {
       "type": "variable",
@@ -15158,8 +15207,8 @@
       "value": "$sprk-text-input-line-height",
       "scope": "default",
       "line": {
-        "start": 970,
-        "end": 970
+        "start": 973,
+        "end": 973
       }
     },
     "access": "public",
@@ -15174,8 +15223,8 @@
   {
     "description": "The outline setting for Selects.\n",
     "commentRange": {
-      "start": 971,
-      "end": 971
+      "start": 974,
+      "end": 974
     },
     "context": {
       "type": "variable",
@@ -15183,8 +15232,8 @@
       "value": "$sprk-text-input-outline",
       "scope": "default",
       "line": {
-        "start": 972,
-        "end": 972
+        "start": 975,
+        "end": 975
       }
     },
     "access": "public",
@@ -15199,8 +15248,8 @@
   {
     "description": "The padding of Selects.\n",
     "commentRange": {
-      "start": 973,
-      "end": 973
+      "start": 976,
+      "end": 976
     },
     "context": {
       "type": "variable",
@@ -15208,8 +15257,8 @@
       "value": "12px 45px 12px 13px",
       "scope": "default",
       "line": {
-        "start": 974,
-        "end": 974
+        "start": 977,
+        "end": 977
       }
     },
     "access": "public",
@@ -15224,8 +15273,8 @@
   {
     "description": "The value for margin-top on the icon in Selects.\n",
     "commentRange": {
-      "start": 975,
-      "end": 975
+      "start": 978,
+      "end": 978
     },
     "context": {
       "type": "variable",
@@ -15233,8 +15282,8 @@
       "value": "-31px",
       "scope": "default",
       "line": {
-        "start": 976,
-        "end": 976
+        "start": 979,
+        "end": 979
       }
     },
     "access": "public",
@@ -15249,8 +15298,8 @@
   {
     "description": "The value for margin-right on the icon in Selects.\n",
     "commentRange": {
-      "start": 977,
-      "end": 977
+      "start": 980,
+      "end": 980
     },
     "context": {
       "type": "variable",
@@ -15258,8 +15307,8 @@
       "value": "19px",
       "scope": "default",
       "line": {
-        "start": 978,
-        "end": 978
+        "start": 981,
+        "end": 981
       }
     },
     "access": "public",
@@ -15274,8 +15323,8 @@
   {
     "description": "The stroke width of the icon in Selects.\n",
     "commentRange": {
-      "start": 979,
-      "end": 979
+      "start": 982,
+      "end": 982
     },
     "context": {
       "type": "variable",
@@ -15283,8 +15332,8 @@
       "value": "6px",
       "scope": "default",
       "line": {
-        "start": 980,
-        "end": 980
+        "start": 983,
+        "end": 983
       }
     },
     "access": "public",
@@ -15299,8 +15348,8 @@
   {
     "description": "The border color of disabled Selects.\n",
     "commentRange": {
-      "start": 981,
-      "end": 981
+      "start": 984,
+      "end": 984
     },
     "context": {
       "type": "variable",
@@ -15308,8 +15357,8 @@
       "value": "$sprk-text-input-disabled-border-color",
       "scope": "default",
       "line": {
-        "start": 982,
-        "end": 982
+        "start": 985,
+        "end": 985
       }
     },
     "access": "public",
@@ -15324,8 +15373,8 @@
   {
     "description": "The background color of disabled Selects.\n",
     "commentRange": {
-      "start": 983,
-      "end": 983
+      "start": 986,
+      "end": 986
     },
     "context": {
       "type": "variable",
@@ -15333,8 +15382,8 @@
       "value": "$sprk-text-input-disabled-background-color",
       "scope": "default",
       "line": {
-        "start": 984,
-        "end": 984
+        "start": 987,
+        "end": 987
       }
     },
     "access": "public",
@@ -15349,8 +15398,8 @@
   {
     "description": "The color property value of disabled Selects.\n",
     "commentRange": {
-      "start": 985,
-      "end": 985
+      "start": 988,
+      "end": 988
     },
     "context": {
       "type": "variable",
@@ -15358,8 +15407,8 @@
       "value": "$sprk-text-input-disabled-color",
       "scope": "default",
       "line": {
-        "start": 986,
-        "end": 986
+        "start": 989,
+        "end": 989
       }
     },
     "access": "public",
@@ -15374,8 +15423,8 @@
   {
     "description": "The value for the Firefox specific -moz-focusring color setting.\n",
     "commentRange": {
-      "start": 987,
-      "end": 987
+      "start": 990,
+      "end": 990
     },
     "context": {
       "type": "variable",
@@ -15383,8 +15432,8 @@
       "value": "transparent",
       "scope": "default",
       "line": {
-        "start": 988,
-        "end": 988
+        "start": 991,
+        "end": 991
       }
     },
     "access": "public",
@@ -15399,8 +15448,8 @@
   {
     "description": "The value for the Firefox specific -moz-focusring text-shadow setting.\n",
     "commentRange": {
-      "start": 989,
-      "end": 989
+      "start": 992,
+      "end": 992
     },
     "context": {
       "type": "variable",
@@ -15408,8 +15457,8 @@
       "value": "0 0 0 $sprk-select-color",
       "scope": "default",
       "line": {
-        "start": 990,
-        "end": 990
+        "start": 993,
+        "end": 993
       }
     },
     "access": "public",
@@ -15424,8 +15473,8 @@
   {
     "description": "The minimum height of Textarea.\n",
     "commentRange": {
-      "start": 996,
-      "end": 996
+      "start": 999,
+      "end": 999
     },
     "context": {
       "type": "variable",
@@ -15433,8 +15482,8 @@
       "value": "125px",
       "scope": "default",
       "line": {
-        "start": 997,
-        "end": 997
+        "start": 1000,
+        "end": 1000
       }
     },
     "access": "public",
@@ -15449,8 +15498,8 @@
   {
     "description": "The margin surrounding Textarea.\n",
     "commentRange": {
-      "start": 998,
-      "end": 998
+      "start": 1001,
+      "end": 1001
     },
     "context": {
       "type": "variable",
@@ -15458,8 +15507,8 @@
       "value": "$sprk-space-stack-m",
       "scope": "default",
       "line": {
-        "start": 999,
-        "end": 999
+        "start": 1002,
+        "end": 1002
       }
     },
     "access": "public",
@@ -15474,8 +15523,8 @@
   {
     "description": "The padding inside Textarea.\n",
     "commentRange": {
-      "start": 1000,
-      "end": 1000
+      "start": 1003,
+      "end": 1003
     },
     "context": {
       "type": "variable",
@@ -15483,8 +15532,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1001,
-        "end": 1001
+        "start": 1004,
+        "end": 1004
       }
     },
     "access": "public",
@@ -15499,8 +15548,8 @@
   {
     "description": "Color setting for Inputs with errors.\n",
     "commentRange": {
-      "start": 1007,
-      "end": 1007
+      "start": 1010,
+      "end": 1010
     },
     "context": {
       "type": "variable",
@@ -15508,8 +15557,8 @@
       "value": "$sprk-yellow",
       "scope": "default",
       "line": {
-        "start": 1008,
-        "end": 1008
+        "start": 1011,
+        "end": 1011
       }
     },
     "access": "public",
@@ -15524,8 +15573,8 @@
   {
     "description": "Value for color on Inputs with errors.\n",
     "commentRange": {
-      "start": 1009,
-      "end": 1009
+      "start": 1012,
+      "end": 1012
     },
     "context": {
       "type": "variable",
@@ -15533,8 +15582,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1010,
-        "end": 1010
+        "start": 1013,
+        "end": 1013
       }
     },
     "access": "public",
@@ -15549,8 +15598,8 @@
   {
     "description": "The font family used for Input error text.\n",
     "commentRange": {
-      "start": 1011,
-      "end": 1011
+      "start": 1014,
+      "end": 1014
     },
     "context": {
       "type": "variable",
@@ -15558,8 +15607,8 @@
       "value": "$sprk-font-family-body-two",
       "scope": "default",
       "line": {
-        "start": 1012,
-        "end": 1012
+        "start": 1015,
+        "end": 1015
       }
     },
     "access": "public",
@@ -15574,8 +15623,8 @@
   {
     "description": "The font weight used for Input error text.\n",
     "commentRange": {
-      "start": 1013,
-      "end": 1013
+      "start": 1016,
+      "end": 1016
     },
     "context": {
       "type": "variable",
@@ -15583,8 +15632,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1014,
-        "end": 1014
+        "start": 1017,
+        "end": 1017
       }
     },
     "access": "public",
@@ -15599,8 +15648,8 @@
   {
     "description": "The font size used for Input error text.\n",
     "commentRange": {
-      "start": 1015,
-      "end": 1015
+      "start": 1018,
+      "end": 1018
     },
     "context": {
       "type": "variable",
@@ -15608,8 +15657,8 @@
       "value": "0.8125rem",
       "scope": "default",
       "line": {
-        "start": 1016,
-        "end": 1016
+        "start": 1019,
+        "end": 1019
       }
     },
     "access": "public",
@@ -15624,8 +15673,8 @@
   {
     "description": "The line height used for Input error text.\n",
     "commentRange": {
-      "start": 1017,
-      "end": 1017
+      "start": 1020,
+      "end": 1020
     },
     "context": {
       "type": "variable",
@@ -15633,8 +15682,8 @@
       "value": "1.4",
       "scope": "default",
       "line": {
-        "start": 1018,
-        "end": 1018
+        "start": 1021,
+        "end": 1021
       }
     },
     "access": "public",
@@ -15649,8 +15698,8 @@
   {
     "description": "The margin for Input error text.\n",
     "commentRange": {
-      "start": 1019,
-      "end": 1019
+      "start": 1022,
+      "end": 1022
     },
     "context": {
       "type": "variable",
@@ -15658,8 +15707,8 @@
       "value": "0 0 0 6px",
       "scope": "default",
       "line": {
-        "start": 1020,
-        "end": 1020
+        "start": 1023,
+        "end": 1023
       }
     },
     "access": "public",
@@ -15674,8 +15723,8 @@
   {
     "description": "The margin for Input containers that have an error.\n",
     "commentRange": {
-      "start": 1021,
-      "end": 1021
+      "start": 1024,
+      "end": 1024
     },
     "context": {
       "type": "variable",
@@ -15683,8 +15732,8 @@
       "value": "$sprk-space-s 0 0 0",
       "scope": "default",
       "line": {
-        "start": 1022,
-        "end": 1022
+        "start": 1025,
+        "end": 1025
       }
     },
     "access": "public",
@@ -15699,8 +15748,8 @@
   {
     "description": "The Input error icon size.\n",
     "commentRange": {
-      "start": 1023,
-      "end": 1023
+      "start": 1026,
+      "end": 1026
     },
     "context": {
       "type": "variable",
@@ -15708,8 +15757,8 @@
       "value": "1.25rem",
       "scope": "default",
       "line": {
-        "start": 1024,
-        "end": 1024
+        "start": 1027,
+        "end": 1027
       }
     },
     "access": "public",
@@ -15724,8 +15773,8 @@
   {
     "description": "The color of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1030,
-      "end": 1030
+      "start": 1033,
+      "end": 1033
     },
     "context": {
       "type": "variable",
@@ -15733,8 +15782,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1031,
-        "end": 1031
+        "start": 1034,
+        "end": 1034
       }
     },
     "access": "public",
@@ -15749,8 +15798,8 @@
   {
     "description": "The font size of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1032,
-      "end": 1032
+      "start": 1035,
+      "end": 1035
     },
     "context": {
       "type": "variable",
@@ -15758,8 +15807,8 @@
       "value": "0.8125rem",
       "scope": "default",
       "line": {
-        "start": 1033,
-        "end": 1033
+        "start": 1036,
+        "end": 1036
       }
     },
     "access": "public",
@@ -15774,8 +15823,8 @@
   {
     "description": "The font family of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1034,
-      "end": 1034
+      "start": 1037,
+      "end": 1037
     },
     "context": {
       "type": "variable",
@@ -15783,8 +15832,8 @@
       "value": "$sprk-text-input-font-family",
       "scope": "default",
       "line": {
-        "start": 1035,
-        "end": 1035
+        "start": 1038,
+        "end": 1038
       }
     },
     "access": "public",
@@ -15799,8 +15848,8 @@
   {
     "description": "The font weight of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1036,
-      "end": 1036
+      "start": 1039,
+      "end": 1039
     },
     "context": {
       "type": "variable",
@@ -15808,8 +15857,8 @@
       "value": "$sprk-text-input-font-weight",
       "scope": "default",
       "line": {
-        "start": 1037,
-        "end": 1037
+        "start": 1040,
+        "end": 1040
       }
     },
     "access": "public",
@@ -15824,8 +15873,8 @@
   {
     "description": "The line height of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1038,
-      "end": 1038
+      "start": 1041,
+      "end": 1041
     },
     "context": {
       "type": "variable",
@@ -15833,8 +15882,8 @@
       "value": "$sprk-text-input-line-height",
       "scope": "default",
       "line": {
-        "start": 1039,
-        "end": 1039
+        "start": 1042,
+        "end": 1042
       }
     },
     "access": "public",
@@ -15849,8 +15898,8 @@
   {
     "description": "The margin of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1040,
-      "end": 1040
+      "start": 1043,
+      "end": 1043
     },
     "context": {
       "type": "variable",
@@ -15858,8 +15907,8 @@
       "value": "$sprk-error-container-margin",
       "scope": "default",
       "line": {
-        "start": 1041,
-        "end": 1041
+        "start": 1044,
+        "end": 1044
       }
     },
     "access": "public",
@@ -15874,8 +15923,8 @@
   {
     "description": "The color of the placeholder for Inputs.\n",
     "commentRange": {
-      "start": 1047,
-      "end": 1047
+      "start": 1050,
+      "end": 1050
     },
     "context": {
       "type": "variable",
@@ -15883,8 +15932,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1048,
-        "end": 1048
+        "start": 1051,
+        "end": 1051
       }
     },
     "access": "public",
@@ -15899,8 +15948,8 @@
   {
     "description": "The font size of the placeholder for Inputs.\n",
     "commentRange": {
-      "start": 1049,
-      "end": 1049
+      "start": 1052,
+      "end": 1052
     },
     "context": {
       "type": "variable",
@@ -15908,8 +15957,8 @@
       "value": "$sprk-text-input-font-size",
       "scope": "default",
       "line": {
-        "start": 1050,
-        "end": 1050
+        "start": 1053,
+        "end": 1053
       }
     },
     "access": "public",
@@ -15924,8 +15973,8 @@
   {
     "description": "The font family of the placeholder for Inputs.\n",
     "commentRange": {
-      "start": 1051,
-      "end": 1051
+      "start": 1054,
+      "end": 1054
     },
     "context": {
       "type": "variable",
@@ -15933,8 +15982,8 @@
       "value": "$sprk-text-input-font-family",
       "scope": "default",
       "line": {
-        "start": 1052,
-        "end": 1052
+        "start": 1055,
+        "end": 1055
       }
     },
     "access": "public",
@@ -15949,8 +15998,8 @@
   {
     "description": "The font weight of the placeholder for Inputs.\n",
     "commentRange": {
-      "start": 1053,
-      "end": 1053
+      "start": 1056,
+      "end": 1056
     },
     "context": {
       "type": "variable",
@@ -15958,8 +16007,8 @@
       "value": "$sprk-text-input-font-weight",
       "scope": "default",
       "line": {
-        "start": 1054,
-        "end": 1054
+        "start": 1057,
+        "end": 1057
       }
     },
     "access": "public",
@@ -15974,8 +16023,8 @@
   {
     "description": "The margin of the selection container for Inputs.\n",
     "commentRange": {
-      "start": 1060,
-      "end": 1060
+      "start": 1063,
+      "end": 1063
     },
     "context": {
       "type": "variable",
@@ -15983,8 +16032,8 @@
       "value": "0 0 $sprk-space-m 0",
       "scope": "default",
       "line": {
-        "start": 1061,
-        "end": 1061
+        "start": 1064,
+        "end": 1064
       }
     },
     "access": "public",
@@ -15999,8 +16048,8 @@
   {
     "description": "The font weight of the label in the selection container for Inputs.\n",
     "commentRange": {
-      "start": 1062,
-      "end": 1062
+      "start": 1065,
+      "end": 1065
     },
     "context": {
       "type": "variable",
@@ -16008,8 +16057,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 1063,
-        "end": 1063
+        "start": 1066,
+        "end": 1066
       }
     },
     "access": "public",
@@ -16024,8 +16073,8 @@
   {
     "description": "The height of the selection container for Inputs.\n",
     "commentRange": {
-      "start": 1064,
-      "end": 1064
+      "start": 1067,
+      "end": 1067
     },
     "context": {
       "type": "variable",
@@ -16033,8 +16082,8 @@
       "value": "auto",
       "scope": "default",
       "line": {
-        "start": 1065,
-        "end": 1065
+        "start": 1068,
+        "end": 1068
       }
     },
     "access": "public",
@@ -16049,8 +16098,8 @@
   {
     "description": "The width of Input inside the selection container.\n",
     "commentRange": {
-      "start": 1066,
-      "end": 1066
+      "start": 1069,
+      "end": 1069
     },
     "context": {
       "type": "variable",
@@ -16058,8 +16107,8 @@
       "value": "auto",
       "scope": "default",
       "line": {
-        "start": 1067,
-        "end": 1067
+        "start": 1070,
+        "end": 1070
       }
     },
     "access": "public",
@@ -16074,8 +16123,8 @@
   {
     "description": "The margin of the Input inside the selection container.\n",
     "commentRange": {
-      "start": 1068,
-      "end": 1068
+      "start": 1071,
+      "end": 1071
     },
     "context": {
       "type": "variable",
@@ -16083,8 +16132,8 @@
       "value": "0 $sprk-space-s 0 0",
       "scope": "default",
       "line": {
-        "start": 1069,
-        "end": 1069
+        "start": 1072,
+        "end": 1072
       }
     },
     "access": "public",
@@ -16099,8 +16148,8 @@
   {
     "description": "The maximum width of the Date Picker popup.\n",
     "commentRange": {
-      "start": 1075,
-      "end": 1075
+      "start": 1078,
+      "end": 1078
     },
     "context": {
       "type": "variable",
@@ -16108,8 +16157,8 @@
       "value": "20rem",
       "scope": "default",
       "line": {
-        "start": 1076,
-        "end": 1076
+        "start": 1079,
+        "end": 1079
       }
     },
     "access": "public",
@@ -16124,8 +16173,8 @@
   {
     "description": "The border radius applied to the Date Picker popup.\n",
     "commentRange": {
-      "start": 1077,
-      "end": 1077
+      "start": 1080,
+      "end": 1080
     },
     "context": {
       "type": "variable",
@@ -16133,8 +16182,8 @@
       "value": "4px",
       "scope": "default",
       "line": {
-        "start": 1078,
-        "end": 1078
+        "start": 1081,
+        "end": 1081
       }
     },
     "access": "public",
@@ -16149,8 +16198,8 @@
   {
     "description": "The size of the buttons used internally by the Date Picker popup.\n",
     "commentRange": {
-      "start": 1079,
-      "end": 1079
+      "start": 1082,
+      "end": 1082
     },
     "context": {
       "type": "variable",
@@ -16158,8 +16207,8 @@
       "value": "2.25rem",
       "scope": "default",
       "line": {
-        "start": 1080,
-        "end": 1080
+        "start": 1083,
+        "end": 1083
       }
     },
     "access": "public",
@@ -16174,8 +16223,8 @@
   {
     "description": "The offset applied to columns used internally by the Date Picker.\n",
     "commentRange": {
-      "start": 1081,
-      "end": 1081
+      "start": 1084,
+      "end": 1084
     },
     "context": {
       "type": "variable",
@@ -16183,8 +16232,8 @@
       "value": "0.25rem",
       "scope": "default",
       "line": {
-        "start": 1082,
-        "end": 1082
+        "start": 1085,
+        "end": 1085
       }
     },
     "access": "public",
@@ -16199,8 +16248,8 @@
   {
     "description": "The box shadow of the Date Picker.\n",
     "commentRange": {
-      "start": 1083,
-      "end": 1083
+      "start": 1086,
+      "end": 1086
     },
     "context": {
       "type": "variable",
@@ -16208,8 +16257,8 @@
       "value": "0 4px 16px rgba(51, 51, 51, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1084,
-        "end": 1084
+        "start": 1087,
+        "end": 1087
       }
     },
     "access": "public",
@@ -16224,8 +16273,8 @@
   {
     "description": "The font family in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1085,
-      "end": 1085
+      "start": 1088,
+      "end": 1088
     },
     "context": {
       "type": "variable",
@@ -16233,8 +16282,8 @@
       "value": "$sprk-font-family-body-two",
       "scope": "default",
       "line": {
-        "start": 1086,
-        "end": 1086
+        "start": 1089,
+        "end": 1089
       }
     },
     "access": "public",
@@ -16249,8 +16298,8 @@
   {
     "description": "The font size of the Date Picker popup.\n",
     "commentRange": {
-      "start": 1087,
-      "end": 1087
+      "start": 1090,
+      "end": 1090
     },
     "context": {
       "type": "variable",
@@ -16258,8 +16307,8 @@
       "value": "1rem",
       "scope": "default",
       "line": {
-        "start": 1088,
-        "end": 1088
+        "start": 1091,
+        "end": 1091
       }
     },
     "access": "public",
@@ -16274,8 +16323,8 @@
   {
     "description": "The font weight of the Date Picker popup.\n",
     "commentRange": {
-      "start": 1089,
-      "end": 1089
+      "start": 1092,
+      "end": 1092
     },
     "context": {
       "type": "variable",
@@ -16283,8 +16332,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 1090,
-        "end": 1090
+        "start": 1093,
+        "end": 1093
       }
     },
     "access": "public",
@@ -16299,8 +16348,8 @@
   {
     "description": "Color used internally by Date Picker to highlight elements\n",
     "commentRange": {
-      "start": 1091,
-      "end": 1091
+      "start": 1094,
+      "end": 1094
     },
     "context": {
       "type": "variable",
@@ -16308,8 +16357,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 1092,
-        "end": 1092
+        "start": 1095,
+        "end": 1095
       }
     },
     "access": "public",
@@ -16324,8 +16373,8 @@
   {
     "description": "Font weight used by the currently selected day in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1093,
-      "end": 1093
+      "start": 1096,
+      "end": 1096
     },
     "context": {
       "type": "variable",
@@ -16333,8 +16382,8 @@
       "value": "500",
       "scope": "default",
       "line": {
-        "start": 1094,
-        "end": 1094
+        "start": 1097,
+        "end": 1097
       }
     },
     "access": "public",
@@ -16349,8 +16398,8 @@
   {
     "description": "The value for background in the Date Picker.\n",
     "commentRange": {
-      "start": 1095,
-      "end": 1095
+      "start": 1098,
+      "end": 1098
     },
     "context": {
       "type": "variable",
@@ -16358,8 +16407,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1096,
-        "end": 1096
+        "start": 1099,
+        "end": 1099
       }
     },
     "access": "public",
@@ -16374,8 +16423,8 @@
   {
     "description": "The value for padding in the Date Picker.\n",
     "commentRange": {
-      "start": 1097,
-      "end": 1097
+      "start": 1100,
+      "end": 1100
     },
     "context": {
       "type": "variable",
@@ -16383,8 +16432,8 @@
       "value": "$sprk-space-inset-s",
       "scope": "default",
       "line": {
-        "start": 1098,
-        "end": 1098
+        "start": 1101,
+        "end": 1101
       }
     },
     "access": "public",
@@ -16399,8 +16448,8 @@
   {
     "description": "The value for padding on wide viewports in the Date Picker.\n",
     "commentRange": {
-      "start": 1099,
-      "end": 1099
+      "start": 1102,
+      "end": 1102
     },
     "context": {
       "type": "variable",
@@ -16408,8 +16457,8 @@
       "value": "$sprk-space-inset-m",
       "scope": "default",
       "line": {
-        "start": 1100,
-        "end": 1100
+        "start": 1103,
+        "end": 1103
       }
     },
     "access": "public",
@@ -16424,8 +16473,8 @@
   {
     "description": "The border setting for the header in the Date Picker.\n",
     "commentRange": {
-      "start": 1101,
-      "end": 1101
+      "start": 1104,
+      "end": 1104
     },
     "context": {
       "type": "variable",
@@ -16433,8 +16482,8 @@
       "value": "1px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1102,
-        "end": 1102
+        "start": 1105,
+        "end": 1105
       }
     },
     "access": "public",
@@ -16449,8 +16498,8 @@
   {
     "description": "The font size for the header in the Date Picker.\n",
     "commentRange": {
-      "start": 1103,
-      "end": 1103
+      "start": 1106,
+      "end": 1106
     },
     "context": {
       "type": "variable",
@@ -16458,8 +16507,8 @@
       "value": "$sprk-font-size-body-three",
       "scope": "default",
       "line": {
-        "start": 1104,
-        "end": 1104
+        "start": 1107,
+        "end": 1107
       }
     },
     "access": "public",
@@ -16474,8 +16523,8 @@
   {
     "description": "The font weight for the header in the Date Picker.\n",
     "commentRange": {
-      "start": 1105,
-      "end": 1105
+      "start": 1108,
+      "end": 1108
     },
     "context": {
       "type": "variable",
@@ -16483,8 +16532,8 @@
       "value": "700",
       "scope": "default",
       "line": {
-        "start": 1106,
-        "end": 1106
+        "start": 1109,
+        "end": 1109
       }
     },
     "access": "public",
@@ -16499,8 +16548,8 @@
   {
     "description": "The padding for the header in the Date Picker.\n",
     "commentRange": {
-      "start": 1107,
-      "end": 1107
+      "start": 1110,
+      "end": 1110
     },
     "context": {
       "type": "variable",
@@ -16508,8 +16557,8 @@
       "value": "0 0 $sprk-space-s 0",
       "scope": "default",
       "line": {
-        "start": 1108,
-        "end": 1108
+        "start": 1111,
+        "end": 1111
       }
     },
     "access": "public",
@@ -16524,8 +16573,8 @@
   {
     "description": "The padding around the month header in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1109,
-      "end": 1109
+      "start": 1112,
+      "end": 1112
     },
     "context": {
       "type": "variable",
@@ -16533,8 +16582,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1110,
-        "end": 1110
+        "start": 1113,
+        "end": 1113
       }
     },
     "access": "public",
@@ -16549,8 +16598,8 @@
   {
     "description": "The padding around the day in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1111,
-      "end": 1111
+      "start": 1114,
+      "end": 1114
     },
     "context": {
       "type": "variable",
@@ -16558,8 +16607,8 @@
       "value": "6px",
       "scope": "default",
       "line": {
-        "start": 1112,
-        "end": 1112
+        "start": 1115,
+        "end": 1115
       }
     },
     "access": "public",
@@ -16574,8 +16623,8 @@
   {
     "description": "The margin around the day in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1113,
-      "end": 1113
+      "start": 1116,
+      "end": 1116
     },
     "context": {
       "type": "variable",
@@ -16583,8 +16632,8 @@
       "value": "0 2px",
       "scope": "default",
       "line": {
-        "start": 1114,
-        "end": 1114
+        "start": 1117,
+        "end": 1117
       }
     },
     "access": "public",
@@ -16599,8 +16648,8 @@
   {
     "description": "The color of the day in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1115,
-      "end": 1115
+      "start": 1118,
+      "end": 1118
     },
     "context": {
       "type": "variable",
@@ -16608,8 +16657,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1116,
-        "end": 1116
+        "start": 1119,
+        "end": 1119
       }
     },
     "access": "public",
@@ -16624,38 +16673,13 @@
   {
     "description": "The color of the day in the Date Picker popup on hover.\n",
     "commentRange": {
-      "start": 1117,
-      "end": 1117
+      "start": 1120,
+      "end": 1120
     },
     "context": {
       "type": "variable",
       "name": "sprk-date-picker-day-hover-color",
       "value": "$sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1118,
-        "end": 1118
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of days in the Date Picker\npopup that are in the next month or disabled.\n",
-    "commentRange": {
-      "start": 1119,
-      "end": 1120
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-date-picker-day-edge-day-color",
-      "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
         "start": 1121,
@@ -16672,10 +16696,35 @@
     }
   },
   {
-    "description": "The font size of the month and year in the Date Picker popup.\n",
+    "description": "The color of days in the Date Picker\npopup that are in the next month or disabled.\n",
     "commentRange": {
       "start": 1122,
-      "end": 1122
+      "end": 1123
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-date-picker-day-edge-day-color",
+      "value": "$sprk-black-tint-50",
+      "scope": "default",
+      "line": {
+        "start": 1124,
+        "end": 1124
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font size of the month and year in the Date Picker popup.\n",
+    "commentRange": {
+      "start": 1125,
+      "end": 1125
     },
     "context": {
       "type": "variable",
@@ -16683,8 +16732,8 @@
       "value": "$sprk-font-size-display-six",
       "scope": "default",
       "line": {
-        "start": 1123,
-        "end": 1123
+        "start": 1126,
+        "end": 1126
       }
     },
     "access": "public",
@@ -16699,8 +16748,8 @@
   {
     "description": "The color of the prev/next arrows in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1124,
-      "end": 1124
+      "start": 1127,
+      "end": 1127
     },
     "context": {
       "type": "variable",
@@ -16708,8 +16757,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1125,
-        "end": 1125
+        "start": 1128,
+        "end": 1128
       }
     },
     "access": "public",
@@ -16724,8 +16773,8 @@
   {
     "description": "The margin applied to the Date Picker popup.\n",
     "commentRange": {
-      "start": 1126,
-      "end": 1126
+      "start": 1129,
+      "end": 1129
     },
     "context": {
       "type": "variable",
@@ -16733,8 +16782,8 @@
       "value": "$sprk-space-m 0 0 0",
       "scope": "default",
       "line": {
-        "start": 1127,
-        "end": 1127
+        "start": 1130,
+        "end": 1130
       }
     },
     "access": "public",
@@ -16749,8 +16798,8 @@
   {
     "description": "The margin applied to the Date Picker popup on wide viewports.\n",
     "commentRange": {
-      "start": 1128,
-      "end": 1128
+      "start": 1131,
+      "end": 1131
     },
     "context": {
       "type": "variable",
@@ -16758,8 +16807,8 @@
       "value": "2px",
       "scope": "default",
       "line": {
-        "start": 1129,
-        "end": 1129
+        "start": 1132,
+        "end": 1132
       }
     },
     "access": "public",
@@ -16774,8 +16823,8 @@
   {
     "description": "The z-index applied to the Date Picker popup.\n",
     "commentRange": {
-      "start": 1130,
-      "end": 1130
+      "start": 1133,
+      "end": 1133
     },
     "context": {
       "type": "variable",
@@ -16783,8 +16832,8 @@
       "value": "$sprk-layer-height-m",
       "scope": "default",
       "line": {
-        "start": 1131,
-        "end": 1131
+        "start": 1134,
+        "end": 1134
       }
     },
     "access": "public",
@@ -16799,8 +16848,8 @@
   {
     "description": "The value for max-height applied to the Date Picker popup.\n",
     "commentRange": {
-      "start": 1132,
-      "end": 1132
+      "start": 1135,
+      "end": 1135
     },
     "context": {
       "type": "variable",
@@ -16808,8 +16857,8 @@
       "value": "500px",
       "scope": "default",
       "line": {
-        "start": 1133,
-        "end": 1133
+        "start": 1136,
+        "end": 1136
       }
     },
     "access": "public",
@@ -16824,8 +16873,8 @@
   {
     "description": "The X offset of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1139,
-      "end": 1139
+      "start": 1142,
+      "end": 1142
     },
     "context": {
       "type": "variable",
@@ -16833,8 +16882,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1140,
-        "end": 1140
+        "start": 1143,
+        "end": 1143
       }
     },
     "access": "public",
@@ -16849,8 +16898,8 @@
   {
     "description": "The Y offset of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1141,
-      "end": 1141
+      "start": 1144,
+      "end": 1144
     },
     "context": {
       "type": "variable",
@@ -16858,8 +16907,8 @@
       "value": "2em",
       "scope": "default",
       "line": {
-        "start": 1142,
-        "end": 1142
+        "start": 1145,
+        "end": 1145
       }
     },
     "access": "public",
@@ -16874,8 +16923,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1143,
-      "end": 1143
+      "start": 1146,
+      "end": 1146
     },
     "context": {
       "type": "variable",
@@ -16883,8 +16932,8 @@
       "value": "1rem",
       "scope": "default",
       "line": {
-        "start": 1144,
-        "end": 1144
+        "start": 1147,
+        "end": 1147
       }
     },
     "access": "public",
@@ -16899,8 +16948,8 @@
   {
     "description": "The font weight of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1145,
-      "end": 1145
+      "start": 1148,
+      "end": 1148
     },
     "context": {
       "type": "variable",
@@ -16908,8 +16957,8 @@
       "value": "700",
       "scope": "default",
       "line": {
-        "start": 1146,
-        "end": 1146
+        "start": 1149,
+        "end": 1149
       }
     },
     "access": "public",
@@ -16924,8 +16973,8 @@
   {
     "description": "The top offset of the icon displayed on the right side of Inputs.\n",
     "commentRange": {
-      "start": 1147,
-      "end": 1147
+      "start": 1150,
+      "end": 1150
     },
     "context": {
       "type": "variable",
@@ -16933,8 +16982,8 @@
       "value": "38px",
       "scope": "default",
       "line": {
-        "start": 1148,
-        "end": 1148
+        "start": 1151,
+        "end": 1151
       }
     },
     "access": "public",
@@ -16949,8 +16998,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1149,
-      "end": 1149
+      "start": 1152,
+      "end": 1152
     },
     "context": {
       "type": "variable",
@@ -16958,8 +17007,8 @@
       "value": "71px",
       "scope": "default",
       "line": {
-        "start": 1150,
-        "end": 1150
+        "start": 1153,
+        "end": 1153
       }
     },
     "access": "public",
@@ -16974,8 +17023,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1151,
-      "end": 1151
+      "start": 1154,
+      "end": 1154
     },
     "context": {
       "type": "variable",
@@ -16983,8 +17032,8 @@
       "value": "0 0 1px 37px",
       "scope": "default",
       "line": {
-        "start": 1152,
-        "end": 1152
+        "start": 1155,
+        "end": 1155
       }
     },
     "access": "public",
@@ -16999,8 +17048,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1153,
-      "end": 1153
+      "start": 1156,
+      "end": 1156
     },
     "context": {
       "type": "variable",
@@ -17008,8 +17057,8 @@
       "value": "0 37px 1px 12px",
       "scope": "default",
       "line": {
-        "start": 1154,
-        "end": 1154
+        "start": 1157,
+        "end": 1157
       }
     },
     "access": "public",
@@ -17024,8 +17073,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1155,
-      "end": 1155
+      "start": 1158,
+      "end": 1158
     },
     "context": {
       "type": "variable",
@@ -17033,8 +17082,8 @@
       "value": "0 40px",
       "scope": "default",
       "line": {
-        "start": 1156,
-        "end": 1156
+        "start": 1159,
+        "end": 1159
       }
     },
     "access": "public",
@@ -17049,8 +17098,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1157,
-      "end": 1157
+      "start": 1160,
+      "end": 1160
     },
     "context": {
       "type": "variable",
@@ -17058,8 +17107,8 @@
       "value": "$sprk-layer-height-xs",
       "scope": "default",
       "line": {
-        "start": 1158,
-        "end": 1158
+        "start": 1161,
+        "end": 1161
       }
     },
     "access": "public",
@@ -17074,8 +17123,8 @@
   {
     "description": "The X offset of icons inside Inputs.\n",
     "commentRange": {
-      "start": 1164,
-      "end": 1164
+      "start": 1167,
+      "end": 1167
     },
     "context": {
       "type": "variable",
@@ -17083,8 +17132,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1165,
-        "end": 1165
+        "start": 1168,
+        "end": 1168
       }
     },
     "access": "public",
@@ -17099,8 +17148,8 @@
   {
     "description": "The Y offset of icons inside Inputs.\n",
     "commentRange": {
-      "start": 1166,
-      "end": 1166
+      "start": 1169,
+      "end": 1169
     },
     "context": {
       "type": "variable",
@@ -17108,8 +17157,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1167,
-        "end": 1167
+        "start": 1170,
+        "end": 1170
       }
     },
     "access": "public",
@@ -17124,8 +17173,8 @@
   {
     "description": "The padding inside Inputs that contain icons.\n",
     "commentRange": {
-      "start": 1168,
-      "end": 1168
+      "start": 1171,
+      "end": 1171
     },
     "context": {
       "type": "variable",
@@ -17133,8 +17182,8 @@
       "value": "12px 0 12px 40px",
       "scope": "default",
       "line": {
-        "start": 1169,
-        "end": 1169
+        "start": 1172,
+        "end": 1172
       }
     },
     "access": "public",
@@ -17149,8 +17198,8 @@
   {
     "description": "The z-index applied to the icon inside Inputs.\n",
     "commentRange": {
-      "start": 1170,
-      "end": 1170
+      "start": 1173,
+      "end": 1173
     },
     "context": {
       "type": "variable",
@@ -17158,8 +17207,8 @@
       "value": "$sprk-layer-height-xs",
       "scope": "default",
       "line": {
-        "start": 1171,
-        "end": 1171
+        "start": 1174,
+        "end": 1174
       }
     },
     "access": "public",
@@ -17174,8 +17223,8 @@
   {
     "description": "The padding applied to Input labels.\n",
     "commentRange": {
-      "start": 1177,
-      "end": 1177
+      "start": 1180,
+      "end": 1180
     },
     "context": {
       "type": "variable",
@@ -17183,8 +17232,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1178,
-        "end": 1178
+        "start": 1181,
+        "end": 1181
       }
     },
     "access": "public",
@@ -17199,8 +17248,8 @@
   {
     "description": "The font family applied to Input labels.\n",
     "commentRange": {
-      "start": 1179,
-      "end": 1179
+      "start": 1182,
+      "end": 1182
     },
     "context": {
       "type": "variable",
@@ -17208,8 +17257,8 @@
       "value": "$sprk-font-family-body-two",
       "scope": "default",
       "line": {
-        "start": 1180,
-        "end": 1180
+        "start": 1183,
+        "end": 1183
       }
     },
     "access": "public",
@@ -17224,8 +17273,8 @@
   {
     "description": "The font size applied to Input labels.\n",
     "commentRange": {
-      "start": 1181,
-      "end": 1181
+      "start": 1184,
+      "end": 1184
     },
     "context": {
       "type": "variable",
@@ -17233,8 +17282,8 @@
       "value": "0.875rem",
       "scope": "default",
       "line": {
-        "start": 1182,
-        "end": 1182
+        "start": 1185,
+        "end": 1185
       }
     },
     "access": "public",
@@ -17249,8 +17298,8 @@
   {
     "description": "The font weight applied to Input labels.\n",
     "commentRange": {
-      "start": 1183,
-      "end": 1183
+      "start": 1186,
+      "end": 1186
     },
     "context": {
       "type": "variable",
@@ -17258,8 +17307,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1184,
-        "end": 1184
+        "start": 1187,
+        "end": 1187
       }
     },
     "access": "public",
@@ -17274,8 +17323,8 @@
   {
     "description": "The line height applied to Input labels.\n",
     "commentRange": {
-      "start": 1185,
-      "end": 1185
+      "start": 1188,
+      "end": 1188
     },
     "context": {
       "type": "variable",
@@ -17283,8 +17332,8 @@
       "value": "1",
       "scope": "default",
       "line": {
-        "start": 1186,
-        "end": 1186
+        "start": 1189,
+        "end": 1189
       }
     },
     "access": "public",
@@ -17299,8 +17348,8 @@
   {
     "description": "The margin applied to Input labels.\n",
     "commentRange": {
-      "start": 1187,
-      "end": 1187
+      "start": 1190,
+      "end": 1190
     },
     "context": {
       "type": "variable",
@@ -17308,8 +17357,8 @@
       "value": "0 0 $sprk-space-s 0",
       "scope": "default",
       "line": {
-        "start": 1188,
-        "end": 1188
+        "start": 1191,
+        "end": 1191
       }
     },
     "access": "public",
@@ -17324,8 +17373,8 @@
   {
     "description": "The margin surrounding visibility controls (Ex. 'Show SSN').\n",
     "commentRange": {
-      "start": 1189,
-      "end": 1189
+      "start": 1192,
+      "end": 1192
     },
     "context": {
       "type": "variable",
@@ -17333,8 +17382,8 @@
       "value": "6px 0 0 0",
       "scope": "default",
       "line": {
-        "start": 1190,
-        "end": 1190
+        "start": 1193,
+        "end": 1193
       }
     },
     "access": "public",
@@ -17349,8 +17398,8 @@
   {
     "description": "The font size used for visibility controls.\n",
     "commentRange": {
-      "start": 1191,
-      "end": 1191
+      "start": 1194,
+      "end": 1194
     },
     "context": {
       "type": "variable",
@@ -17358,8 +17407,8 @@
       "value": "$sprk-label-font-size",
       "scope": "default",
       "line": {
-        "start": 1192,
-        "end": 1192
+        "start": 1195,
+        "end": 1195
       }
     },
     "access": "public",
@@ -17374,8 +17423,8 @@
   {
     "description": "The color of the disabled Input labels.\n",
     "commentRange": {
-      "start": 1193,
-      "end": 1193
+      "start": 1196,
+      "end": 1196
     },
     "context": {
       "type": "variable",
@@ -17383,8 +17432,8 @@
       "value": "$sprk-gray-dark",
       "scope": "default",
       "line": {
-        "start": 1194,
-        "end": 1194
+        "start": 1197,
+        "end": 1197
       }
     },
     "access": "public",
@@ -17399,8 +17448,8 @@
   {
     "description": "The small Table padding.\n",
     "commentRange": {
-      "start": 1200,
-      "end": 1200
+      "start": 1203,
+      "end": 1203
     },
     "context": {
       "type": "variable",
@@ -17408,8 +17457,8 @@
       "value": "$sprk-space-inset-s",
       "scope": "default",
       "line": {
-        "start": 1201,
-        "end": 1201
+        "start": 1204,
+        "end": 1204
       }
     },
     "access": "public",
@@ -17424,8 +17473,8 @@
   {
     "description": "The medium Table padding.\n",
     "commentRange": {
-      "start": 1202,
-      "end": 1202
+      "start": 1205,
+      "end": 1205
     },
     "context": {
       "type": "variable",
@@ -17433,8 +17482,8 @@
       "value": "$sprk-space-inset-m",
       "scope": "default",
       "line": {
-        "start": 1203,
-        "end": 1203
+        "start": 1206,
+        "end": 1206
       }
     },
     "access": "public",
@@ -17449,8 +17498,8 @@
   {
     "description": "The large Table padding.\n",
     "commentRange": {
-      "start": 1204,
-      "end": 1204
+      "start": 1207,
+      "end": 1207
     },
     "context": {
       "type": "variable",
@@ -17458,8 +17507,8 @@
       "value": "$sprk-space-inset-l",
       "scope": "default",
       "line": {
-        "start": 1205,
-        "end": 1205
+        "start": 1208,
+        "end": 1208
       }
     },
     "access": "public",
@@ -17474,8 +17523,8 @@
   {
     "description": "The Table cell alignment.\n",
     "commentRange": {
-      "start": 1206,
-      "end": 1206
+      "start": 1209,
+      "end": 1209
     },
     "context": {
       "type": "variable",
@@ -17483,8 +17532,8 @@
       "value": "center",
       "scope": "default",
       "line": {
-        "start": 1207,
-        "end": 1207
+        "start": 1210,
+        "end": 1210
       }
     },
     "access": "public",
@@ -17499,8 +17548,8 @@
   {
     "description": "The stripe color or the striped Table.\n",
     "commentRange": {
-      "start": 1208,
-      "end": 1208
+      "start": 1211,
+      "end": 1211
     },
     "context": {
       "type": "variable",
@@ -17508,8 +17557,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1209,
-        "end": 1209
+        "start": 1212,
+        "end": 1212
       }
     },
     "access": "public",
@@ -17524,8 +17573,8 @@
   {
     "description": "The highlight background color of the sprk-b-TableHighlight.\n",
     "commentRange": {
-      "start": 1210,
-      "end": 1210
+      "start": 1213,
+      "end": 1213
     },
     "context": {
       "type": "variable",
@@ -17533,8 +17582,8 @@
       "value": "$sprk-red",
       "scope": "default",
       "line": {
-        "start": 1211,
-        "end": 1211
+        "start": 1214,
+        "end": 1214
       }
     },
     "access": "public",
@@ -17549,8 +17598,8 @@
   {
     "description": "The highlight text color of the sprk-b-TableHighlight.\n",
     "commentRange": {
-      "start": 1212,
-      "end": 1212
+      "start": 1215,
+      "end": 1215
     },
     "context": {
       "type": "variable",
@@ -17558,8 +17607,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1213,
-        "end": 1213
+        "start": 1216,
+        "end": 1216
       }
     },
     "access": "public",
@@ -17574,8 +17623,8 @@
   {
     "description": "The heading alignment of in Tables.\n",
     "commentRange": {
-      "start": 1214,
-      "end": 1214
+      "start": 1217,
+      "end": 1217
     },
     "context": {
       "type": "variable",
@@ -17583,8 +17632,8 @@
       "value": "center",
       "scope": "default",
       "line": {
-        "start": 1215,
-        "end": 1215
+        "start": 1218,
+        "end": 1218
       }
     },
     "access": "public",
@@ -17599,8 +17648,8 @@
   {
     "description": "The border width on Tables.\n",
     "commentRange": {
-      "start": 1216,
-      "end": 1216
+      "start": 1219,
+      "end": 1219
     },
     "context": {
       "type": "variable",
@@ -17608,8 +17657,8 @@
       "value": "1px",
       "scope": "default",
       "line": {
-        "start": 1217,
-        "end": 1217
+        "start": 1220,
+        "end": 1220
       }
     },
     "access": "public",
@@ -17624,8 +17673,8 @@
   {
     "description": "The border style of Tables.\n",
     "commentRange": {
-      "start": 1218,
-      "end": 1218
+      "start": 1221,
+      "end": 1221
     },
     "context": {
       "type": "variable",
@@ -17633,8 +17682,8 @@
       "value": "solid",
       "scope": "default",
       "line": {
-        "start": 1219,
-        "end": 1219
+        "start": 1222,
+        "end": 1222
       }
     },
     "access": "public",
@@ -17649,8 +17698,8 @@
   {
     "description": "The border color of Tables.\n",
     "commentRange": {
-      "start": 1220,
-      "end": 1220
+      "start": 1223,
+      "end": 1223
     },
     "context": {
       "type": "variable",
@@ -17658,8 +17707,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1221,
-        "end": 1221
+        "start": 1224,
+        "end": 1224
       }
     },
     "access": "public",
@@ -17674,8 +17723,8 @@
   {
     "description": "The border collapse setting of Tables.\n",
     "commentRange": {
-      "start": 1222,
-      "end": 1222
+      "start": 1225,
+      "end": 1225
     },
     "context": {
       "type": "variable",
@@ -17683,8 +17732,8 @@
       "value": "collapse",
       "scope": "default",
       "line": {
-        "start": 1223,
-        "end": 1223
+        "start": 1226,
+        "end": 1226
       }
     },
     "access": "public",
@@ -17699,8 +17748,8 @@
   {
     "description": "The width of the bottom border on Table rows.\n",
     "commentRange": {
-      "start": 1226,
-      "end": 1226
+      "start": 1229,
+      "end": 1229
     },
     "context": {
       "type": "variable",
@@ -17708,8 +17757,8 @@
       "value": "1px",
       "scope": "default",
       "line": {
-        "start": 1227,
-        "end": 1227
+        "start": 1230,
+        "end": 1230
       }
     },
     "access": "public",
@@ -17724,8 +17773,8 @@
   {
     "description": "The style of the bottom border on Table rows.\n",
     "commentRange": {
-      "start": 1228,
-      "end": 1228
+      "start": 1231,
+      "end": 1231
     },
     "context": {
       "type": "variable",
@@ -17733,8 +17782,8 @@
       "value": "solid",
       "scope": "default",
       "line": {
-        "start": 1229,
-        "end": 1229
+        "start": 1232,
+        "end": 1232
       }
     },
     "access": "public",
@@ -17749,8 +17798,8 @@
   {
     "description": "The color of the bottom border on Table rows.\n",
     "commentRange": {
-      "start": 1230,
-      "end": 1230
+      "start": 1233,
+      "end": 1233
     },
     "context": {
       "type": "variable",
@@ -17758,8 +17807,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1231,
-        "end": 1231
+        "start": 1234,
+        "end": 1234
       }
     },
     "access": "public",
@@ -17774,8 +17823,8 @@
   {
     "description": "The background color of the Table header.\n",
     "commentRange": {
-      "start": 1232,
-      "end": 1232
+      "start": 1235,
+      "end": 1235
     },
     "context": {
       "type": "variable",
@@ -17783,8 +17832,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1233,
-        "end": 1233
+        "start": 1236,
+        "end": 1236
       }
     },
     "access": "public",
@@ -17799,8 +17848,8 @@
   {
     "description": "The font color of the Table header.\n",
     "commentRange": {
-      "start": 1234,
-      "end": 1234
+      "start": 1237,
+      "end": 1237
     },
     "context": {
       "type": "variable",
@@ -17808,8 +17857,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1235,
-        "end": 1235
+        "start": 1238,
+        "end": 1238
       }
     },
     "access": "public",
@@ -17824,8 +17873,8 @@
   {
     "description": "The font size of the Table header.\n",
     "commentRange": {
-      "start": 1236,
-      "end": 1236
+      "start": 1239,
+      "end": 1239
     },
     "context": {
       "type": "variable",
@@ -17833,8 +17882,8 @@
       "value": "$sprk-font-size-body-one",
       "scope": "default",
       "line": {
-        "start": 1237,
-        "end": 1237
+        "start": 1240,
+        "end": 1240
       }
     },
     "access": "public",
@@ -17849,8 +17898,8 @@
   {
     "description": "The font weight of the Table header.\n",
     "commentRange": {
-      "start": 1238,
-      "end": 1238
+      "start": 1241,
+      "end": 1241
     },
     "context": {
       "type": "variable",
@@ -17858,8 +17907,8 @@
       "value": "$sprk-font-weight-body-one",
       "scope": "default",
       "line": {
-        "start": 1239,
-        "end": 1239
+        "start": 1242,
+        "end": 1242
       }
     },
     "access": "public",
@@ -17874,8 +17923,8 @@
   {
     "description": "The width of the right border on the Table header.\n",
     "commentRange": {
-      "start": 1240,
-      "end": 1240
+      "start": 1243,
+      "end": 1243
     },
     "context": {
       "type": "variable",
@@ -17883,8 +17932,8 @@
       "value": "2px",
       "scope": "default",
       "line": {
-        "start": 1241,
-        "end": 1241
+        "start": 1244,
+        "end": 1244
       }
     },
     "access": "public",
@@ -17899,8 +17948,8 @@
   {
     "description": "The color of the right border on the Table header.\n",
     "commentRange": {
-      "start": 1242,
-      "end": 1242
+      "start": 1245,
+      "end": 1245
     },
     "context": {
       "type": "variable",
@@ -17908,8 +17957,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1243,
-        "end": 1243
+        "start": 1246,
+        "end": 1246
       }
     },
     "access": "public",
@@ -17924,8 +17973,8 @@
   {
     "description": "The background color of empty Table headers.\n",
     "commentRange": {
-      "start": 1244,
-      "end": 1244
+      "start": 1247,
+      "end": 1247
     },
     "context": {
       "type": "variable",
@@ -17933,8 +17982,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1245,
-        "end": 1245
+        "start": 1248,
+        "end": 1248
       }
     },
     "access": "public",
@@ -17949,8 +17998,8 @@
   {
     "description": "The background color of Secondary Table headers.\n",
     "commentRange": {
-      "start": 1248,
-      "end": 1248
+      "start": 1251,
+      "end": 1251
     },
     "context": {
       "type": "variable",
@@ -17958,8 +18007,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1249,
-        "end": 1249
+        "start": 1252,
+        "end": 1252
       }
     },
     "access": "public",
@@ -17974,8 +18023,8 @@
   {
     "description": "The font color of Secondary Table headers.\n",
     "commentRange": {
-      "start": 1250,
-      "end": 1250
+      "start": 1253,
+      "end": 1253
     },
     "context": {
       "type": "variable",
@@ -17983,8 +18032,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1251,
-        "end": 1251
+        "start": 1254,
+        "end": 1254
       }
     },
     "access": "public",
@@ -17999,8 +18048,8 @@
   {
     "description": "The text alignment of Secondary Table headers.\n",
     "commentRange": {
-      "start": 1252,
-      "end": 1252
+      "start": 1255,
+      "end": 1255
     },
     "context": {
       "type": "variable",
@@ -18008,8 +18057,8 @@
       "value": "left",
       "scope": "default",
       "line": {
-        "start": 1253,
-        "end": 1253
+        "start": 1256,
+        "end": 1256
       }
     },
     "access": "public",
@@ -18024,8 +18073,8 @@
   {
     "description": "The text alignment of Secondary Table cells.\n",
     "commentRange": {
-      "start": 1254,
-      "end": 1254
+      "start": 1257,
+      "end": 1257
     },
     "context": {
       "type": "variable",
@@ -18033,8 +18082,8 @@
       "value": "left",
       "scope": "default",
       "line": {
-        "start": 1255,
-        "end": 1255
+        "start": 1258,
+        "end": 1258
       }
     },
     "access": "public",
@@ -18049,8 +18098,8 @@
   {
     "description": "The width of the right border on the Secondary Table header.\n",
     "commentRange": {
-      "start": 1256,
-      "end": 1256
+      "start": 1259,
+      "end": 1259
     },
     "context": {
       "type": "variable",
@@ -18058,8 +18107,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1257,
-        "end": 1257
+        "start": 1260,
+        "end": 1260
       }
     },
     "access": "public",
@@ -18074,8 +18123,8 @@
   {
     "description": "The color of the right border on the Secondary Table header.\n",
     "commentRange": {
-      "start": 1258,
-      "end": 1258
+      "start": 1261,
+      "end": 1261
     },
     "context": {
       "type": "variable",
@@ -18083,8 +18132,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1259,
-        "end": 1259
+        "start": 1262,
+        "end": 1262
       }
     },
     "access": "public",
@@ -18099,8 +18148,8 @@
   {
     "description": "The background color of the header in the Grouped Columns Table variant.\n",
     "commentRange": {
-      "start": 1262,
-      "end": 1262
+      "start": 1265,
+      "end": 1265
     },
     "context": {
       "type": "variable",
@@ -18108,8 +18157,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1263,
-        "end": 1263
+        "start": 1266,
+        "end": 1266
       }
     },
     "access": "public",
@@ -18124,8 +18173,8 @@
   {
     "description": "The font size of the header in the Grouped Columns Table variant.\n",
     "commentRange": {
-      "start": 1264,
-      "end": 1264
+      "start": 1267,
+      "end": 1267
     },
     "context": {
       "type": "variable",
@@ -18133,8 +18182,8 @@
       "value": "$sprk-font-size-body-four",
       "scope": "default",
       "line": {
-        "start": 1265,
-        "end": 1265
+        "start": 1268,
+        "end": 1268
       }
     },
     "access": "public",
@@ -18149,8 +18198,8 @@
   {
     "description": "The font weight of the header in the Grouped Columns Table variant.\n",
     "commentRange": {
-      "start": 1266,
-      "end": 1266
+      "start": 1269,
+      "end": 1269
     },
     "context": {
       "type": "variable",
@@ -18158,8 +18207,8 @@
       "value": "normal",
       "scope": "default",
       "line": {
-        "start": 1267,
-        "end": 1267
+        "start": 1270,
+        "end": 1270
       }
     },
     "access": "public",
@@ -18174,8 +18223,8 @@
   {
     "description": "The distance between the borders of\nadjacent cells in the Secondary Row\nComparison Table (horizontal | vertical).\n",
     "commentRange": {
-      "start": 1270,
-      "end": 1272
+      "start": 1273,
+      "end": 1275
     },
     "context": {
       "type": "variable",
@@ -18183,8 +18232,8 @@
       "value": "0 15px",
       "scope": "default",
       "line": {
-        "start": 1273,
-        "end": 1273
+        "start": 1276,
+        "end": 1276
       }
     },
     "access": "public",
@@ -18199,8 +18248,8 @@
   {
     "description": "The width of the borders in the Secondary Row Comparison Table cells.\n",
     "commentRange": {
-      "start": 1274,
-      "end": 1274
+      "start": 1277,
+      "end": 1277
     },
     "context": {
       "type": "variable",
@@ -18208,8 +18257,8 @@
       "value": "1px",
       "scope": "default",
       "line": {
-        "start": 1275,
-        "end": 1275
+        "start": 1278,
+        "end": 1278
       }
     },
     "access": "public",
@@ -18224,8 +18273,8 @@
   {
     "description": "The style of the borders in the Secondary Row Comparison Table cells.\n",
     "commentRange": {
-      "start": 1276,
-      "end": 1276
+      "start": 1279,
+      "end": 1279
     },
     "context": {
       "type": "variable",
@@ -18233,8 +18282,8 @@
       "value": "solid",
       "scope": "default",
       "line": {
-        "start": 1277,
-        "end": 1277
+        "start": 1280,
+        "end": 1280
       }
     },
     "access": "public",
@@ -18249,8 +18298,8 @@
   {
     "description": "The color of the borders in the Secondary Row Comparison Table cells.\n",
     "commentRange": {
-      "start": 1278,
-      "end": 1278
+      "start": 1281,
+      "end": 1281
     },
     "context": {
       "type": "variable",
@@ -18258,8 +18307,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1279,
-        "end": 1279
+        "start": 1282,
+        "end": 1282
       }
     },
     "access": "public",
@@ -18274,8 +18323,8 @@
   {
     "description": "The padding of the tiny Box object.\n",
     "commentRange": {
-      "start": 1285,
-      "end": 1285
+      "start": 1288,
+      "end": 1288
     },
     "context": {
       "type": "variable",
@@ -18283,8 +18332,8 @@
       "value": "$sprk-space-inset-xs",
       "scope": "default",
       "line": {
-        "start": 1286,
-        "end": 1286
+        "start": 1289,
+        "end": 1289
       }
     },
     "access": "public",
@@ -18299,8 +18348,8 @@
   {
     "description": "The padding of the small Box object.\n",
     "commentRange": {
-      "start": 1287,
-      "end": 1287
+      "start": 1290,
+      "end": 1290
     },
     "context": {
       "type": "variable",
@@ -18308,8 +18357,8 @@
       "value": "$sprk-space-inset-s",
       "scope": "default",
       "line": {
-        "start": 1288,
-        "end": 1288
+        "start": 1291,
+        "end": 1291
       }
     },
     "access": "public",
@@ -18324,8 +18373,8 @@
   {
     "description": "The padding of the default (medium) Box object.\n",
     "commentRange": {
-      "start": 1289,
-      "end": 1289
+      "start": 1292,
+      "end": 1292
     },
     "context": {
       "type": "variable",
@@ -18333,8 +18382,8 @@
       "value": "$sprk-space-inset-m",
       "scope": "default",
       "line": {
-        "start": 1290,
-        "end": 1290
+        "start": 1293,
+        "end": 1293
       }
     },
     "access": "public",
@@ -18349,8 +18398,8 @@
   {
     "description": "The padding of the large Box object.\n",
     "commentRange": {
-      "start": 1291,
-      "end": 1291
+      "start": 1294,
+      "end": 1294
     },
     "context": {
       "type": "variable",
@@ -18358,8 +18407,8 @@
       "value": "$sprk-space-inset-l",
       "scope": "default",
       "line": {
-        "start": 1292,
-        "end": 1292
+        "start": 1295,
+        "end": 1295
       }
     },
     "access": "public",
@@ -18374,8 +18423,8 @@
   {
     "description": "The padding of the huge Box object.\n",
     "commentRange": {
-      "start": 1293,
-      "end": 1293
+      "start": 1296,
+      "end": 1296
     },
     "context": {
       "type": "variable",
@@ -18383,8 +18432,8 @@
       "value": "$sprk-space-inset-xl",
       "scope": "default",
       "line": {
-        "start": 1294,
-        "end": 1294
+        "start": 1297,
+        "end": 1297
       }
     },
     "access": "public",
@@ -18399,8 +18448,8 @@
   {
     "description": "The gutter of the tiny Media object.\n",
     "commentRange": {
-      "start": 1300,
-      "end": 1300
+      "start": 1303,
+      "end": 1303
     },
     "context": {
       "type": "variable",
@@ -18408,8 +18457,8 @@
       "value": "$sprk-space-xs",
       "scope": "default",
       "line": {
-        "start": 1301,
-        "end": 1301
+        "start": 1304,
+        "end": 1304
       }
     },
     "access": "public",
@@ -18424,8 +18473,8 @@
   {
     "description": "The gutter of the small Media object.\n",
     "commentRange": {
-      "start": 1302,
-      "end": 1302
+      "start": 1305,
+      "end": 1305
     },
     "context": {
       "type": "variable",
@@ -18433,8 +18482,8 @@
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1303,
-        "end": 1303
+        "start": 1306,
+        "end": 1306
       }
     },
     "access": "public",
@@ -18449,8 +18498,8 @@
   {
     "description": "The gutter of the default (medium) Media object.\n",
     "commentRange": {
-      "start": 1304,
-      "end": 1304
+      "start": 1307,
+      "end": 1307
     },
     "context": {
       "type": "variable",
@@ -18458,8 +18507,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1305,
-        "end": 1305
+        "start": 1308,
+        "end": 1308
       }
     },
     "access": "public",
@@ -18474,8 +18523,8 @@
   {
     "description": "The gutter of the large Media object.\n",
     "commentRange": {
-      "start": 1306,
-      "end": 1306
+      "start": 1309,
+      "end": 1309
     },
     "context": {
       "type": "variable",
@@ -18483,8 +18532,8 @@
       "value": "$sprk-space-l",
       "scope": "default",
       "line": {
-        "start": 1307,
-        "end": 1307
+        "start": 1310,
+        "end": 1310
       }
     },
     "access": "public",
@@ -18499,8 +18548,8 @@
   {
     "description": "The gutter of the huge Media object.\n",
     "commentRange": {
-      "start": 1308,
-      "end": 1308
+      "start": 1311,
+      "end": 1311
     },
     "context": {
       "type": "variable",
@@ -18508,8 +18557,8 @@
       "value": "$sprk-space-xl",
       "scope": "default",
       "line": {
-        "start": 1309,
-        "end": 1309
+        "start": 1312,
+        "end": 1312
       }
     },
     "access": "public",
@@ -18524,8 +18573,8 @@
   {
     "description": "\nThe spacing of the tiny Stack object.\n",
     "commentRange": {
-      "start": 1313,
-      "end": 1314
+      "start": 1316,
+      "end": 1317
     },
     "context": {
       "type": "variable",
@@ -18533,8 +18582,8 @@
       "value": "$sprk-space-xs",
       "scope": "default",
       "line": {
-        "start": 1315,
-        "end": 1315
+        "start": 1318,
+        "end": 1318
       }
     },
     "access": "public",
@@ -18549,8 +18598,8 @@
   {
     "description": "The spacing of the small Stack object.\n",
     "commentRange": {
-      "start": 1316,
-      "end": 1316
+      "start": 1319,
+      "end": 1319
     },
     "context": {
       "type": "variable",
@@ -18558,8 +18607,8 @@
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1317,
-        "end": 1317
+        "start": 1320,
+        "end": 1320
       }
     },
     "access": "public",
@@ -18574,8 +18623,8 @@
   {
     "description": "The spacing of the medium Stack object.\n",
     "commentRange": {
-      "start": 1318,
-      "end": 1318
+      "start": 1321,
+      "end": 1321
     },
     "context": {
       "type": "variable",
@@ -18583,8 +18632,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1319,
-        "end": 1319
+        "start": 1322,
+        "end": 1322
       }
     },
     "access": "public",
@@ -18599,8 +18648,8 @@
   {
     "description": "The spacing of the large Stack object.\n",
     "commentRange": {
-      "start": 1320,
-      "end": 1320
+      "start": 1323,
+      "end": 1323
     },
     "context": {
       "type": "variable",
@@ -18608,8 +18657,8 @@
       "value": "$sprk-space-l",
       "scope": "default",
       "line": {
-        "start": 1321,
-        "end": 1321
+        "start": 1324,
+        "end": 1324
       }
     },
     "access": "public",
@@ -18624,8 +18673,8 @@
   {
     "description": "The spacing of the huge Stack object.\n",
     "commentRange": {
-      "start": 1322,
-      "end": 1322
+      "start": 1325,
+      "end": 1325
     },
     "context": {
       "type": "variable",
@@ -18633,8 +18682,8 @@
       "value": "$sprk-space-xl",
       "scope": "default",
       "line": {
-        "start": 1323,
-        "end": 1323
+        "start": 1326,
+        "end": 1326
       }
     },
     "access": "public",
@@ -18649,8 +18698,8 @@
   {
     "description": "The spacing of the Misc A Stack object.\n",
     "commentRange": {
-      "start": 1324,
-      "end": 1324
+      "start": 1327,
+      "end": 1327
     },
     "context": {
       "type": "variable",
@@ -18658,8 +18707,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 1325,
-        "end": 1325
+        "start": 1328,
+        "end": 1328
       }
     },
     "access": "public",
@@ -18674,8 +18723,8 @@
   {
     "description": "The spacing of the Misc B Stack object.\n",
     "commentRange": {
-      "start": 1326,
-      "end": 1326
+      "start": 1329,
+      "end": 1329
     },
     "context": {
       "type": "variable",
@@ -18683,8 +18732,8 @@
       "value": "$sprk-space-misc-b",
       "scope": "default",
       "line": {
-        "start": 1327,
-        "end": 1327
+        "start": 1330,
+        "end": 1330
       }
     },
     "access": "public",
@@ -18699,8 +18748,8 @@
   {
     "description": "The spacing of the Misc C Stack object.\n",
     "commentRange": {
-      "start": 1328,
-      "end": 1328
+      "start": 1331,
+      "end": 1331
     },
     "context": {
       "type": "variable",
@@ -18708,8 +18757,8 @@
       "value": "$sprk-space-misc-c",
       "scope": "default",
       "line": {
-        "start": 1329,
-        "end": 1329
+        "start": 1332,
+        "end": 1332
       }
     },
     "access": "public",
@@ -18724,38 +18773,13 @@
   {
     "description": "The spacing of the Misc D Stack object.\n",
     "commentRange": {
-      "start": 1330,
-      "end": 1330
+      "start": 1333,
+      "end": 1333
     },
     "context": {
       "type": "variable",
       "name": "sprk-stack-spacing-misc-d",
       "value": "$sprk-space-misc-d",
-      "scope": "default",
-      "line": {
-        "start": 1331,
-        "end": 1331
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The breakpoint for Stack objects\nthat split at the extra extra small point.\n",
-    "commentRange": {
-      "start": 1332,
-      "end": 1333
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-split-breakpoint-xxs",
-      "value": "20rem",
       "scope": "default",
       "line": {
         "start": 1334,
@@ -18772,15 +18796,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that\nsplit at the extra small point.\n",
+    "description": "The breakpoint for Stack objects\nthat split at the extra extra small point.\n",
     "commentRange": {
       "start": 1335,
       "end": 1336
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-xs",
-      "value": "30rem",
+      "name": "sprk-split-breakpoint-xxs",
+      "value": "20rem",
       "scope": "default",
       "line": {
         "start": 1337,
@@ -18797,15 +18821,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that split at the\nsmall point.\n",
+    "description": "The breakpoint for Stack objects that\nsplit at the extra small point.\n",
     "commentRange": {
       "start": 1338,
       "end": 1339
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-s",
-      "value": "42.5rem",
+      "name": "sprk-split-breakpoint-xs",
+      "value": "30rem",
       "scope": "default",
       "line": {
         "start": 1340,
@@ -18822,15 +18846,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that split at the\nmedium point.\n",
+    "description": "The breakpoint for Stack objects that split at the\nsmall point.\n",
     "commentRange": {
       "start": 1341,
       "end": 1342
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-m",
-      "value": "55rem",
+      "name": "sprk-split-breakpoint-s",
+      "value": "42.5rem",
       "scope": "default",
       "line": {
         "start": 1343,
@@ -18847,15 +18871,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that split at the\nlarge point.\n",
+    "description": "The breakpoint for Stack objects that split at the\nmedium point.\n",
     "commentRange": {
       "start": 1344,
       "end": 1345
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-l",
-      "value": "67.5rem",
+      "name": "sprk-split-breakpoint-m",
+      "value": "55rem",
       "scope": "default",
       "line": {
         "start": 1346,
@@ -18872,15 +18896,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that split at the\nextra large point.\n",
+    "description": "The breakpoint for Stack objects that split at the\nlarge point.\n",
     "commentRange": {
       "start": 1347,
       "end": 1348
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-xl",
-      "value": "80rem",
+      "name": "sprk-split-breakpoint-l",
+      "value": "67.5rem",
       "scope": "default",
       "line": {
         "start": 1349,
@@ -18897,10 +18921,35 @@
     }
   },
   {
+    "description": "The breakpoint for Stack objects that split at the\nextra large point.\n",
+    "commentRange": {
+      "start": 1350,
+      "end": 1351
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-split-breakpoint-xl",
+      "value": "80rem",
+      "scope": "default",
+      "line": {
+        "start": 1352,
+        "end": 1352
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
     "description": "The value for color of Dividers.\n",
     "commentRange": {
-      "start": 1355,
-      "end": 1355
+      "start": 1358,
+      "end": 1358
     },
     "context": {
       "type": "variable",
@@ -18908,8 +18957,8 @@
       "value": "rgb(230, 230, 230)",
       "scope": "default",
       "line": {
-        "start": 1356,
-        "end": 1356
+        "start": 1359,
+        "end": 1359
       }
     },
     "access": "public",
@@ -18924,8 +18973,8 @@
   {
     "description": "The value of border for Dividers.\n",
     "commentRange": {
-      "start": 1357,
-      "end": 1357
+      "start": 1360,
+      "end": 1360
     },
     "context": {
       "type": "variable",
@@ -18933,8 +18982,8 @@
       "value": "2px solid $sprk-divider-color",
       "scope": "default",
       "line": {
-        "start": 1358,
-        "end": 1358
+        "start": 1361,
+        "end": 1361
       }
     },
     "access": "public",
@@ -18949,8 +18998,8 @@
   {
     "description": "The maximum width of Accordions.\n",
     "commentRange": {
-      "start": 1364,
-      "end": 1364
+      "start": 1367,
+      "end": 1367
     },
     "context": {
       "type": "variable",
@@ -18958,8 +19007,8 @@
       "value": "53.125rem",
       "scope": "default",
       "line": {
-        "start": 1365,
-        "end": 1365
+        "start": 1368,
+        "end": 1368
       }
     },
     "access": "public",
@@ -18974,8 +19023,8 @@
   {
     "description": "The border of Accordions.\n",
     "commentRange": {
-      "start": 1366,
-      "end": 1366
+      "start": 1369,
+      "end": 1369
     },
     "context": {
       "type": "variable",
@@ -18983,8 +19032,8 @@
       "value": "$sprk-divider-border",
       "scope": "default",
       "line": {
-        "start": 1367,
-        "end": 1367
+        "start": 1370,
+        "end": 1370
       }
     },
     "access": "public",
@@ -18999,8 +19048,8 @@
   {
     "description": "The font color of the Accordion item summary.\n",
     "commentRange": {
-      "start": 1368,
-      "end": 1368
+      "start": 1371,
+      "end": 1371
     },
     "context": {
       "type": "variable",
@@ -19008,8 +19057,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1369,
-        "end": 1369
+        "start": 1372,
+        "end": 1372
       }
     },
     "access": "public",
@@ -19024,8 +19073,8 @@
   {
     "description": "The background color of the Accordion item summary.\n",
     "commentRange": {
-      "start": 1370,
-      "end": 1370
+      "start": 1373,
+      "end": 1373
     },
     "context": {
       "type": "variable",
@@ -19033,8 +19082,8 @@
       "value": "transparent",
       "scope": "default",
       "line": {
-        "start": 1371,
-        "end": 1371
+        "start": 1374,
+        "end": 1374
       }
     },
     "access": "public",
@@ -19049,8 +19098,8 @@
   {
     "description": "The text-align value of the Accordion item summary.\n",
     "commentRange": {
-      "start": 1372,
-      "end": 1372
+      "start": 1375,
+      "end": 1375
     },
     "context": {
       "type": "variable",
@@ -19058,8 +19107,8 @@
       "value": "left",
       "scope": "default",
       "line": {
-        "start": 1373,
-        "end": 1373
+        "start": 1376,
+        "end": 1376
       }
     },
     "access": "public",
@@ -19074,38 +19123,13 @@
   {
     "description": "The border of the Accordion item summary.\n",
     "commentRange": {
-      "start": 1374,
-      "end": 1374
+      "start": 1377,
+      "end": 1377
     },
     "context": {
       "type": "variable",
       "name": "sprk-accordion-summary-border",
       "value": "none",
-      "scope": "default",
-      "line": {
-        "start": 1375,
-        "end": 1375
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the icon in the summary when the\nAccordion item is open or hovered.\n",
-    "commentRange": {
-      "start": 1376,
-      "end": 1377
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-accordion-summary-active-color",
-      "value": "$sprk-green",
       "scope": "default",
       "line": {
         "start": 1378,
@@ -19122,10 +19146,35 @@
     }
   },
   {
-    "description": "The padding of the Accordion summary.\n",
+    "description": "The color of the icon in the summary when the\nAccordion item is open or hovered.\n",
     "commentRange": {
       "start": 1379,
-      "end": 1379
+      "end": 1380
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-accordion-summary-active-color",
+      "value": "$sprk-green",
+      "scope": "default",
+      "line": {
+        "start": 1381,
+        "end": 1381
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding of the Accordion summary.\n",
+    "commentRange": {
+      "start": 1382,
+      "end": 1382
     },
     "context": {
       "type": "variable",
@@ -19133,8 +19182,8 @@
       "value": "$sprk-space-misc-a 0",
       "scope": "default",
       "line": {
-        "start": 1380,
-        "end": 1380
+        "start": 1383,
+        "end": 1383
       }
     },
     "access": "public",
@@ -19149,38 +19198,13 @@
   {
     "description": "The padding of the Accordion content.\n",
     "commentRange": {
-      "start": 1381,
-      "end": 1381
+      "start": 1384,
+      "end": 1384
     },
     "context": {
       "type": "variable",
       "name": "sprk-accordion-content-padding",
       "value": "0 0 $sprk-space-l",
-      "scope": "default",
-      "line": {
-        "start": 1382,
-        "end": 1382
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The background color used for hover\nand active on items in the Accordion.\n",
-    "commentRange": {
-      "start": 1383,
-      "end": 1384
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-accordion-active-background-color",
-      "value": "$sprk-gray",
       "scope": "default",
       "line": {
         "start": 1385,
@@ -19197,10 +19221,35 @@
     }
   },
   {
-    "description": "The text decoration of the Accordion item summary.\n",
+    "description": "The background color used for hover\nand active on items in the Accordion.\n",
     "commentRange": {
       "start": 1386,
-      "end": 1386
+      "end": 1387
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-accordion-active-background-color",
+      "value": "$sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1388,
+        "end": 1388
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The text decoration of the Accordion item summary.\n",
+    "commentRange": {
+      "start": 1389,
+      "end": 1389
     },
     "context": {
       "type": "variable",
@@ -19208,8 +19257,8 @@
       "value": "none",
       "scope": "private",
       "line": {
-        "start": 1387,
-        "end": 1387
+        "start": 1390,
+        "end": 1390
       }
     },
     "access": "public",
@@ -19224,8 +19273,8 @@
   {
     "description": "The text decoration of the Accordion item summary when active.\n",
     "commentRange": {
-      "start": 1388,
-      "end": 1388
+      "start": 1391,
+      "end": 1391
     },
     "context": {
       "type": "variable",
@@ -19233,8 +19282,8 @@
       "value": "none",
       "scope": "private",
       "line": {
-        "start": 1389,
-        "end": 1389
+        "start": 1392,
+        "end": 1392
       }
     },
     "access": "public",
@@ -19249,8 +19298,8 @@
   {
     "description": "The top border style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1395,
-      "end": 1395
+      "start": 1398,
+      "end": 1398
     },
     "context": {
       "type": "variable",
@@ -19258,8 +19307,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1396,
-        "end": 1396
+        "start": 1399,
+        "end": 1399
       }
     },
     "access": "public",
@@ -19274,8 +19323,8 @@
   {
     "description": "The right border style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1397,
-      "end": 1397
+      "start": 1400,
+      "end": 1400
     },
     "context": {
       "type": "variable",
@@ -19283,8 +19332,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1398,
-        "end": 1398
+        "start": 1401,
+        "end": 1401
       }
     },
     "access": "public",
@@ -19299,8 +19348,8 @@
   {
     "description": "The bottom border style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1399,
-      "end": 1399
+      "start": 1402,
+      "end": 1402
     },
     "context": {
       "type": "variable",
@@ -19308,8 +19357,8 @@
       "value": "$sprk-link-has-icon-border-bottom",
       "scope": "default",
       "line": {
-        "start": 1400,
-        "end": 1400
+        "start": 1403,
+        "end": 1403
       }
     },
     "access": "public",
@@ -19324,8 +19373,8 @@
   {
     "description": "The left border style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1401,
-      "end": 1401
+      "start": 1404,
+      "end": 1404
     },
     "context": {
       "type": "variable",
@@ -19333,8 +19382,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1402,
-        "end": 1402
+        "start": 1405,
+        "end": 1405
       }
     },
     "access": "public",
@@ -19349,8 +19398,8 @@
   {
     "description": "The text decoration style Toggle Trigger.\n",
     "commentRange": {
-      "start": 1403,
-      "end": 1403
+      "start": 1406,
+      "end": 1406
     },
     "context": {
       "type": "variable",
@@ -19358,8 +19407,8 @@
       "value": "$sprk-link-text-decoration",
       "scope": "default",
       "line": {
-        "start": 1404,
-        "end": 1404
+        "start": 1407,
+        "end": 1407
       }
     },
     "access": "public",
@@ -19374,8 +19423,8 @@
   {
     "description": "The transition for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1405,
-      "end": 1405
+      "start": 1408,
+      "end": 1408
     },
     "context": {
       "type": "variable",
@@ -19383,8 +19432,8 @@
       "value": "$sprk-link-transition",
       "scope": "default",
       "line": {
-        "start": 1406,
-        "end": 1406
+        "start": 1409,
+        "end": 1409
       }
     },
     "access": "public",
@@ -19399,8 +19448,8 @@
   {
     "description": "The hover border bottom style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1407,
-      "end": 1407
+      "start": 1410,
+      "end": 1410
     },
     "context": {
       "type": "variable",
@@ -19408,8 +19457,8 @@
       "value": "$sprk-link-has-icon-hover-border-bottom",
       "scope": "default",
       "line": {
-        "start": 1408,
-        "end": 1408
+        "start": 1411,
+        "end": 1411
       }
     },
     "access": "public",
@@ -19424,8 +19473,8 @@
   {
     "description": "The hover text color for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1409,
-      "end": 1409
+      "start": 1412,
+      "end": 1412
     },
     "context": {
       "type": "variable",
@@ -19433,8 +19482,8 @@
       "value": "$sprk-link-has-icon-hover-color-text",
       "scope": "default",
       "line": {
-        "start": 1410,
-        "end": 1410
+        "start": 1413,
+        "end": 1413
       }
     },
     "access": "public",
@@ -19449,8 +19498,8 @@
   {
     "description": "The background color for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1411,
-      "end": 1411
+      "start": 1414,
+      "end": 1414
     },
     "context": {
       "type": "variable",
@@ -19458,8 +19507,8 @@
       "value": "transparent",
       "scope": "default",
       "line": {
-        "start": 1412,
-        "end": 1412
+        "start": 1415,
+        "end": 1415
       }
     },
     "access": "public",
@@ -19474,8 +19523,8 @@
   {
     "description": "The padding top for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1413,
-      "end": 1413
+      "start": 1416,
+      "end": 1416
     },
     "context": {
       "type": "variable",
@@ -19483,8 +19532,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1414,
-        "end": 1414
+        "start": 1417,
+        "end": 1417
       }
     },
     "access": "public",
@@ -19499,8 +19548,8 @@
   {
     "description": "The padding right for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1415,
-      "end": 1415
+      "start": 1418,
+      "end": 1418
     },
     "context": {
       "type": "variable",
@@ -19508,8 +19557,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1416,
-        "end": 1416
+        "start": 1419,
+        "end": 1419
       }
     },
     "access": "public",
@@ -19524,8 +19573,8 @@
   {
     "description": "The padding bottom for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1417,
-      "end": 1417
+      "start": 1420,
+      "end": 1420
     },
     "context": {
       "type": "variable",
@@ -19533,8 +19582,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1418,
-        "end": 1418
+        "start": 1421,
+        "end": 1421
       }
     },
     "access": "public",
@@ -19549,8 +19598,8 @@
   {
     "description": "The padding left for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1419,
-      "end": 1419
+      "start": 1422,
+      "end": 1422
     },
     "context": {
       "type": "variable",
@@ -19558,8 +19607,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1420,
-        "end": 1420
+        "start": 1423,
+        "end": 1423
       }
     },
     "access": "public",
@@ -19574,8 +19623,8 @@
   {
     "description": "The text alignment for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1421,
-      "end": 1421
+      "start": 1424,
+      "end": 1424
     },
     "context": {
       "type": "variable",
@@ -19583,8 +19632,8 @@
       "value": "left",
       "scope": "default",
       "line": {
-        "start": 1422,
-        "end": 1422
+        "start": 1425,
+        "end": 1425
       }
     },
     "access": "public",
@@ -19599,8 +19648,8 @@
   {
     "description": "The font size for small Toggle Trigger.\n",
     "commentRange": {
-      "start": 1423,
-      "end": 1423
+      "start": 1426,
+      "end": 1426
     },
     "context": {
       "type": "variable",
@@ -19608,8 +19657,8 @@
       "value": "$sprk-font-size-body-four",
       "scope": "default",
       "line": {
-        "start": 1424,
-        "end": 1424
+        "start": 1427,
+        "end": 1427
       }
     },
     "access": "public",
@@ -19624,8 +19673,8 @@
   {
     "description": "The font weight for small Toggle Trigger.\n",
     "commentRange": {
-      "start": 1425,
-      "end": 1425
+      "start": 1428,
+      "end": 1428
     },
     "context": {
       "type": "variable",
@@ -19633,8 +19682,8 @@
       "value": "normal",
       "scope": "default",
       "line": {
-        "start": 1426,
-        "end": 1426
+        "start": 1429,
+        "end": 1429
       }
     },
     "access": "public",
@@ -19649,8 +19698,8 @@
   {
     "description": "The transition timing for the\nrotation of the icon when the Toggle is opened.\n",
     "commentRange": {
-      "start": 1428,
-      "end": 1429
+      "start": 1431,
+      "end": 1432
     },
     "context": {
       "type": "variable",
@@ -19658,8 +19707,8 @@
       "value": "0.3s ease",
       "scope": "default",
       "line": {
-        "start": 1430,
-        "end": 1430
+        "start": 1433,
+        "end": 1433
       }
     },
     "access": "public",
@@ -19674,8 +19723,8 @@
   {
     "description": "Background color of the Dropdown items that\nare active or hovered.\n",
     "commentRange": {
-      "start": 1437,
-      "end": 1438
+      "start": 1440,
+      "end": 1441
     },
     "context": {
       "type": "variable",
@@ -19683,8 +19732,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1439,
-        "end": 1439
+        "start": 1442,
+        "end": 1442
       }
     },
     "access": "public",
@@ -19699,8 +19748,8 @@
   {
     "description": "The left border of the Dropdown item that is active.\n",
     "commentRange": {
-      "start": 1440,
-      "end": 1440
+      "start": 1443,
+      "end": 1443
     },
     "context": {
       "type": "variable",
@@ -19708,8 +19757,8 @@
       "value": "2.5px solid $sprk-green",
       "scope": "default",
       "line": {
-        "start": 1441,
-        "end": 1441
+        "start": 1444,
+        "end": 1444
       }
     },
     "access": "public",
@@ -19724,8 +19773,8 @@
   {
     "description": "The box-shadow of the Dropdown item that is active.\n",
     "commentRange": {
-      "start": 1442,
-      "end": 1442
+      "start": 1445,
+      "end": 1445
     },
     "context": {
       "type": "variable",
@@ -19733,8 +19782,8 @@
       "value": "-1px 0 0 0 $sprk-green",
       "scope": "default",
       "line": {
-        "start": 1443,
-        "end": 1443
+        "start": 1446,
+        "end": 1446
       }
     },
     "access": "public",
@@ -19749,8 +19798,8 @@
   {
     "description": "The border of the Dropdown.\n",
     "commentRange": {
-      "start": 1444,
-      "end": 1444
+      "start": 1447,
+      "end": 1447
     },
     "context": {
       "type": "variable",
@@ -19758,8 +19807,8 @@
       "value": "1px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1445,
-        "end": 1445
+        "start": 1448,
+        "end": 1448
       }
     },
     "access": "public",
@@ -19774,8 +19823,8 @@
   {
     "description": "The font size of the Dropdown.\n",
     "commentRange": {
-      "start": 1446,
-      "end": 1446
+      "start": 1449,
+      "end": 1449
     },
     "context": {
       "type": "variable",
@@ -19783,8 +19832,8 @@
       "value": "$sprk-font-size-body-one",
       "scope": "default",
       "line": {
-        "start": 1447,
-        "end": 1447
+        "start": 1450,
+        "end": 1450
       }
     },
     "access": "public",
@@ -19799,38 +19848,13 @@
   {
     "description": "The font weight of the Dropdown.\n",
     "commentRange": {
-      "start": 1448,
-      "end": 1448
+      "start": 1451,
+      "end": 1451
     },
     "context": {
       "type": "variable",
       "name": "sprk-dropdown-font-weight",
       "value": "400",
-      "scope": "default",
-      "line": {
-        "start": 1449,
-        "end": 1449
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding around the Informational Dropdown\nfooter.\n",
-    "commentRange": {
-      "start": 1450,
-      "end": 1451
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-footer-padding",
-      "value": "$sprk-space-inset-short-l",
       "scope": "default",
       "line": {
         "start": 1452,
@@ -19847,10 +19871,35 @@
     }
   },
   {
-    "description": "The line height of the Dropdown.\n",
+    "description": "The padding around the Informational Dropdown\nfooter.\n",
     "commentRange": {
       "start": 1453,
-      "end": 1453
+      "end": 1454
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-footer-padding",
+      "value": "$sprk-space-inset-short-l",
+      "scope": "default",
+      "line": {
+        "start": 1455,
+        "end": 1455
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The line height of the Dropdown.\n",
+    "commentRange": {
+      "start": 1456,
+      "end": 1456
     },
     "context": {
       "type": "variable",
@@ -19858,8 +19907,8 @@
       "value": "1",
       "scope": "default",
       "line": {
-        "start": 1454,
-        "end": 1454
+        "start": 1457,
+        "end": 1457
       }
     },
     "access": "public",
@@ -19874,8 +19923,8 @@
   {
     "description": "The max-width of the Dropdown.\n",
     "commentRange": {
-      "start": 1455,
-      "end": 1455
+      "start": 1458,
+      "end": 1458
     },
     "context": {
       "type": "variable",
@@ -19883,8 +19932,8 @@
       "value": "24rem",
       "scope": "default",
       "line": {
-        "start": 1456,
-        "end": 1456
+        "start": 1459,
+        "end": 1459
       }
     },
     "access": "public",
@@ -19899,8 +19948,8 @@
   {
     "description": "The padding around the Dropdown items.\n",
     "commentRange": {
-      "start": 1457,
-      "end": 1457
+      "start": 1460,
+      "end": 1460
     },
     "context": {
       "type": "variable",
@@ -19908,8 +19957,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 1458,
-        "end": 1458
+        "start": 1461,
+        "end": 1461
       }
     },
     "access": "public",
@@ -19924,8 +19973,8 @@
   {
     "description": "The box shadow of the Dropdown.\n",
     "commentRange": {
-      "start": 1459,
-      "end": 1459
+      "start": 1462,
+      "end": 1462
     },
     "context": {
       "type": "variable",
@@ -19933,8 +19982,8 @@
       "value": "0 0 40px 2px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1460,
-        "end": 1460
+        "start": 1463,
+        "end": 1463
       }
     },
     "access": "public",
@@ -19949,8 +19998,8 @@
   {
     "description": "The color of the Dropdown title.\n",
     "commentRange": {
-      "start": 1461,
-      "end": 1461
+      "start": 1464,
+      "end": 1464
     },
     "context": {
       "type": "variable",
@@ -19958,8 +20007,8 @@
       "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
-        "start": 1462,
-        "end": 1462
+        "start": 1465,
+        "end": 1465
       }
     },
     "access": "public",
@@ -19974,8 +20023,8 @@
   {
     "description": "The font size of the Dropdown title.\n",
     "commentRange": {
-      "start": 1463,
-      "end": 1463
+      "start": 1466,
+      "end": 1466
     },
     "context": {
       "type": "variable",
@@ -19983,8 +20032,8 @@
       "value": "$sprk-dropdown-font-size",
       "scope": "default",
       "line": {
-        "start": 1464,
-        "end": 1464
+        "start": 1467,
+        "end": 1467
       }
     },
     "access": "public",
@@ -19999,8 +20048,8 @@
   {
     "description": "The font weight of the Dropdown title.\n",
     "commentRange": {
-      "start": 1465,
-      "end": 1465
+      "start": 1468,
+      "end": 1468
     },
     "context": {
       "type": "variable",
@@ -20008,8 +20057,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 1466,
-        "end": 1466
+        "start": 1469,
+        "end": 1469
       }
     },
     "access": "public",
@@ -20024,8 +20073,8 @@
   {
     "description": "The color of the mask overlay that is shown behind the Modal.\n",
     "commentRange": {
-      "start": 1472,
-      "end": 1472
+      "start": 1475,
+      "end": 1475
     },
     "context": {
       "type": "variable",
@@ -20033,8 +20082,8 @@
       "value": "rgba(34, 34, 34, 0.35)",
       "scope": "default",
       "line": {
-        "start": 1473,
-        "end": 1473
+        "start": 1476,
+        "end": 1476
       }
     },
     "access": "public",
@@ -20049,8 +20098,8 @@
   {
     "description": "The background color of the Modal.\n",
     "commentRange": {
-      "start": 1474,
-      "end": 1474
+      "start": 1477,
+      "end": 1477
     },
     "context": {
       "type": "variable",
@@ -20058,8 +20107,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1475,
-        "end": 1475
+        "start": 1478,
+        "end": 1478
       }
     },
     "access": "public",
@@ -20074,8 +20123,8 @@
   {
     "description": "The maximum width of the Modal.\n",
     "commentRange": {
-      "start": 1476,
-      "end": 1476
+      "start": 1479,
+      "end": 1479
     },
     "context": {
       "type": "variable",
@@ -20083,8 +20132,8 @@
       "value": "43.75rem",
       "scope": "default",
       "line": {
-        "start": 1477,
-        "end": 1477
+        "start": 1480,
+        "end": 1480
       }
     },
     "access": "public",
@@ -20099,8 +20148,8 @@
   {
     "description": "The maximum height of the Modal.\n",
     "commentRange": {
-      "start": 1478,
-      "end": 1478
+      "start": 1481,
+      "end": 1481
     },
     "context": {
       "type": "variable",
@@ -20108,8 +20157,8 @@
       "value": "70%",
       "scope": "default",
       "line": {
-        "start": 1479,
-        "end": 1479
+        "start": 1482,
+        "end": 1482
       }
     },
     "access": "public",
@@ -20124,8 +20173,8 @@
   {
     "description": "Determines how far down\nfrom the top of the page the\nModal renders at the small breakpoint.\n",
     "commentRange": {
-      "start": 1480,
-      "end": 1482
+      "start": 1483,
+      "end": 1485
     },
     "context": {
       "type": "variable",
@@ -20133,8 +20182,8 @@
       "value": "25rem",
       "scope": "default",
       "line": {
-        "start": 1483,
-        "end": 1483
+        "start": 1486,
+        "end": 1486
       }
     },
     "access": "public",
@@ -20149,8 +20198,8 @@
   {
     "description": "Determines how far down\nfrom the top of the page the\nModal renders at the medium breakpoint.\n",
     "commentRange": {
-      "start": 1484,
-      "end": 1486
+      "start": 1487,
+      "end": 1489
     },
     "context": {
       "type": "variable",
@@ -20158,8 +20207,8 @@
       "value": "37.5rem",
       "scope": "default",
       "line": {
-        "start": 1487,
-        "end": 1487
+        "start": 1490,
+        "end": 1490
       }
     },
     "access": "public",
@@ -20174,8 +20223,8 @@
   {
     "description": "The box shadow on the Modal.\n",
     "commentRange": {
-      "start": 1488,
-      "end": 1488
+      "start": 1491,
+      "end": 1491
     },
     "context": {
       "type": "variable",
@@ -20183,8 +20232,8 @@
       "value": "0 4px 5px rgba(0, 0, 0, 0.6)",
       "scope": "default",
       "line": {
-        "start": 1489,
-        "end": 1489
+        "start": 1492,
+        "end": 1492
       }
     },
     "access": "public",
@@ -20199,8 +20248,8 @@
   {
     "description": "The border radius on the Modal.\n",
     "commentRange": {
-      "start": 1490,
-      "end": 1490
+      "start": 1493,
+      "end": 1493
     },
     "context": {
       "type": "variable",
@@ -20208,8 +20257,8 @@
       "value": "8px",
       "scope": "default",
       "line": {
-        "start": 1491,
-        "end": 1491
+        "start": 1494,
+        "end": 1494
       }
     },
     "access": "public",
@@ -20224,8 +20273,8 @@
   {
     "description": "The width of the menu icon on narrow viewports in the Masthead.\n",
     "commentRange": {
-      "start": 1497,
-      "end": 1497
+      "start": 1500,
+      "end": 1500
     },
     "context": {
       "type": "variable",
@@ -20233,8 +20282,8 @@
       "value": "$sprk-icon-l",
       "scope": "default",
       "line": {
-        "start": 1498,
-        "end": 1498
+        "start": 1501,
+        "end": 1501
       }
     },
     "access": "public",
@@ -20249,8 +20298,8 @@
   {
     "description": "The height of the menu icon on narrow viewports in the Masthead.\n",
     "commentRange": {
-      "start": 1499,
-      "end": 1499
+      "start": 1502,
+      "end": 1502
     },
     "context": {
       "type": "variable",
@@ -20258,8 +20307,8 @@
       "value": "$sprk-icon-l",
       "scope": "default",
       "line": {
-        "start": 1500,
-        "end": 1500
+        "start": 1503,
+        "end": 1503
       }
     },
     "access": "public",
@@ -20274,8 +20323,8 @@
   {
     "description": "The background color of the Masthead.\n",
     "commentRange": {
-      "start": 1501,
-      "end": 1501
+      "start": 1504,
+      "end": 1504
     },
     "context": {
       "type": "variable",
@@ -20283,8 +20332,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1502,
-        "end": 1502
+        "start": 1505,
+        "end": 1505
       }
     },
     "access": "public",
@@ -20299,37 +20348,12 @@
   {
     "description": "The padding of the Masthead content, menu, and branding sections.\n",
     "commentRange": {
-      "start": 1503,
-      "end": 1503
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-content-padding",
-      "value": "$sprk-space-s",
-      "scope": "default",
-      "line": {
-        "start": 1504,
-        "end": 1504
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding top around the content items in the\ncontent section of the Masthead.\n",
-    "commentRange": {
-      "start": 1505,
+      "start": 1506,
       "end": 1506
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-top",
+      "name": "sprk-masthead-content-padding",
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
@@ -20347,14 +20371,14 @@
     }
   },
   {
-    "description": "The padding bottom around the content\nitems in the content section of the Masthead.\n",
+    "description": "The padding top around the content items in the\ncontent section of the Masthead.\n",
     "commentRange": {
       "start": 1508,
       "end": 1509
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-bottom",
+      "name": "sprk-masthead-content-item-padding-top",
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
@@ -20372,14 +20396,14 @@
     }
   },
   {
-    "description": "The padding right around the content items in the\ncontent section of the Masthead.\n",
+    "description": "The padding bottom around the content\nitems in the content section of the Masthead.\n",
     "commentRange": {
       "start": 1511,
       "end": 1512
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-right",
+      "name": "sprk-masthead-content-item-padding-bottom",
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
@@ -20397,19 +20421,19 @@
     }
   },
   {
-    "description": "The padding around the content\nsection in the Masthead on wide viewports.\n",
+    "description": "The padding right around the content items in the\ncontent section of the Masthead.\n",
     "commentRange": {
-      "start": 1517,
-      "end": 1518
+      "start": 1514,
+      "end": 1515
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-padding-wide",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-content-item-padding-right",
+      "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1519,
-        "end": 1519
+        "start": 1516,
+        "end": 1516
       }
     },
     "access": "public",
@@ -20422,15 +20446,15 @@
     }
   },
   {
-    "description": "The padding top of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The padding around the content\nsection in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1520,
       "end": 1521
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-top-wide",
-      "value": "$sprk-space-s",
+      "name": "sprk-masthead-content-padding-wide",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
         "start": 1522,
@@ -20447,14 +20471,14 @@
     }
   },
   {
-    "description": "The padding bottom of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The padding top of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1523,
       "end": 1524
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-bottom-wide",
+      "name": "sprk-masthead-content-item-padding-top-wide",
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
@@ -20472,15 +20496,15 @@
     }
   },
   {
-    "description": "The padding right of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The padding bottom of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1526,
       "end": 1527
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-right-wide",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-content-item-padding-bottom-wide",
+      "value": "$sprk-space-s",
       "scope": "default",
       "line": {
         "start": 1528,
@@ -20497,14 +20521,14 @@
     }
   },
   {
-    "description": "The padding left of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The padding right of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1529,
       "end": 1530
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-left-wide",
+      "name": "sprk-masthead-content-item-padding-right-wide",
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
@@ -20522,10 +20546,35 @@
     }
   },
   {
-    "description": "The visited state color of Masthead links.\n",
+    "description": "The padding left of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1532,
-      "end": 1532
+      "end": 1533
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-left-wide",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1534,
+        "end": 1534
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The visited state color of Masthead links.\n",
+    "commentRange": {
+      "start": 1535,
+      "end": 1535
     },
     "context": {
       "type": "variable",
@@ -20533,8 +20582,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1533,
-        "end": 1533
+        "start": 1536,
+        "end": 1536
       }
     },
     "access": "public",
@@ -20549,8 +20598,8 @@
   {
     "description": "The hover state color of Masthead links.\n",
     "commentRange": {
-      "start": 1534,
-      "end": 1534
+      "start": 1537,
+      "end": 1537
     },
     "context": {
       "type": "variable",
@@ -20558,8 +20607,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 1535,
-        "end": 1535
+        "start": 1538,
+        "end": 1538
       }
     },
     "access": "public",
@@ -20574,8 +20623,8 @@
   {
     "description": "The font weight for Masthead links.\n",
     "commentRange": {
-      "start": 1536,
-      "end": 1536
+      "start": 1539,
+      "end": 1539
     },
     "context": {
       "type": "variable",
@@ -20583,8 +20632,8 @@
       "value": "500",
       "scope": "default",
       "line": {
-        "start": 1537,
-        "end": 1537
+        "start": 1540,
+        "end": 1540
       }
     },
     "access": "public",
@@ -20599,8 +20648,8 @@
   {
     "description": "The size of the bottom border on the Masthead.\n",
     "commentRange": {
-      "start": 1538,
-      "end": 1538
+      "start": 1541,
+      "end": 1541
     },
     "context": {
       "type": "variable",
@@ -20608,8 +20657,8 @@
       "value": "1px",
       "scope": "default",
       "line": {
-        "start": 1539,
-        "end": 1539
+        "start": 1542,
+        "end": 1542
       }
     },
     "access": "public",
@@ -20624,8 +20673,8 @@
   {
     "description": "The bottom border on the Masthead.\n",
     "commentRange": {
-      "start": 1540,
-      "end": 1540
+      "start": 1543,
+      "end": 1543
     },
     "context": {
       "type": "variable",
@@ -20633,8 +20682,8 @@
       "value": "$sprk-masthead-border-bottom-size solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1541,
-        "end": 1541
+        "start": 1544,
+        "end": 1544
       }
     },
     "access": "public",
@@ -20649,8 +20698,8 @@
   {
     "description": "The bottom border on the Masthead on wide viewports.\n",
     "commentRange": {
-      "start": 1542,
-      "end": 1542
+      "start": 1545,
+      "end": 1545
     },
     "context": {
       "type": "variable",
@@ -20658,8 +20707,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1543,
-        "end": 1543
+        "start": 1546,
+        "end": 1546
       }
     },
     "access": "public",
@@ -20674,8 +20723,8 @@
   {
     "description": "The right border on the site links in the Masthead.\n",
     "commentRange": {
-      "start": 1544,
-      "end": 1544
+      "start": 1547,
+      "end": 1547
     },
     "context": {
       "type": "variable",
@@ -20683,8 +20732,8 @@
       "value": "2px solid $sprk-black-tint-25",
       "scope": "default",
       "line": {
-        "start": 1545,
-        "end": 1545
+        "start": 1548,
+        "end": 1548
       }
     },
     "access": "public",
@@ -20699,8 +20748,8 @@
   {
     "description": "The point at which the Masthead navigation switches\nfrom narrow viewport style to large viewport\nstyle.\n",
     "commentRange": {
-      "start": 1546,
-      "end": 1548
+      "start": 1549,
+      "end": 1551
     },
     "context": {
       "type": "variable",
@@ -20708,8 +20757,8 @@
       "value": "54rem",
       "scope": "default",
       "line": {
-        "start": 1549,
-        "end": 1549
+        "start": 1552,
+        "end": 1552
       }
     },
     "access": "public",
@@ -20724,8 +20773,8 @@
   {
     "description": "The maximum width of the Masthead.\n",
     "commentRange": {
-      "start": 1550,
-      "end": 1550
+      "start": 1553,
+      "end": 1553
     },
     "context": {
       "type": "variable",
@@ -20733,8 +20782,8 @@
       "value": "89rem",
       "scope": "default",
       "line": {
-        "start": 1551,
-        "end": 1551
+        "start": 1554,
+        "end": 1554
       }
     },
     "access": "public",
@@ -20749,8 +20798,8 @@
   {
     "description": "The maximum width of the logo in the Masthead.\n",
     "commentRange": {
-      "start": 1552,
-      "end": 1552
+      "start": 1555,
+      "end": 1555
     },
     "context": {
       "type": "variable",
@@ -20758,8 +20807,8 @@
       "value": "192px",
       "scope": "default",
       "line": {
-        "start": 1553,
-        "end": 1553
+        "start": 1556,
+        "end": 1556
       }
     },
     "access": "public",
@@ -20774,8 +20823,8 @@
   {
     "description": "The minimum width of the logo in the Masthead.\n",
     "commentRange": {
-      "start": 1554,
-      "end": 1554
+      "start": 1557,
+      "end": 1557
     },
     "context": {
       "type": "variable",
@@ -20783,8 +20832,8 @@
       "value": "174px",
       "scope": "default",
       "line": {
-        "start": 1555,
-        "end": 1555
+        "start": 1558,
+        "end": 1558
       }
     },
     "access": "public",
@@ -20799,8 +20848,8 @@
   {
     "description": "The box shadow of the Masthead.\n",
     "commentRange": {
-      "start": 1556,
-      "end": 1556
+      "start": 1559,
+      "end": 1559
     },
     "context": {
       "type": "variable",
@@ -20808,8 +20857,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1557,
-        "end": 1557
+        "start": 1560,
+        "end": 1560
       }
     },
     "access": "public",
@@ -20824,8 +20873,8 @@
   {
     "description": "The box shadow of the Masthead in wide viewports.\n",
     "commentRange": {
-      "start": 1558,
-      "end": 1558
+      "start": 1561,
+      "end": 1561
     },
     "context": {
       "type": "variable",
@@ -20833,8 +20882,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1559,
-        "end": 1559
+        "start": 1562,
+        "end": 1562
       }
     },
     "access": "public",
@@ -20849,8 +20898,8 @@
   {
     "description": "The Masthead shadow that gets applied when the page is scrolled.\n",
     "commentRange": {
-      "start": 1560,
-      "end": 1560
+      "start": 1563,
+      "end": 1563
     },
     "context": {
       "type": "variable",
@@ -20858,8 +20907,8 @@
       "value": "0 0 40px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1561,
-        "end": 1561
+        "start": 1564,
+        "end": 1564
       }
     },
     "access": "public",
@@ -20874,38 +20923,13 @@
   {
     "description": "The border of the selector in the Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1562,
-      "end": 1562
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-selector-border",
-      "value": "2px solid $sprk-black-tint-25",
-      "scope": "default",
-      "line": {
-        "start": 1563,
-        "end": 1563
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border radius of the selector in the Masthead with Extended Navigation.\n",
-    "commentRange": {
       "start": 1565,
       "end": 1565
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-border-radius",
-      "value": "5px",
+      "name": "sprk-masthead-selector-border",
+      "value": "2px solid $sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1566,
@@ -20922,10 +20946,35 @@
     }
   },
   {
+    "description": "The border radius of the selector in the Masthead with Extended Navigation.\n",
+    "commentRange": {
+      "start": 1568,
+      "end": 1568
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-selector-border-radius",
+      "value": "5px",
+      "scope": "default",
+      "line": {
+        "start": 1569,
+        "end": 1569
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
     "description": "The bottom border that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1567,
-      "end": 1569
+      "start": 1570,
+      "end": 1572
     },
     "context": {
       "type": "variable",
@@ -20933,8 +20982,8 @@
       "value": "2px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1570,
-        "end": 1570
+        "start": 1573,
+        "end": 1573
       }
     },
     "access": "public",
@@ -20949,8 +20998,8 @@
   {
     "description": "The box shadow that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1571,
-      "end": 1573
+      "start": 1574,
+      "end": 1576
     },
     "context": {
       "type": "variable",
@@ -20958,8 +21007,8 @@
       "value": "0 5px 10px\n  rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1574,
-        "end": 1575
+        "start": 1577,
+        "end": 1578
       }
     },
     "access": "public",
@@ -20974,38 +21023,13 @@
   {
     "description": "The border color that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1576,
-      "end": 1578
+      "start": 1579,
+      "end": 1581
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-selector-border-color-mask-open",
       "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1579,
-        "end": 1579
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font color of the selector in\nthe Masthead with Extended Navigation.\n",
-    "commentRange": {
-      "start": 1580,
-      "end": 1581
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-selector-font-color",
-      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1582,
@@ -21022,15 +21046,15 @@
     }
   },
   {
-    "description": "The background color of the selector in\nthe Masthead with Extended Navigation.\n",
+    "description": "The font color of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1583,
       "end": 1584
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-bg-color",
-      "value": "$sprk-white",
+      "name": "sprk-masthead-selector-font-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1585,
@@ -21047,15 +21071,15 @@
     }
   },
   {
-    "description": "The padding of the selector in\nthe Masthead with Extended Navigation.\n",
+    "description": "The background color of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1586,
       "end": 1587
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-padding",
-      "value": "$sprk-space-inset-short-m",
+      "name": "sprk-masthead-selector-bg-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1588,
@@ -21072,15 +21096,15 @@
     }
   },
   {
-    "description": "The padding of the selector dropdown in\nthe Masthead with Extended Navigation.\n",
+    "description": "The padding of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1589,
       "end": 1590
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-dropdown-padding",
-      "value": "0",
+      "name": "sprk-masthead-selector-padding",
+      "value": "$sprk-space-inset-short-m",
       "scope": "default",
       "line": {
         "start": 1591,
@@ -21097,15 +21121,15 @@
     }
   },
   {
-    "description": "The minimum width of the selector\nin the Masthead with Extended Navigation.\n",
+    "description": "The padding of the selector dropdown in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1592,
       "end": 1593
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-min-width",
-      "value": "17rem",
+      "name": "sprk-masthead-selector-dropdown-padding",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1594,
@@ -21122,10 +21146,35 @@
     }
   },
   {
-    "description": "This is the height of the Masthead on\nnarrow viewports and is used to calculate\nhow far from the top the narrow\nnavigation items should be displayed.\n",
+    "description": "The minimum width of the selector\nin the Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1595,
-      "end": 1598
+      "end": 1596
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-selector-min-width",
+      "value": "17rem",
+      "scope": "default",
+      "line": {
+        "start": 1597,
+        "end": 1597
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "This is the height of the Masthead on\nnarrow viewports and is used to calculate\nhow far from the top the narrow\nnavigation items should be displayed.\n",
+    "commentRange": {
+      "start": 1598,
+      "end": 1601
     },
     "context": {
       "type": "variable",
@@ -21133,8 +21182,8 @@
       "value": "81px",
       "scope": "default",
       "line": {
-        "start": 1599,
-        "end": 1599
+        "start": 1602,
+        "end": 1602
       }
     },
     "access": "public",
@@ -21149,8 +21198,8 @@
   {
     "description": "The color of the mask that\ngets applied when the Masthead selector\ndropdown is open on narrow screens.\n",
     "commentRange": {
-      "start": 1600,
-      "end": 1602
+      "start": 1603,
+      "end": 1605
     },
     "context": {
       "type": "variable",
@@ -21158,8 +21207,8 @@
       "value": "rgba(0, 0, 0, 0.5)",
       "scope": "default",
       "line": {
-        "start": 1603,
-        "end": 1603
+        "start": 1606,
+        "end": 1606
       }
     },
     "access": "public",
@@ -21174,38 +21223,13 @@
   {
     "description": "The transition applied to the Masthead.\n",
     "commentRange": {
-      "start": 1604,
-      "end": 1604
+      "start": 1607,
+      "end": 1607
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-transition",
       "value": "all 0.3s ease-in",
-      "scope": "default",
-      "line": {
-        "start": 1605,
-        "end": 1605
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The transform length that gets applied\nwhen the Masthead scrolls out of view on narrow screens.\n",
-    "commentRange": {
-      "start": 1606,
-      "end": 1607
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-translateY",
-      "value": "translateY(-100%)",
       "scope": "default",
       "line": {
         "start": 1608,
@@ -21222,19 +21246,19 @@
     }
   },
   {
-    "description": "The maximum width of the\nbig navigation items in the\nnavigation bar in the Masthead Extended.\n",
+    "description": "The transform length that gets applied\nwhen the Masthead scrolls out of view on narrow screens.\n",
     "commentRange": {
-      "start": 1611,
-      "end": 1613
+      "start": 1609,
+      "end": 1610
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-column-width",
-      "value": "64rem",
+      "name": "sprk-masthead-translateY",
+      "value": "translateY(-100%)",
       "scope": "default",
       "line": {
-        "start": 1614,
-        "end": 1614
+        "start": 1611,
+        "end": 1611
       }
     },
     "access": "public",
@@ -21247,15 +21271,15 @@
     }
   },
   {
-    "description": "The background color of the big\nnavigation bar in the Masthead Extended.\n",
+    "description": "The maximum width of the\nbig navigation items in the\nnavigation bar in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1615,
+      "start": 1614,
       "end": 1616
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-bg",
-      "value": "$sprk-white",
+      "name": "sprk-big-nav-column-width",
+      "value": "64rem",
       "scope": "default",
       "line": {
         "start": 1617,
@@ -21272,15 +21296,15 @@
     }
   },
   {
-    "description": "The font weight of the big\nnavigation link in the Masthead Extended.\n",
+    "description": "The background color of the big\nnavigation bar in the Masthead Extended.\n",
     "commentRange": {
       "start": 1618,
       "end": 1619
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-link-font-weight",
-      "value": "400",
+      "name": "sprk-big-nav-bg",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1620,
@@ -21297,15 +21321,15 @@
     }
   },
   {
-    "description": "The padding of the big navigation\nlink in the Masthead Extended.\n",
+    "description": "The font weight of the big\nnavigation link in the Masthead Extended.\n",
     "commentRange": {
       "start": 1621,
       "end": 1622
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-link-padding",
-      "value": "0 $sprk-space-s",
+      "name": "sprk-big-nav-link-font-weight",
+      "value": "400",
       "scope": "default",
       "line": {
         "start": 1623,
@@ -21322,19 +21346,19 @@
     }
   },
   {
-    "description": "The color of the big navigation link in the Masthead Extended.\n",
+    "description": "The padding of the big navigation\nlink in the Masthead Extended.\n",
     "commentRange": {
       "start": 1624,
-      "end": 1624
+      "end": 1625
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-link-color",
-      "value": "$sprk-black",
+      "name": "sprk-big-nav-link-padding",
+      "value": "0 $sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1625,
-        "end": 1625
+        "start": 1626,
+        "end": 1626
       }
     },
     "access": "public",
@@ -21347,15 +21371,15 @@
     }
   },
   {
-    "description": "The text and underline color of\nthe active big navigation item in the Masthead Extended.\n",
+    "description": "The color of the big navigation link in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1626,
+      "start": 1627,
       "end": 1627
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-active-color",
-      "value": "$sprk-big-nav-link-color",
+      "name": "sprk-big-nav-link-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1628,
@@ -21372,10 +21396,35 @@
     }
   },
   {
-    "description": "The line height\nof the big navigation items\nin the Masthead Extended.\n",
+    "description": "The text and underline color of\nthe active big navigation item in the Masthead Extended.\n",
     "commentRange": {
       "start": 1629,
-      "end": 1631
+      "end": 1630
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-big-nav-active-color",
+      "value": "$sprk-big-nav-link-color",
+      "scope": "default",
+      "line": {
+        "start": 1631,
+        "end": 1631
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The line height\nof the big navigation items\nin the Masthead Extended.\n",
+    "commentRange": {
+      "start": 1632,
+      "end": 1634
     },
     "context": {
       "type": "variable",
@@ -21383,8 +21432,8 @@
       "value": "53px",
       "scope": "default",
       "line": {
-        "start": 1632,
-        "end": 1632
+        "start": 1635,
+        "end": 1635
       }
     },
     "access": "public",
@@ -21399,38 +21448,13 @@
   {
     "description": "The left border of the active item\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
-      "start": 1634,
-      "end": 1635
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-accordion-active-left-border",
-      "value": "3px solid $sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1636,
-        "end": 1636
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the active item\nin the naviation links when masthead is on narrow viewports.\n",
-    "commentRange": {
       "start": 1637,
       "end": 1638
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-active-heading-font-weight",
-      "value": "400",
+      "name": "sprk-masthead-accordion-active-left-border",
+      "value": "3px solid $sprk-black",
       "scope": "default",
       "line": {
         "start": 1639,
@@ -21447,15 +21471,15 @@
     }
   },
   {
-    "description": "The color of the active item\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font weight of the active item\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1640,
       "end": 1641
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-active-heading-color",
-      "value": "$sprk-black",
+      "name": "sprk-masthead-accordion-active-heading-font-weight",
+      "value": "400",
       "scope": "default",
       "line": {
         "start": 1642,
@@ -21472,14 +21496,14 @@
     }
   },
   {
-    "description": "The color of the heading\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The color of the active item\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1643,
       "end": 1644
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-heading-color",
+      "name": "sprk-masthead-accordion-active-heading-color",
       "value": "$sprk-black",
       "scope": "default",
       "line": {
@@ -21497,15 +21521,15 @@
     }
   },
   {
-    "description": "The font weight of the heading\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The color of the heading\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1646,
       "end": 1647
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-heading-font-weight",
-      "value": "400",
+      "name": "sprk-masthead-accordion-heading-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1648,
@@ -21522,15 +21546,15 @@
     }
   },
   {
-    "description": "The font weight of the details\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font weight of the heading\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1649,
       "end": 1650
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-details-font-weight",
-      "value": "300",
+      "name": "sprk-masthead-accordion-heading-font-weight",
+      "value": "400",
       "scope": "default",
       "line": {
         "start": 1651,
@@ -21547,15 +21571,15 @@
     }
   },
   {
-    "description": "The font color of the details\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font weight of the details\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1652,
       "end": 1653
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-details-font-color",
-      "value": "$sprk-black",
+      "name": "sprk-masthead-accordion-details-font-weight",
+      "value": "300",
       "scope": "default",
       "line": {
         "start": 1654,
@@ -21572,15 +21596,15 @@
     }
   },
   {
-    "description": "The background color of the active\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font color of the details\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1655,
       "end": 1656
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-active-background-color",
-      "value": "$sprk-gray",
+      "name": "sprk-masthead-accordion-details-font-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1657,
@@ -21597,15 +21621,15 @@
     }
   },
   {
-    "description": "The font color of the active\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The background color of the active\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1658,
       "end": 1659
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-active-font-color",
-      "value": "$sprk-black",
+      "name": "sprk-masthead-accordion-active-background-color",
+      "value": "$sprk-gray",
       "scope": "default",
       "line": {
         "start": 1660,
@@ -21622,14 +21646,14 @@
     }
   },
   {
-    "description": "The font color of the text\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font color of the active\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1661,
       "end": 1662
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-font-color",
+      "name": "sprk-masthead-accordion-active-font-color",
       "value": "$sprk-black",
       "scope": "default",
       "line": {
@@ -21647,15 +21671,15 @@
     }
   },
   {
-    "description": "The color of the line on open items\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font color of the text\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1664,
       "end": 1665
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-open-line-background-color",
-      "value": "$sprk-black-tint-25",
+      "name": "sprk-masthead-accordion-font-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1666,
@@ -21672,15 +21696,15 @@
     }
   },
   {
-    "description": "The height of the line on open\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The color of the line on open items\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1667,
       "end": 1668
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-open-line-height",
-      "value": "2px",
+      "name": "sprk-masthead-accordion-item-open-line-background-color",
+      "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1669,
@@ -21697,15 +21721,15 @@
     }
   },
   {
-    "description": "The padding of the items in the\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The height of the line on open\nnavigation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1670,
       "end": 1671
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-padding",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-accordion-item-open-line-height",
+      "value": "2px",
       "scope": "default",
       "line": {
         "start": 1672,
@@ -21722,15 +21746,15 @@
     }
   },
   {
-    "description": "The text alignment of an item in the\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The padding of the items in the\nnavigation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1673,
       "end": 1674
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-text-align",
-      "value": "left",
+      "name": "sprk-masthead-accordion-item-padding",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
         "start": 1675,
@@ -21747,15 +21771,15 @@
     }
   },
   {
-    "description": "The border of an item in the\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The text alignment of an item in the\nnavigation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1676,
       "end": 1677
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-border",
-      "value": "0",
+      "name": "sprk-masthead-accordion-item-text-align",
+      "value": "left",
       "scope": "default",
       "line": {
         "start": 1678,
@@ -21772,15 +21796,15 @@
     }
   },
   {
-    "description": "The background of an item in the\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The border of an item in the\nnavigation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1679,
       "end": 1680
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-background",
-      "value": "transparent",
+      "name": "sprk-masthead-accordion-item-border",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1681,
@@ -21797,10 +21821,35 @@
     }
   },
   {
+    "description": "The background of an item in the\nnavigation links when masthead is on narrow viewports.\n",
+    "commentRange": {
+      "start": 1682,
+      "end": 1683
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-item-background",
+      "value": "transparent",
+      "scope": "default",
+      "line": {
+        "start": 1684,
+        "end": 1684
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
     "description": "The height and width of Spinners.\n",
     "commentRange": {
-      "start": 1687,
-      "end": 1687
+      "start": 1690,
+      "end": 1690
     },
     "context": {
       "type": "variable",
@@ -21808,8 +21857,8 @@
       "value": "1.3rem",
       "scope": "default",
       "line": {
-        "start": 1688,
-        "end": 1688
+        "start": 1691,
+        "end": 1691
       }
     },
     "access": "public",
@@ -21824,8 +21873,8 @@
   {
     "description": "The height and width of large Spinners.\n",
     "commentRange": {
-      "start": 1689,
-      "end": 1689
+      "start": 1692,
+      "end": 1692
     },
     "context": {
       "type": "variable",
@@ -21833,8 +21882,8 @@
       "value": "3rem",
       "scope": "default",
       "line": {
-        "start": 1690,
-        "end": 1690
+        "start": 1693,
+        "end": 1693
       }
     },
     "access": "public",
@@ -21849,8 +21898,8 @@
   {
     "description": "The speed of the animation for Spinners.\n",
     "commentRange": {
-      "start": 1691,
-      "end": 1691
+      "start": 1694,
+      "end": 1694
     },
     "context": {
       "type": "variable",
@@ -21858,8 +21907,8 @@
       "value": "1s",
       "scope": "default",
       "line": {
-        "start": 1692,
-        "end": 1692
+        "start": 1695,
+        "end": 1695
       }
     },
     "access": "public",
@@ -21874,8 +21923,8 @@
   {
     "description": "The thickness of Spinners.\n",
     "commentRange": {
-      "start": 1693,
-      "end": 1693
+      "start": 1696,
+      "end": 1696
     },
     "context": {
       "type": "variable",
@@ -21883,8 +21932,8 @@
       "value": "0.18rem",
       "scope": "default",
       "line": {
-        "start": 1694,
-        "end": 1694
+        "start": 1697,
+        "end": 1697
       }
     },
     "access": "public",
@@ -21899,8 +21948,8 @@
   {
     "description": "The color of Spinners.\n",
     "commentRange": {
-      "start": 1695,
-      "end": 1695
+      "start": 1698,
+      "end": 1698
     },
     "context": {
       "type": "variable",
@@ -21908,8 +21957,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1696,
-        "end": 1696
+        "start": 1699,
+        "end": 1699
       }
     },
     "access": "public",
@@ -21924,8 +21973,8 @@
   {
     "description": "The color of the dark Spinner.\n",
     "commentRange": {
-      "start": 1697,
-      "end": 1697
+      "start": 1700,
+      "end": 1700
     },
     "context": {
       "type": "variable",
@@ -21933,8 +21982,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1698,
-        "end": 1698
+        "start": 1701,
+        "end": 1701
       }
     },
     "access": "public",
@@ -21949,8 +21998,8 @@
   {
     "description": "The breakpoint at which the tabs\ngo from stacked layout to side by side in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1704,
-      "end": 1705
+      "start": 1707,
+      "end": 1708
     },
     "context": {
       "type": "variable",
@@ -21958,8 +22007,8 @@
       "value": "46rem",
       "scope": "default",
       "line": {
-        "start": 1706,
-        "end": 1706
+        "start": 1709,
+        "end": 1709
       }
     },
     "access": "public",
@@ -21974,8 +22023,8 @@
   {
     "description": "The tab button text color in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1707,
-      "end": 1707
+      "start": 1710,
+      "end": 1710
     },
     "context": {
       "type": "variable",
@@ -21983,8 +22032,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1708,
-        "end": 1708
+        "start": 1711,
+        "end": 1711
       }
     },
     "access": "public",
@@ -21999,8 +22048,8 @@
   {
     "description": "The tab button background color in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1709,
-      "end": 1709
+      "start": 1712,
+      "end": 1712
     },
     "context": {
       "type": "variable",
@@ -22008,8 +22057,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1710,
-        "end": 1710
+        "start": 1713,
+        "end": 1713
       }
     },
     "access": "public",
@@ -22024,38 +22073,13 @@
   {
     "description": "The border on the top of the button tabs in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1711,
-      "end": 1711
+      "start": 1714,
+      "end": 1714
     },
     "context": {
       "type": "variable",
       "name": "sprk-tab-navigation-btn-border-top",
       "value": "3px solid $sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1712,
-        "end": 1712
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border on the top of the\nbutton tabs on hover in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1713,
-      "end": 1714
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-hover-border-top",
-      "value": "3px solid $sprk-red",
       "scope": "default",
       "line": {
         "start": 1715,
@@ -22072,15 +22096,15 @@
     }
   },
   {
-    "description": "The button tab text color of the\ncurrently active tab in Tabbed Navigation.\n",
+    "description": "The border on the top of the\nbutton tabs on hover in Tabbed Navigation.\n",
     "commentRange": {
       "start": 1716,
       "end": 1717
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-color",
-      "value": "$sprk-red",
+      "name": "sprk-tab-navigation-btn-hover-border-top",
+      "value": "3px solid $sprk-red",
       "scope": "default",
       "line": {
         "start": 1718,
@@ -22097,15 +22121,15 @@
     }
   },
   {
-    "description": "The button tab top border of the\ncurrently active tab in Tabbed Navigation.\n",
+    "description": "The button tab text color of the\ncurrently active tab in Tabbed Navigation.\n",
     "commentRange": {
       "start": 1719,
       "end": 1720
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-border-top",
-      "value": "3px solid $sprk-red",
+      "name": "sprk-tab-navigation-btn-active-color",
+      "value": "$sprk-red",
       "scope": "default",
       "line": {
         "start": 1721,
@@ -22122,15 +22146,15 @@
     }
   },
   {
-    "description": "The button tab background color\nof the currently active tab in Tabbed Navigation.\n",
+    "description": "The button tab top border of the\ncurrently active tab in Tabbed Navigation.\n",
     "commentRange": {
       "start": 1722,
       "end": 1723
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-bg-color",
-      "value": "$sprk-white",
+      "name": "sprk-tab-navigation-btn-active-border-top",
+      "value": "3px solid $sprk-red",
       "scope": "default",
       "line": {
         "start": 1724,
@@ -22147,19 +22171,19 @@
     }
   },
   {
-    "description": "The background color of the Stepper.\n",
+    "description": "The button tab background color\nof the currently active tab in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1730,
-      "end": 1730
+      "start": 1725,
+      "end": 1726
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-bg",
-      "value": "transparent",
+      "name": "sprk-tab-navigation-btn-active-bg-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1731,
-        "end": 1731
+        "start": 1727,
+        "end": 1727
       }
     },
     "access": "public",
@@ -22172,15 +22196,15 @@
     }
   },
   {
-    "description": "The minimum width at which the Stepper\nswitches between narrow and wide layouts.\n",
+    "description": "The background color of the Stepper.\n",
     "commentRange": {
-      "start": 1732,
+      "start": 1733,
       "end": 1733
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-breakpoint",
-      "value": "$sprk-split-breakpoint-xl",
+      "name": "sprk-stepper-bg",
+      "value": "transparent",
       "scope": "default",
       "line": {
         "start": 1734,
@@ -22197,10 +22221,35 @@
     }
   },
   {
-    "description": "The maximum width of the Stepper.\n",
+    "description": "The minimum width at which the Stepper\nswitches between narrow and wide layouts.\n",
     "commentRange": {
       "start": 1735,
-      "end": 1735
+      "end": 1736
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-breakpoint",
+      "value": "$sprk-split-breakpoint-xl",
+      "scope": "default",
+      "line": {
+        "start": 1737,
+        "end": 1737
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The maximum width of the Stepper.\n",
+    "commentRange": {
+      "start": 1738,
+      "end": 1738
     },
     "context": {
       "type": "variable",
@@ -22208,8 +22257,8 @@
       "value": "480px",
       "scope": "default",
       "line": {
-        "start": 1736,
-        "end": 1736
+        "start": 1739,
+        "end": 1739
       }
     },
     "access": "public",
@@ -22224,8 +22273,8 @@
   {
     "description": "The border width of the Stepper icons.\n",
     "commentRange": {
-      "start": 1737,
-      "end": 1737
+      "start": 1740,
+      "end": 1740
     },
     "context": {
       "type": "variable",
@@ -22233,8 +22282,8 @@
       "value": "2px",
       "scope": "default",
       "line": {
-        "start": 1738,
-        "end": 1738
+        "start": 1741,
+        "end": 1741
       }
     },
     "access": "public",
@@ -22249,8 +22298,8 @@
   {
     "description": "The color of the border around the Stepper icon.\n",
     "commentRange": {
-      "start": 1739,
-      "end": 1739
+      "start": 1742,
+      "end": 1742
     },
     "context": {
       "type": "variable",
@@ -22258,8 +22307,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1740,
-        "end": 1740
+        "start": 1743,
+        "end": 1743
       }
     },
     "access": "public",
@@ -22274,8 +22323,8 @@
   {
     "description": "The color of the step icon when the step is selected in the Stepper.\n",
     "commentRange": {
-      "start": 1741,
-      "end": 1741
+      "start": 1744,
+      "end": 1744
     },
     "context": {
       "type": "variable",
@@ -22283,8 +22332,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 1742,
-        "end": 1742
+        "start": 1745,
+        "end": 1745
       }
     },
     "access": "public",
@@ -22299,8 +22348,8 @@
   {
     "description": "The color of the icon border when the\nStepper is on a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1743,
-      "end": 1745
+      "start": 1746,
+      "end": 1748
     },
     "context": {
       "type": "variable",
@@ -22308,8 +22357,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1746,
-        "end": 1746
+        "start": 1749,
+        "end": 1749
       }
     },
     "access": "public",
@@ -22324,8 +22373,8 @@
   {
     "description": "The height of the step icon in the Stepper.\n",
     "commentRange": {
-      "start": 1747,
-      "end": 1747
+      "start": 1750,
+      "end": 1750
     },
     "context": {
       "type": "variable",
@@ -22333,8 +22382,8 @@
       "value": "16px",
       "scope": "default",
       "line": {
-        "start": 1748,
-        "end": 1748
+        "start": 1751,
+        "end": 1751
       }
     },
     "access": "public",
@@ -22349,8 +22398,8 @@
   {
     "description": "The width of the step icon in the Stepper.\n",
     "commentRange": {
-      "start": 1749,
-      "end": 1749
+      "start": 1752,
+      "end": 1752
     },
     "context": {
       "type": "variable",
@@ -22358,8 +22407,8 @@
       "value": "16px",
       "scope": "default",
       "line": {
-        "start": 1750,
-        "end": 1750
+        "start": 1753,
+        "end": 1753
       }
     },
     "access": "public",
@@ -22374,38 +22423,13 @@
   {
     "description": "The color of the step icon in the Stepper.\n",
     "commentRange": {
-      "start": 1751,
-      "end": 1751
+      "start": 1754,
+      "end": 1754
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-icon-color",
       "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1752,
-        "end": 1752
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the step icon\nin the Stepper when hovered.\n",
-    "commentRange": {
-      "start": 1753,
-      "end": 1754
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-color-hover",
-      "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
         "start": 1755,
@@ -22422,19 +22446,19 @@
     }
   },
   {
-    "description": "The color of the Stepper step icon when the step is selected.\n",
+    "description": "The color of the step icon\nin the Stepper when hovered.\n",
     "commentRange": {
       "start": 1756,
-      "end": 1756
+      "end": 1757
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-color-selected",
-      "value": "$sprk-white",
+      "name": "sprk-stepper-icon-color-hover",
+      "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1757,
-        "end": 1757
+        "start": 1758,
+        "end": 1758
       }
     },
     "access": "public",
@@ -22447,15 +22471,15 @@
     }
   },
   {
-    "description": "The color of the step icon when the\nStepper has a dark background (sprk-c-Stepper--has-dark-bg).\n",
+    "description": "The color of the Stepper step icon when the step is selected.\n",
     "commentRange": {
-      "start": 1758,
+      "start": 1759,
       "end": 1759
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-dark-icon-color",
-      "value": "$sprk-blue",
+      "name": "sprk-stepper-icon-color-selected",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1760,
@@ -22472,10 +22496,35 @@
     }
   },
   {
-    "description": "The color of the Stepper step icon when the step\nis selected and the Stepper has a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
+    "description": "The color of the step icon when the\nStepper has a dark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
       "start": 1761,
-      "end": 1763
+      "end": 1762
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-dark-icon-color",
+      "value": "$sprk-blue",
+      "scope": "default",
+      "line": {
+        "start": 1763,
+        "end": 1763
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the Stepper step icon when the step\nis selected and the Stepper has a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
+    "commentRange": {
+      "start": 1764,
+      "end": 1766
     },
     "context": {
       "type": "variable",
@@ -22483,8 +22532,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1764,
-        "end": 1764
+        "start": 1767,
+        "end": 1767
       }
     },
     "access": "public",
@@ -22499,38 +22548,13 @@
   {
     "description": "The color of the step icon on hover\nwhen the Stepper has a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1765,
-      "end": 1767
+      "start": 1768,
+      "end": 1770
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-dark-icon-color-hover",
       "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1768,
-        "end": 1768
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The transition of the Stepper step icon.\n",
-    "commentRange": {
-      "start": 1770,
-      "end": 1770
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-transition",
-      "value": "0.3s all ease-in-out",
       "scope": "default",
       "line": {
         "start": 1771,
@@ -22547,19 +22571,19 @@
     }
   },
   {
-    "description": "The z-index of the Stepper step icon.\n",
+    "description": "The transition of the Stepper step icon.\n",
     "commentRange": {
-      "start": 1772,
-      "end": 1772
+      "start": 1773,
+      "end": 1773
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-z-index",
-      "value": "$sprk-layer-height-xs",
+      "name": "sprk-stepper-icon-transition",
+      "value": "0.3s all ease-in-out",
       "scope": "default",
       "line": {
-        "start": 1773,
-        "end": 1773
+        "start": 1774,
+        "end": 1774
       }
     },
     "access": "public",
@@ -22572,15 +22596,15 @@
     }
   },
   {
-    "description": "The spread value of the icon box\nshadow when the Stepper step is selected.\n",
+    "description": "The z-index of the Stepper step icon.\n",
     "commentRange": {
-      "start": 1774,
+      "start": 1775,
       "end": 1775
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-box-shadow-selected-spread",
-      "value": "8px",
+      "name": "sprk-stepper-icon-z-index",
+      "value": "$sprk-layer-height-xs",
       "scope": "default",
       "line": {
         "start": 1776,
@@ -22597,10 +22621,35 @@
     }
   },
   {
-    "description": "The box shadow of the Stepper step icon\nwhen the icon is selected.\n",
+    "description": "The spread value of the icon box\nshadow when the Stepper step is selected.\n",
     "commentRange": {
       "start": 1777,
       "end": 1778
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-box-shadow-selected-spread",
+      "value": "8px",
+      "scope": "default",
+      "line": {
+        "start": 1779,
+        "end": 1779
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Stepper step icon\nwhen the icon is selected.\n",
+    "commentRange": {
+      "start": 1780,
+      "end": 1781
     },
     "context": {
       "type": "variable",
@@ -22608,8 +22657,8 @@
       "value": "0 0 0\n  $sprk-stepper-icon-box-shadow-selected-spread\n  $sprk-stepper-icon-border-color-selected",
       "scope": "default",
       "line": {
-        "start": 1779,
-        "end": 1781
+        "start": 1782,
+        "end": 1784
       }
     },
     "access": "public",
@@ -22624,38 +22673,13 @@
   {
     "description": "The background color of the content in the Stepper step.\n",
     "commentRange": {
-      "start": 1782,
-      "end": 1782
+      "start": 1785,
+      "end": 1785
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-step-content-bg",
       "value": "transparent",
-      "scope": "default",
-      "line": {
-        "start": 1783,
-        "end": 1783
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border radius of the Stepper step\ncontent box when it has a description.\n",
-    "commentRange": {
-      "start": 1784,
-      "end": 1785
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-description-border-radius",
-      "value": "5px",
       "scope": "default",
       "line": {
         "start": 1786,
@@ -22672,15 +22696,15 @@
     }
   },
   {
-    "description": "The box shadow of the Stepper step content\nbox when it has a description.\n",
+    "description": "The border radius of the Stepper step\ncontent box when it has a description.\n",
     "commentRange": {
       "start": 1787,
       "end": 1788
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-box-shadow",
-      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
+      "name": "sprk-stepper-step-description-border-radius",
+      "value": "5px",
       "scope": "default",
       "line": {
         "start": 1789,
@@ -22697,15 +22721,15 @@
     }
   },
   {
-    "description": "The spacing between the\nStepper step heading and description.\n",
+    "description": "The box shadow of the Stepper step content\nbox when it has a description.\n",
     "commentRange": {
       "start": 1790,
       "end": 1791
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-top-spacing",
-      "value": "$sprk-space-m",
+      "name": "sprk-stepper-step-description-box-shadow",
+      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
         "start": 1792,
@@ -22722,10 +22746,35 @@
     }
   },
   {
-    "description": "The font weight of the Stepper step heading.\n",
+    "description": "The spacing between the\nStepper step heading and description.\n",
     "commentRange": {
       "start": 1793,
-      "end": 1793
+      "end": 1794
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-step-description-top-spacing",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1795,
+        "end": 1795
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font weight of the Stepper step heading.\n",
+    "commentRange": {
+      "start": 1796,
+      "end": 1796
     },
     "context": {
       "type": "variable",
@@ -22733,8 +22782,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1794,
-        "end": 1794
+        "start": 1797,
+        "end": 1797
       }
     },
     "access": "public",
@@ -22749,8 +22798,8 @@
   {
     "description": "The font size of the Stepper step heading.\n",
     "commentRange": {
-      "start": 1795,
-      "end": 1795
+      "start": 1798,
+      "end": 1798
     },
     "context": {
       "type": "variable",
@@ -22758,8 +22807,8 @@
       "value": "$sprk-font-size-display-six",
       "scope": "default",
       "line": {
-        "start": 1796,
-        "end": 1796
+        "start": 1799,
+        "end": 1799
       }
     },
     "access": "public",
@@ -22774,8 +22823,8 @@
   {
     "description": "The color of the Stepper step heading.\n",
     "commentRange": {
-      "start": 1797,
-      "end": 1797
+      "start": 1800,
+      "end": 1800
     },
     "context": {
       "type": "variable",
@@ -22783,8 +22832,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1798,
-        "end": 1798
+        "start": 1801,
+        "end": 1801
       }
     },
     "access": "public",
@@ -22799,38 +22848,13 @@
   {
     "description": "The color of the Stepper step heading when\nthe Stepper is on a dark\nbackground (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1799,
-      "end": 1801
+      "start": 1802,
+      "end": 1804
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-dark-step-heading-color",
       "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1802,
-        "end": 1802
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Stepper\nstep heading when the step is selected.\n",
-    "commentRange": {
-      "start": 1803,
-      "end": 1804
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-heading-color-selected",
-      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1805,
@@ -22847,19 +22871,19 @@
     }
   },
   {
-    "description": "The padding value for the Stepper step.\n",
+    "description": "The color of the Stepper\nstep heading when the step is selected.\n",
     "commentRange": {
       "start": 1806,
-      "end": 1806
+      "end": 1807
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-padding",
-      "value": "$sprk-space-misc-a",
+      "name": "sprk-stepper-step-heading-color-selected",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1807,
-        "end": 1807
+        "start": 1808,
+        "end": 1808
       }
     },
     "access": "public",
@@ -22872,15 +22896,15 @@
     }
   },
   {
-    "description": "The background color of the\nStepper step content box when the step is selected.\n",
+    "description": "The padding value for the Stepper step.\n",
     "commentRange": {
-      "start": 1808,
+      "start": 1809,
       "end": 1809
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-content-bg-selected",
-      "value": "transparent",
+      "name": "sprk-stepper-step-padding",
+      "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
         "start": 1810,
@@ -22897,10 +22921,35 @@
     }
   },
   {
-    "description": "The background color of the Stepper step\ncontent box when it has a\ndescription and when the step is selected.\n",
+    "description": "The background color of the\nStepper step content box when the step is selected.\n",
     "commentRange": {
       "start": 1811,
-      "end": 1813
+      "end": 1812
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-step-content-bg-selected",
+      "value": "transparent",
+      "scope": "default",
+      "line": {
+        "start": 1813,
+        "end": 1813
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Stepper step\ncontent box when it has a\ndescription and when the step is selected.\n",
+    "commentRange": {
+      "start": 1814,
+      "end": 1816
     },
     "context": {
       "type": "variable",
@@ -22908,8 +22957,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1814,
-        "end": 1814
+        "start": 1817,
+        "end": 1817
       }
     },
     "access": "public",
@@ -22924,8 +22973,8 @@
   {
     "description": "The text color of a selected Stepper step's\ncontent and header when it has a\ndescription. This applies to\nsteppers with the sprk-c-Stepper--has-dark-bg class.\n",
     "commentRange": {
-      "start": 1815,
-      "end": 1818
+      "start": 1818,
+      "end": 1821
     },
     "context": {
       "type": "variable",
@@ -22933,8 +22982,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1819,
-        "end": 1819
+        "start": 1822,
+        "end": 1822
       }
     },
     "access": "public",
@@ -22949,8 +22998,8 @@
   {
     "description": "The color of the bar that connects the steps in the Stepper.\n",
     "commentRange": {
-      "start": 1820,
-      "end": 1820
+      "start": 1823,
+      "end": 1823
     },
     "context": {
       "type": "variable",
@@ -22958,8 +23007,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1821,
-        "end": 1821
+        "start": 1824,
+        "end": 1824
       }
     },
     "access": "public",
@@ -22974,8 +23023,8 @@
   {
     "description": "The color of the bar that connects\nthe steps when the Stepper is on a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1822,
-      "end": 1824
+      "start": 1825,
+      "end": 1827
     },
     "context": {
       "type": "variable",
@@ -22983,8 +23032,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1825,
-        "end": 1825
+        "start": 1828,
+        "end": 1828
       }
     },
     "access": "public",
@@ -22999,8 +23048,8 @@
   {
     "description": "The border value for the Carousel component.\n",
     "commentRange": {
-      "start": 1844,
-      "end": 1844
+      "start": 1847,
+      "end": 1847
     },
     "context": {
       "type": "variable",
@@ -23008,8 +23057,8 @@
       "value": "$sprk-stepper-icon-border-width solid\n  $sprk-stepper-dark-icon-border-color",
       "scope": "default",
       "line": {
-        "start": 1845,
-        "end": 1846
+        "start": 1848,
+        "end": 1849
       }
     },
     "access": "public",
@@ -23024,8 +23073,8 @@
   {
     "description": "The height of the dots in the Carousel component.\n",
     "commentRange": {
-      "start": 1847,
-      "end": 1847
+      "start": 1850,
+      "end": 1850
     },
     "context": {
       "type": "variable",
@@ -23033,8 +23082,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1848,
-        "end": 1848
+        "start": 1851,
+        "end": 1851
       }
     },
     "access": "public",
@@ -23049,8 +23098,8 @@
   {
     "description": "The width of the dots in the Carousel component.\n",
     "commentRange": {
-      "start": 1849,
-      "end": 1849
+      "start": 1852,
+      "end": 1852
     },
     "context": {
       "type": "variable",
@@ -23058,8 +23107,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1850,
-        "end": 1850
+        "start": 1853,
+        "end": 1853
       }
     },
     "access": "public",
@@ -23074,8 +23123,8 @@
   {
     "description": "The height of the dots in the Carousel component on wide viewports.\n",
     "commentRange": {
-      "start": 1851,
-      "end": 1851
+      "start": 1854,
+      "end": 1854
     },
     "context": {
       "type": "variable",
@@ -23083,8 +23132,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1852,
-        "end": 1852
+        "start": 1855,
+        "end": 1855
       }
     },
     "access": "public",
@@ -23099,8 +23148,8 @@
   {
     "description": "The width of the dots in the Carousel component on wide viewports.\n",
     "commentRange": {
-      "start": 1853,
-      "end": 1853
+      "start": 1856,
+      "end": 1856
     },
     "context": {
       "type": "variable",
@@ -23108,8 +23157,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1854,
-        "end": 1854
+        "start": 1857,
+        "end": 1857
       }
     },
     "access": "public",
@@ -23124,8 +23173,8 @@
   {
     "description": "The spacing between dots in the Carousel component.\n",
     "commentRange": {
-      "start": 1855,
-      "end": 1855
+      "start": 1858,
+      "end": 1858
     },
     "context": {
       "type": "variable",
@@ -23133,8 +23182,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1856,
-        "end": 1856
+        "start": 1859,
+        "end": 1859
       }
     },
     "access": "public",
@@ -23149,8 +23198,8 @@
   {
     "description": "The spacing between dots in the Carousel component on wide viewports.\n",
     "commentRange": {
-      "start": 1857,
-      "end": 1857
+      "start": 1860,
+      "end": 1860
     },
     "context": {
       "type": "variable",
@@ -23158,8 +23207,8 @@
       "value": "$sprk-carousel-dot-spacing",
       "scope": "default",
       "line": {
-        "start": 1858,
-        "end": 1858
+        "start": 1861,
+        "end": 1861
       }
     },
     "access": "public",
@@ -23174,8 +23223,8 @@
   {
     "description": "The box shadow of the active dot in the Carousel component.\n",
     "commentRange": {
-      "start": 1859,
-      "end": 1859
+      "start": 1862,
+      "end": 1862
     },
     "context": {
       "type": "variable",
@@ -23183,8 +23232,8 @@
       "value": "$sprk-stepper-icon-box-shadow-selected",
       "scope": "default",
       "line": {
-        "start": 1860,
-        "end": 1860
+        "start": 1863,
+        "end": 1863
       }
     },
     "access": "public",
@@ -23199,8 +23248,8 @@
   {
     "description": "The color of the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1861,
-      "end": 1861
+      "start": 1864,
+      "end": 1864
     },
     "context": {
       "type": "variable",
@@ -23208,8 +23257,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1862,
-        "end": 1862
+        "start": 1865,
+        "end": 1865
       }
     },
     "access": "public",
@@ -23224,8 +23273,8 @@
   {
     "description": "The spacing for the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1863,
-      "end": 1863
+      "start": 1866,
+      "end": 1866
     },
     "context": {
       "type": "variable",
@@ -23233,8 +23282,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1864,
-        "end": 1864
+        "start": 1867,
+        "end": 1867
       }
     },
     "access": "public",
@@ -23249,8 +23298,8 @@
   {
     "description": "The left and right values of the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1865,
-      "end": 1865
+      "start": 1868,
+      "end": 1868
     },
     "context": {
       "type": "variable",
@@ -23258,8 +23307,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1866,
-        "end": 1866
+        "start": 1869,
+        "end": 1869
       }
     },
     "access": "public",
@@ -23274,8 +23323,8 @@
   {
     "description": "The padding value of the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1867,
-      "end": 1867
+      "start": 1870,
+      "end": 1870
     },
     "context": {
       "type": "variable",
@@ -23283,8 +23332,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1868,
-        "end": 1868
+        "start": 1871,
+        "end": 1871
       }
     },
     "access": "public",
@@ -23299,8 +23348,8 @@
   {
     "description": "The maximum width of the image in the Carousel component.\n",
     "commentRange": {
-      "start": 1869,
-      "end": 1869
+      "start": 1872,
+      "end": 1872
     },
     "context": {
       "type": "variable",
@@ -23308,8 +23357,8 @@
       "value": "18.75rem",
       "scope": "default",
       "line": {
-        "start": 1870,
-        "end": 1870
+        "start": 1873,
+        "end": 1873
       }
     },
     "access": "public",
@@ -23324,8 +23373,8 @@
   {
     "description": "The breakpoint for the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1871,
-      "end": 1871
+      "start": 1874,
+      "end": 1874
     },
     "context": {
       "type": "variable",
@@ -23333,8 +23382,8 @@
       "value": "31.25rem",
       "scope": "default",
       "line": {
-        "start": 1872,
-        "end": 1872
+        "start": 1875,
+        "end": 1875
       }
     },
     "access": "public",
@@ -23349,8 +23398,8 @@
   {
     "description": "The padding value for the dots container in the Carousel component.\n",
     "commentRange": {
-      "start": 1873,
-      "end": 1873
+      "start": 1876,
+      "end": 1876
     },
     "context": {
       "type": "variable",
@@ -23358,8 +23407,8 @@
       "value": "$sprk-space-xs",
       "scope": "default",
       "line": {
-        "start": 1874,
-        "end": 1874
+        "start": 1877,
+        "end": 1877
       }
     },
     "access": "public",
@@ -23374,8 +23423,8 @@
   {
     "description": "The breakpoint for the Carousel component.\n",
     "commentRange": {
-      "start": 1875,
-      "end": 1875
+      "start": 1878,
+      "end": 1878
     },
     "context": {
       "type": "variable",
@@ -23383,8 +23432,8 @@
       "value": "$sprk-split-breakpoint-xl",
       "scope": "default",
       "line": {
-        "start": 1876,
-        "end": 1876
+        "start": 1879,
+        "end": 1879
       }
     },
     "access": "public",
@@ -23399,8 +23448,8 @@
   {
     "description": "The maximum width of the Card.\n",
     "commentRange": {
-      "start": 1882,
-      "end": 1882
+      "start": 1885,
+      "end": 1885
     },
     "context": {
       "type": "variable",
@@ -23408,8 +23457,8 @@
       "value": "26.5625rem",
       "scope": "default",
       "line": {
-        "start": 1883,
-        "end": 1883
+        "start": 1886,
+        "end": 1886
       }
     },
     "access": "public",
@@ -23424,8 +23473,8 @@
   {
     "description": "The main Card breakpoint.\n",
     "commentRange": {
-      "start": 1884,
-      "end": 1884
+      "start": 1887,
+      "end": 1887
     },
     "context": {
       "type": "variable",
@@ -23433,8 +23482,8 @@
       "value": "$sprk-split-breakpoint-s",
       "scope": "default",
       "line": {
-        "start": 1885,
-        "end": 1885
+        "start": 1888,
+        "end": 1888
       }
     },
     "access": "public",
@@ -23449,8 +23498,8 @@
   {
     "description": "The box shadow of the Card on narrow viewports.\n",
     "commentRange": {
-      "start": 1886,
-      "end": 1886
+      "start": 1889,
+      "end": 1889
     },
     "context": {
       "type": "variable",
@@ -23458,8 +23507,8 @@
       "value": "0 3px 10px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
-        "start": 1887,
-        "end": 1887
+        "start": 1890,
+        "end": 1890
       }
     },
     "access": "public",
@@ -23474,8 +23523,8 @@
   {
     "description": "The box shadow of the Card on wide viewports.\n",
     "commentRange": {
-      "start": 1888,
-      "end": 1888
+      "start": 1891,
+      "end": 1891
     },
     "context": {
       "type": "variable",
@@ -23483,8 +23532,8 @@
       "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
-        "start": 1889,
-        "end": 1889
+        "start": 1892,
+        "end": 1892
       }
     },
     "access": "public",
@@ -23499,8 +23548,8 @@
   {
     "description": "The box shadow of the Standout Card variant on narrow viewports.\n",
     "commentRange": {
-      "start": 1890,
-      "end": 1890
+      "start": 1893,
+      "end": 1893
     },
     "context": {
       "type": "variable",
@@ -23508,8 +23557,8 @@
       "value": "0 4px 20px 2px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1891,
-        "end": 1891
+        "start": 1894,
+        "end": 1894
       }
     },
     "access": "public",
@@ -23524,8 +23573,8 @@
   {
     "description": "The box shadow of the Standout Card variant on wide viewports.\n",
     "commentRange": {
-      "start": 1892,
-      "end": 1892
+      "start": 1895,
+      "end": 1895
     },
     "context": {
       "type": "variable",
@@ -23533,8 +23582,8 @@
       "value": "0 4px 40px 2px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1893,
-        "end": 1893
+        "start": 1896,
+        "end": 1896
       }
     },
     "access": "public",
@@ -23549,8 +23598,8 @@
   {
     "description": "The border radius of the Card.\n",
     "commentRange": {
-      "start": 1894,
-      "end": 1894
+      "start": 1897,
+      "end": 1897
     },
     "context": {
       "type": "variable",
@@ -23558,8 +23607,8 @@
       "value": "8px",
       "scope": "default",
       "line": {
-        "start": 1895,
-        "end": 1895
+        "start": 1898,
+        "end": 1898
       }
     },
     "access": "public",
@@ -23574,8 +23623,8 @@
   {
     "description": "The padding of the content inside the Card.\n",
     "commentRange": {
-      "start": 1896,
-      "end": 1896
+      "start": 1899,
+      "end": 1899
     },
     "context": {
       "type": "variable",
@@ -23583,8 +23632,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 1897,
-        "end": 1897
+        "start": 1900,
+        "end": 1900
       }
     },
     "access": "public",
@@ -23599,8 +23648,8 @@
   {
     "description": "The background color of the header area for the Highlighted Header Card.\n",
     "commentRange": {
-      "start": 1898,
-      "end": 1898
+      "start": 1901,
+      "end": 1901
     },
     "context": {
       "type": "variable",
@@ -23608,8 +23657,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 1899,
-        "end": 1899
+        "start": 1902,
+        "end": 1902
       }
     },
     "access": "public",
@@ -23624,8 +23673,8 @@
   {
     "description": "The text color for the Highlighted Header Card.\n",
     "commentRange": {
-      "start": 1900,
-      "end": 1900
+      "start": 1903,
+      "end": 1903
     },
     "context": {
       "type": "variable",
@@ -23633,8 +23682,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1901,
-        "end": 1901
+        "start": 1904,
+        "end": 1904
       }
     },
     "access": "public",
@@ -23649,8 +23698,8 @@
   {
     "description": "The border surrounding the Dictionary.\n",
     "commentRange": {
-      "start": 1907,
-      "end": 1907
+      "start": 1910,
+      "end": 1910
     },
     "context": {
       "type": "variable",
@@ -23658,8 +23707,8 @@
       "value": "1px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1908,
-        "end": 1908
+        "start": 1911,
+        "end": 1911
       }
     },
     "access": "public",
@@ -23674,8 +23723,8 @@
   {
     "description": "The background color of the key value pairs in the striped Dictionary.\n",
     "commentRange": {
-      "start": 1909,
-      "end": 1909
+      "start": 1912,
+      "end": 1912
     },
     "context": {
       "type": "variable",
@@ -23683,8 +23732,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1910,
-        "end": 1910
+        "start": 1913,
+        "end": 1913
       }
     },
     "access": "public",
@@ -23699,8 +23748,8 @@
   {
     "description": "The breakpoint of the Dictionary component.\n",
     "commentRange": {
-      "start": 1911,
-      "end": 1911
+      "start": 1914,
+      "end": 1914
     },
     "context": {
       "type": "variable",
@@ -23708,8 +23757,8 @@
       "value": "38.4375rem",
       "scope": "default",
       "line": {
-        "start": 1912,
-        "end": 1912
+        "start": 1915,
+        "end": 1915
       }
     },
     "access": "public",
@@ -23724,8 +23773,8 @@
   {
     "description": "The font size of the labels in the Dictionary.\n",
     "commentRange": {
-      "start": 1913,
-      "end": 1913
+      "start": 1916,
+      "end": 1916
     },
     "context": {
       "type": "variable",
@@ -23733,8 +23782,8 @@
       "value": "$sprk-font-size-body-one",
       "scope": "default",
       "line": {
-        "start": 1914,
-        "end": 1914
+        "start": 1917,
+        "end": 1917
       }
     },
     "access": "public",
@@ -23749,8 +23798,8 @@
   {
     "description": "The font weight of the labels in the Dictionary.\n",
     "commentRange": {
-      "start": 1915,
-      "end": 1915
+      "start": 1918,
+      "end": 1918
     },
     "context": {
       "type": "variable",
@@ -23758,8 +23807,8 @@
       "value": "$sprk-font-weight-body-one",
       "scope": "default",
       "line": {
-        "start": 1916,
-        "end": 1916
+        "start": 1919,
+        "end": 1919
       }
     },
     "access": "public",
@@ -23774,8 +23823,8 @@
   {
     "description": "The line height of the labels in the Dictionary.\n",
     "commentRange": {
-      "start": 1917,
-      "end": 1917
+      "start": 1920,
+      "end": 1920
     },
     "context": {
       "type": "variable",
@@ -23783,8 +23832,8 @@
       "value": "$sprk-line-height-body-one",
       "scope": "default",
       "line": {
-        "start": 1918,
-        "end": 1918
+        "start": 1921,
+        "end": 1921
       }
     },
     "access": "public",
@@ -23799,37 +23848,12 @@
   {
     "description": "The Highlight Board breakpoint at which styles change\nfor padding, font size and button width.\n",
     "commentRange": {
-      "start": 1924,
-      "end": 1925
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-breakpoint",
-      "value": "30rem",
-      "scope": "default",
-      "line": {
-        "start": 1926,
-        "end": 1926
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "settings/_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The maximum width of the content\nfor the Highlight Board when it has an image.\n",
-    "commentRange": {
       "start": 1927,
       "end": 1928
     },
     "context": {
       "type": "variable",
-      "name": "sprk-highlight-board-content-width",
+      "name": "sprk-highlight-board-breakpoint",
       "value": "30rem",
       "scope": "default",
       "line": {
@@ -23847,15 +23871,15 @@
     }
   },
   {
-    "description": "Percentage reduction value for the\nfont size in the Highlight Board in narrow viewports.\n",
+    "description": "The maximum width of the content\nfor the Highlight Board when it has an image.\n",
     "commentRange": {
       "start": 1930,
       "end": 1931
     },
     "context": {
       "type": "variable",
-      "name": "sprk-highlight-board-type-reduction-percentage",
-      "value": "0.8",
+      "name": "sprk-highlight-board-content-width",
+      "value": "30rem",
       "scope": "default",
       "line": {
         "start": 1932,
@@ -23872,10 +23896,35 @@
     }
   },
   {
-    "description": "The height of the Highlight Board image.\n",
+    "description": "Percentage reduction value for the\nfont size in the Highlight Board in narrow viewports.\n",
     "commentRange": {
       "start": 1933,
-      "end": 1933
+      "end": 1934
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-highlight-board-type-reduction-percentage",
+      "value": "0.8",
+      "scope": "default",
+      "line": {
+        "start": 1935,
+        "end": 1935
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "settings/_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The height of the Highlight Board image.\n",
+    "commentRange": {
+      "start": 1936,
+      "end": 1936
     },
     "context": {
       "type": "variable",
@@ -23883,8 +23932,8 @@
       "value": "31.25rem",
       "scope": "default",
       "line": {
-        "start": 1934,
-        "end": 1934
+        "start": 1937,
+        "end": 1937
       }
     },
     "access": "public",
@@ -23899,8 +23948,8 @@
   {
     "description": "The background color of the Highlight Board.\n",
     "commentRange": {
-      "start": 1935,
-      "end": 1935
+      "start": 1938,
+      "end": 1938
     },
     "context": {
       "type": "variable",
@@ -23908,8 +23957,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1936,
-        "end": 1936
+        "start": 1939,
+        "end": 1939
       }
     },
     "access": "public",
@@ -23924,8 +23973,8 @@
   {
     "description": "The background color of\nthe content box in the Highlight Board.\n",
     "commentRange": {
-      "start": 1937,
-      "end": 1938
+      "start": 1940,
+      "end": 1941
     },
     "context": {
       "type": "variable",
@@ -23933,8 +23982,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1939,
-        "end": 1939
+        "start": 1942,
+        "end": 1942
       }
     },
     "access": "public",
@@ -24288,12 +24337,12 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 780,
-      "end": 780
+      "start": 784,
+      "end": 784
     },
     "context": {
       "type": "css",
-      "name": "//\n// Accessibility\n///\n\n/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
+      "name": "/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
       "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
       "line": {
         "start": 789,
@@ -24312,12 +24361,12 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 784,
-      "end": 784
+      "start": 780,
+      "end": 780
     },
     "context": {
       "type": "css",
-      "name": "/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
+      "name": "//\n// Accessibility\n///\n\n/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
       "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
       "line": {
         "start": 789,
@@ -24433,14 +24482,14 @@
     }
   },
   {
-    "description": "Changes the width of the element to 50 percent.\n",
+    "description": "Changes the width of the element to 25 percent.\n",
     "commentRange": {
-      "start": 20,
-      "end": 22
+      "start": 16,
+      "end": 18
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-Width-50",
+      "name": ".sprk-u-Width-25",
       "value": ".sprk-u-Width-#{$width} {\n    width: unquote($string:'#{$width}%') !important;\n  }\n\n  $width: $width + $width-step-value;",
       "line": {
         "start": 30,
@@ -24457,14 +24506,14 @@
     }
   },
   {
-    "description": "Changes the width of the element to 25 percent.\n",
+    "description": "Changes the width of the element to 50 percent.\n",
     "commentRange": {
-      "start": 16,
-      "end": 18
+      "start": 20,
+      "end": 22
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-Width-25",
+      "name": ".sprk-u-Width-50",
       "value": ".sprk-u-Width-#{$width} {\n    width: unquote($string:'#{$width}%') !important;\n  }\n\n  $width: $width + $width-step-value;",
       "line": {
         "start": 30,

--- a/src/data/sass-modifiers.json
+++ b/src/data/sass-modifiers.json
@@ -954,16 +954,16 @@
   {
     "description": "Sets the font color to black.\n",
     "commentRange": {
-      "start": 332,
-      "end": 333
+      "start": 342,
+      "end": 343
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--black",
       "value": "color: $sprk-black !important;",
       "line": {
-        "start": 334,
-        "end": 829
+        "start": 344,
+        "end": 839
       }
     },
     "group": [
@@ -978,16 +978,16 @@
   {
     "description": "Sets the font color to blue.\n",
     "commentRange": {
-      "start": 339,
-      "end": 340
+      "start": 349,
+      "end": 350
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--blue",
       "value": "color: $sprk-blue !important;",
       "line": {
-        "start": 341,
-        "end": 829
+        "start": 351,
+        "end": 839
       }
     },
     "group": [
@@ -1002,16 +1002,16 @@
   {
     "description": "Sets the font color to gray.\n",
     "commentRange": {
-      "start": 346,
-      "end": 347
+      "start": 356,
+      "end": 357
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--gray",
       "value": "color: $sprk-gray !important;",
       "line": {
-        "start": 348,
-        "end": 829
+        "start": 358,
+        "end": 839
       }
     },
     "group": [
@@ -1026,16 +1026,16 @@
   {
     "description": "Sets the font color to green.\n",
     "commentRange": {
-      "start": 353,
-      "end": 354
+      "start": 363,
+      "end": 364
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--green",
       "value": "color: $sprk-green !important;",
       "line": {
-        "start": 355,
-        "end": 829
+        "start": 365,
+        "end": 839
       }
     },
     "group": [
@@ -1050,16 +1050,16 @@
   {
     "description": "Sets the font color to red.\n",
     "commentRange": {
-      "start": 360,
-      "end": 361
+      "start": 370,
+      "end": 371
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--red",
       "value": "color: $sprk-red !important;",
       "line": {
-        "start": 362,
-        "end": 829
+        "start": 372,
+        "end": 839
       }
     },
     "group": [
@@ -1074,16 +1074,16 @@
   {
     "description": "Sets the font color to red tinted at 75%.\n",
     "commentRange": {
-      "start": 366,
-      "end": 367
+      "start": 376,
+      "end": 377
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--red-tint-75",
       "value": "color: $sprk-red-tint-75 !important;",
       "line": {
-        "start": 368,
-        "end": 829
+        "start": 378,
+        "end": 839
       }
     },
     "group": [
@@ -1098,16 +1098,16 @@
   {
     "description": "Sets the font color to red tinted at 50%.\n",
     "commentRange": {
-      "start": 372,
-      "end": 373
+      "start": 382,
+      "end": 383
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--red-tint-50",
       "value": "color: $sprk-red-tint-50 !important;",
       "line": {
-        "start": 374,
-        "end": 829
+        "start": 384,
+        "end": 839
       }
     },
     "group": [
@@ -1122,16 +1122,16 @@
   {
     "description": "Sets the font color to red tinted at 25%.\n",
     "commentRange": {
-      "start": 378,
-      "end": 379
+      "start": 388,
+      "end": 389
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--red-tint-25",
       "value": "color: $sprk-red-tint-25 !important;",
       "line": {
-        "start": 380,
-        "end": 829
+        "start": 390,
+        "end": 839
       }
     },
     "group": [
@@ -1146,16 +1146,16 @@
   {
     "description": "Sets the font color to white.\n",
     "commentRange": {
-      "start": 385,
-      "end": 386
+      "start": 395,
+      "end": 396
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--white",
       "value": "color: $sprk-white !important;",
       "line": {
-        "start": 387,
-        "end": 829
+        "start": 397,
+        "end": 839
       }
     },
     "group": [
@@ -1170,16 +1170,16 @@
   {
     "description": "Sets the font color to yellow.\n",
     "commentRange": {
-      "start": 392,
-      "end": 393
+      "start": 402,
+      "end": 403
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--yellow",
       "value": "color: $sprk-yellow !important;",
       "line": {
-        "start": 394,
-        "end": 829
+        "start": 404,
+        "end": 839
       }
     },
     "group": [
@@ -1194,16 +1194,16 @@
   {
     "description": "Sets the background color to black.\n",
     "commentRange": {
-      "start": 400,
-      "end": 401
+      "start": 410,
+      "end": 411
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--black",
       "value": "background-color: $sprk-black !important;",
       "line": {
-        "start": 402,
-        "end": 829
+        "start": 412,
+        "end": 839
       }
     },
     "group": [
@@ -1218,16 +1218,16 @@
   {
     "description": "Sets the background color to black tinted at 75%.\n",
     "commentRange": {
-      "start": 406,
-      "end": 407
+      "start": 416,
+      "end": 417
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--black-tint-75",
       "value": "background-color: $sprk-black-tint-75 !important;",
       "line": {
-        "start": 408,
-        "end": 829
+        "start": 418,
+        "end": 839
       }
     },
     "group": [
@@ -1242,16 +1242,16 @@
   {
     "description": "Sets the background color to black tinted at 50%.\n",
     "commentRange": {
-      "start": 412,
-      "end": 413
+      "start": 422,
+      "end": 423
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--black-tint-50",
       "value": "background-color: $sprk-black-tint-50 !important;",
       "line": {
-        "start": 414,
-        "end": 829
+        "start": 424,
+        "end": 839
       }
     },
     "group": [
@@ -1266,16 +1266,16 @@
   {
     "description": "Sets the background color to black tinted at 25%.\n",
     "commentRange": {
-      "start": 418,
-      "end": 419
+      "start": 428,
+      "end": 429
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--black-tint-25",
       "value": "background-color: $sprk-black-tint-25 !important;",
       "line": {
-        "start": 420,
-        "end": 829
+        "start": 430,
+        "end": 839
       }
     },
     "group": [
@@ -1290,16 +1290,16 @@
   {
     "description": "Sets the background color to dark gray.\n",
     "commentRange": {
-      "start": 424,
-      "end": 425
+      "start": 434,
+      "end": 435
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--gray-dark",
       "value": "background-color: $sprk-gray-dark !important;",
       "line": {
-        "start": 426,
-        "end": 829
+        "start": 436,
+        "end": 839
       }
     },
     "group": [
@@ -1314,16 +1314,16 @@
   {
     "description": "Sets the background color to blue.\n",
     "commentRange": {
-      "start": 430,
-      "end": 431
+      "start": 440,
+      "end": 441
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--blue",
       "value": "background-color: $sprk-blue !important;",
       "line": {
-        "start": 432,
-        "end": 829
+        "start": 442,
+        "end": 839
       }
     },
     "group": [
@@ -1338,16 +1338,16 @@
   {
     "description": "Sets the background color to blue tinted at 75%.\n",
     "commentRange": {
-      "start": 436,
-      "end": 437
+      "start": 446,
+      "end": 447
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--blue-tint-75",
       "value": "background-color: $sprk-blue-tint-75 !important;",
       "line": {
-        "start": 438,
-        "end": 829
+        "start": 448,
+        "end": 839
       }
     },
     "group": [
@@ -1362,16 +1362,16 @@
   {
     "description": "Sets the background color to blue tinted at 50%.\n",
     "commentRange": {
-      "start": 442,
-      "end": 443
+      "start": 452,
+      "end": 453
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--blue-tint-50",
       "value": "background-color: $sprk-blue-tint-50 !important;",
       "line": {
-        "start": 444,
-        "end": 829
+        "start": 454,
+        "end": 839
       }
     },
     "group": [
@@ -1386,16 +1386,16 @@
   {
     "description": "Sets the background color to blue tinted at 25%.\n",
     "commentRange": {
-      "start": 448,
-      "end": 449
+      "start": 458,
+      "end": 459
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--blue-tint-25",
       "value": "background-color: $sprk-blue-tint-25 !important;",
       "line": {
-        "start": 450,
-        "end": 829
+        "start": 460,
+        "end": 839
       }
     },
     "group": [
@@ -1410,16 +1410,16 @@
   {
     "description": "Sets the background color to gray.\n",
     "commentRange": {
-      "start": 454,
-      "end": 455
+      "start": 464,
+      "end": 465
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--gray",
       "value": "background-color: $sprk-gray !important;",
       "line": {
-        "start": 456,
-        "end": 829
+        "start": 466,
+        "end": 839
       }
     },
     "group": [
@@ -1434,16 +1434,16 @@
   {
     "description": "Sets the background color to red.\n",
     "commentRange": {
-      "start": 460,
-      "end": 461
+      "start": 470,
+      "end": 471
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--red",
       "value": "background-color: $sprk-red !important;",
       "line": {
-        "start": 462,
-        "end": 829
+        "start": 472,
+        "end": 839
       }
     },
     "group": [
@@ -1458,16 +1458,16 @@
   {
     "description": "Sets the background color to red tinted at 75%.\n",
     "commentRange": {
-      "start": 466,
-      "end": 467
+      "start": 476,
+      "end": 477
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--red-tint-75",
       "value": "background-color: $sprk-red-tint-75 !important;",
       "line": {
-        "start": 468,
-        "end": 829
+        "start": 478,
+        "end": 839
       }
     },
     "group": [
@@ -1482,16 +1482,16 @@
   {
     "description": "Sets the background color to red tinted at 50%.\n",
     "commentRange": {
-      "start": 472,
-      "end": 473
+      "start": 482,
+      "end": 483
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--red-tint-50",
       "value": "background-color: $sprk-red-tint-50 !important;",
       "line": {
-        "start": 474,
-        "end": 829
+        "start": 484,
+        "end": 839
       }
     },
     "group": [
@@ -1506,16 +1506,16 @@
   {
     "description": "Sets the background color to red tinted at 25%.\n",
     "commentRange": {
-      "start": 478,
-      "end": 479
+      "start": 488,
+      "end": 489
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--red-tint-25",
       "value": "background-color: $sprk-red-tint-25 !important;",
       "line": {
-        "start": 480,
-        "end": 829
+        "start": 490,
+        "end": 839
       }
     },
     "group": [
@@ -1530,16 +1530,16 @@
   {
     "description": "Sets the background color to green.\n",
     "commentRange": {
-      "start": 484,
-      "end": 485
+      "start": 494,
+      "end": 495
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green",
       "value": "background-color: $sprk-green !important;",
       "line": {
-        "start": 486,
-        "end": 829
+        "start": 496,
+        "end": 839
       }
     },
     "group": [
@@ -1554,16 +1554,16 @@
   {
     "description": "Sets the background color to dark green.\n",
     "commentRange": {
-      "start": 490,
-      "end": 491
+      "start": 500,
+      "end": 501
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green-dark",
       "value": "background-color: $sprk-green-dark !important;",
       "line": {
-        "start": 492,
-        "end": 829
+        "start": 502,
+        "end": 839
       }
     },
     "group": [
@@ -1578,16 +1578,16 @@
   {
     "description": "Sets the background color to green tinted at 75%.\n",
     "commentRange": {
-      "start": 496,
-      "end": 497
+      "start": 506,
+      "end": 507
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green-tint-75",
       "value": "background-color: $sprk-green-tint-75 !important;",
       "line": {
-        "start": 498,
-        "end": 829
+        "start": 508,
+        "end": 839
       }
     },
     "group": [
@@ -1602,16 +1602,16 @@
   {
     "description": "Sets the background color to green tinted at 50%.\n",
     "commentRange": {
-      "start": 502,
-      "end": 503
+      "start": 512,
+      "end": 513
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green-tint-50",
       "value": "background-color: $sprk-green-tint-50 !important;",
       "line": {
-        "start": 504,
-        "end": 829
+        "start": 514,
+        "end": 839
       }
     },
     "group": [
@@ -1626,16 +1626,16 @@
   {
     "description": "Sets the background color to green tinted at 25%.\n",
     "commentRange": {
-      "start": 508,
-      "end": 509
+      "start": 518,
+      "end": 519
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green-tint-25",
       "value": "background-color: $sprk-green-tint-25 !important;",
       "line": {
-        "start": 510,
-        "end": 829
+        "start": 520,
+        "end": 839
       }
     },
     "group": [
@@ -1650,16 +1650,16 @@
   {
     "description": "Sets the background color to white.\n",
     "commentRange": {
-      "start": 514,
-      "end": 515
+      "start": 524,
+      "end": 525
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--white",
       "value": "background-color: $sprk-white !important;",
       "line": {
-        "start": 516,
-        "end": 829
+        "start": 526,
+        "end": 839
       }
     },
     "group": [
@@ -1674,16 +1674,16 @@
   {
     "description": "Sets the background color to yellow.\n",
     "commentRange": {
-      "start": 520,
-      "end": 521
+      "start": 530,
+      "end": 531
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--yellow",
       "value": "background-color: $sprk-yellow !important;",
       "line": {
-        "start": 522,
-        "end": 829
+        "start": 532,
+        "end": 839
       }
     },
     "group": [
@@ -1698,16 +1698,16 @@
   {
     "description": "Sets the background color to yellow tinted at 75%.\n",
     "commentRange": {
-      "start": 526,
-      "end": 527
+      "start": 536,
+      "end": 537
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--yellow-tint-75",
       "value": "background-color: $sprk-yellow-tint-75 !important;",
       "line": {
-        "start": 528,
-        "end": 829
+        "start": 538,
+        "end": 839
       }
     },
     "group": [
@@ -1722,16 +1722,16 @@
   {
     "description": "Sets the background color to yellow tinted at 50%.\n",
     "commentRange": {
-      "start": 532,
-      "end": 533
+      "start": 542,
+      "end": 543
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--yellow-tint-50",
       "value": "background-color: $sprk-yellow-tint-50 !important;",
       "line": {
-        "start": 534,
-        "end": 829
+        "start": 544,
+        "end": 839
       }
     },
     "group": [
@@ -1746,16 +1746,16 @@
   {
     "description": "Sets the background color to yellow tinted at 25%.\n",
     "commentRange": {
-      "start": 538,
-      "end": 539
+      "start": 548,
+      "end": 549
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--yellow-tint-25",
       "value": "background-color: $sprk-yellow-tint-25 !important;",
       "line": {
-        "start": 540,
-        "end": 829
+        "start": 550,
+        "end": 839
       }
     },
     "group": [
@@ -1803,7 +1803,7 @@
       "value": "display: none !important;",
       "line": {
         "start": 26,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1827,7 +1827,7 @@
       "value": "display: none !important;",
       "line": {
         "start": 26,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1851,7 +1851,7 @@
       "value": "display: block !important;",
       "line": {
         "start": 33,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1875,7 +1875,7 @@
       "value": "display: inline !important;",
       "line": {
         "start": 39,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1899,7 +1899,7 @@
       "value": "display: inline-block !important;",
       "line": {
         "start": 46,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1923,7 +1923,7 @@
       "value": "visibility: hidden !important;",
       "line": {
         "start": 53,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1947,7 +1947,7 @@
       "value": "visibility: visible !important;",
       "line": {
         "start": 59,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -2393,7 +2393,7 @@
       "value": "height: 100% !important;",
       "line": {
         "start": 150,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -2430,14 +2430,14 @@
     }
   },
   {
-    "description": "A Spark utility class that can be used on\nthe Highlight Board to make it become 100% width.\n",
+    "description": "Adds the styles for the Stacked Highlight Board variant.\n",
     "commentRange": {
-      "start": 52,
-      "end": 54
+      "start": 49,
+      "end": 50
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-FullWidth",
+      "name": ".sprk-c-HighlightBoard--stacked",
       "value": "position: absolute;\n  bottom: $sprk-space-l;\n  left: $sprk-space-l;\n  max-width: $sprk-highlight-board-content-width;\n  right: $sprk-space-l;\n  text-align: left;",
       "line": {
         "start": 59,
@@ -2454,14 +2454,14 @@
     }
   },
   {
-    "description": "Adds the styles for the Stacked Highlight Board variant.\n",
+    "description": "A Spark utility class that can be used on\nthe Highlight Board to make it become 100% width.\n",
     "commentRange": {
-      "start": 49,
-      "end": 50
+      "start": 52,
+      "end": 54
     },
     "context": {
       "type": "css",
-      "name": ".sprk-c-HighlightBoard--stacked",
+      "name": ".sprk-u-FullWidth",
       "value": "position: absolute;\n  bottom: $sprk-space-l;\n  left: $sprk-space-l;\n  max-width: $sprk-highlight-board-content-width;\n  right: $sprk-space-l;\n  text-align: left;",
       "line": {
         "start": 59,
@@ -3222,18 +3222,18 @@
     }
   },
   {
-    "description": "Sets the bottom margin to the current value of\n`$sprk-space-misc-a` (`24px`).\n",
+    "description": "Sets the padding on the left and right (horizontal)\nto `$sprk-space-misc-b` (`40px`).\n",
     "commentRange": {
-      "start": 550,
-      "end": 553
+      "start": 565,
+      "end": 568
     },
     "context": {
       "type": "css",
-      "name": "sprk-u-MarginBottom--a",
+      "name": "sprk-u-PaddingHorizontal--b",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
-        "start": 569,
-        "end": 829
+        "start": 579,
+        "end": 839
       }
     },
     "group": [
@@ -3246,18 +3246,18 @@
     }
   },
   {
-    "description": "Sets the padding on the left and right (horizontal)\nto `$sprk-space-misc-b` (`40px`).\n",
+    "description": "Sets the bottom margin to the current value of\n`$sprk-space-misc-a` (`24px`).\n",
     "commentRange": {
-      "start": 555,
-      "end": 558
+      "start": 560,
+      "end": 563
     },
     "context": {
       "type": "css",
-      "name": "sprk-u-PaddingHorizontal--b",
+      "name": "sprk-u-MarginBottom--a",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
-        "start": 569,
-        "end": 829
+        "start": 579,
+        "end": 839
       }
     },
     "group": [
@@ -3272,16 +3272,16 @@
   {
     "description": "Sets the margin on all sides to the current value\nof `$sprk-space-misc-d` (`80px`).\n",
     "commentRange": {
-      "start": 560,
-      "end": 563
+      "start": 570,
+      "end": 573
     },
     "context": {
       "type": "css",
       "name": "sprk-u-MarginAll--d",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
-        "start": 569,
-        "end": 829
+        "start": 579,
+        "end": 839
       }
     },
     "group": [
@@ -3320,16 +3320,16 @@
   {
     "description": "Makes content invisible while still being read by a\nscreen reader.\n",
     "commentRange": {
-      "start": 776,
-      "end": 778
+      "start": 786,
+      "end": 788
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-ScreenReaderText",
       "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
       "line": {
-        "start": 779,
-        "end": 829
+        "start": 789,
+        "end": 839
       }
     },
     "group": [
@@ -3344,16 +3344,16 @@
   {
     "description": "When combined with `.sprk-u-ScreenReaderText` the element\nwill become visible on focus.\n",
     "commentRange": {
-      "start": 788,
-      "end": 790
+      "start": 798,
+      "end": 800
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-ShowOnFocus:focus",
       "value": "position: static;\n  width: auto;\n  height: auto;",
       "line": {
-        "start": 791,
-        "end": 829
+        "start": 801,
+        "end": 839
       }
     },
     "group": [
@@ -3392,16 +3392,16 @@
   {
     "description": "When placed on a container, its children will align\nin the absolute center (vertically and horizontally)\nof the box.\n",
     "commentRange": {
-      "start": 799,
-      "end": 802
+      "start": 809,
+      "end": 812
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-AbsoluteCenter",
       "value": "display: flex;\n  align-items: center;\n  justify-content: center;",
       "line": {
-        "start": 803,
-        "end": 829
+        "start": 813,
+        "end": 839
       }
     },
     "group": [
@@ -3416,16 +3416,16 @@
   {
     "description": "When placed on a container, it will cause it to fill\nthe viewport, even if it's inside a limiting container\n(such as `sprk-o-CenteredColumn`).\n",
     "commentRange": {
-      "start": 809,
-      "end": 812
+      "start": 819,
+      "end": 822
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FullWidth",
       "value": "width: 100vw;\n  left: 50%;\n  right: 50%;\n  margin-left: -50vw;\n  margin-right: -50vw;",
       "line": {
-        "start": 813,
-        "end": 829
+        "start": 823,
+        "end": 839
       }
     },
     "group": [
@@ -3440,16 +3440,16 @@
   {
     "description": "When placed on an element that contains text or any of\nthe typography classes, it will remove the text cropping\nand the negative margins applied by the crop.\n",
     "commentRange": {
-      "start": 258,
-      "end": 261
+      "start": 268,
+      "end": 271
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextCrop--none",
       "value": "&::before,\n  &::after {\n    content: none !important;\n    margin-bottom: 0 !important;\n    margin-top: 0 !important;\n  }",
       "line": {
-        "start": 262,
-        "end": 829
+        "start": 272,
+        "end": 839
       }
     },
     "group": [
@@ -3464,16 +3464,16 @@
   {
     "description": "When placed on an element that contains text, it will\nlimit the text to one line and adds an ellipsis when\nit overflows.\n",
     "commentRange": {
-      "start": 821,
-      "end": 824
+      "start": 831,
+      "end": 834
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Truncate",
       "value": "white-space: nowrap !important;\n  overflow: hidden !important;\n  text-overflow: ellipsis !important;",
       "line": {
-        "start": 825,
-        "end": 829
+        "start": 835,
+        "end": 839
       }
     },
     "group": [
@@ -3488,16 +3488,16 @@
   {
     "description": "Content is not clipped and may be rendered outside\nthe padding box.\n",
     "commentRange": {
-      "start": 301,
-      "end": 303
+      "start": 311,
+      "end": 313
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Overflow--visible",
       "value": "overflow: visible !important;",
       "line": {
-        "start": 304,
-        "end": 829
+        "start": 314,
+        "end": 839
       }
     },
     "group": [
@@ -3512,16 +3512,16 @@
   {
     "description": "Content is clipped if necessary to fit the padding\nbox. No scrollbars are provided.\n",
     "commentRange": {
-      "start": 308,
-      "end": 310
+      "start": 318,
+      "end": 320
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Overflow--hidden",
       "value": "overflow: hidden !important;",
       "line": {
-        "start": 311,
-        "end": 829
+        "start": 321,
+        "end": 839
       }
     },
     "group": [
@@ -3536,16 +3536,16 @@
   {
     "description": "Content is clipped if necessary to fit the padding\nbox. Browsers display scrollbars whether or not any\ncontent is actually clipped.\n",
     "commentRange": {
-      "start": 315,
-      "end": 318
+      "start": 325,
+      "end": 328
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Overflow--scroll",
       "value": "overflow: scroll !important;",
       "line": {
-        "start": 319,
-        "end": 829
+        "start": 329,
+        "end": 839
       }
     },
     "group": [
@@ -3560,16 +3560,16 @@
   {
     "description": "If content fits inside the padding box, it looks the\nsame as visible, but still establishes a new\nblock-formatting context.\n",
     "commentRange": {
-      "start": 323,
-      "end": 326
+      "start": 333,
+      "end": 336
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Overflow--auto",
       "value": "overflow: auto !important;",
       "line": {
-        "start": 327,
-        "end": 829
+        "start": 337,
+        "end": 839
       }
     },
     "group": [
@@ -3617,7 +3617,7 @@
       "value": "float: none !important;",
       "line": {
         "start": 69,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3641,7 +3641,7 @@
       "value": "float: left !important;",
       "line": {
         "start": 75,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3665,7 +3665,7 @@
       "value": "float: right !important;",
       "line": {
         "start": 81,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3689,7 +3689,7 @@
       "value": "position: relative !important;",
       "line": {
         "start": 92,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3713,7 +3713,7 @@
       "value": "position: absolute !important;",
       "line": {
         "start": 100,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3737,7 +3737,7 @@
       "value": "position: fixed !important;",
       "line": {
         "start": 109,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3761,7 +3761,7 @@
       "value": "position: static !important;",
       "line": {
         "start": 116,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3785,7 +3785,7 @@
       "value": "top: 0 !important;",
       "line": {
         "start": 122,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3809,7 +3809,7 @@
       "value": "bottom: 0 !important;",
       "line": {
         "start": 128,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3833,7 +3833,7 @@
       "value": "left: 0 !important;",
       "line": {
         "start": 134,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3857,7 +3857,7 @@
       "value": "right: 0 !important;",
       "line": {
         "start": 140,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -3872,16 +3872,16 @@
   {
     "description": "Aligns text to the left of the container.\n",
     "commentRange": {
-      "start": 160,
-      "end": 161
+      "start": 170,
+      "end": 171
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextAlign--left",
       "value": "text-align: left !important;",
       "line": {
-        "start": 162,
-        "end": 829
+        "start": 172,
+        "end": 839
       }
     },
     "group": [
@@ -3896,16 +3896,16 @@
   {
     "description": "Aligns text to the right of the container.\n",
     "commentRange": {
-      "start": 166,
-      "end": 167
+      "start": 176,
+      "end": 177
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextAlign--right",
       "value": "text-align: right !important;",
       "line": {
-        "start": 168,
-        "end": 829
+        "start": 178,
+        "end": 839
       }
     },
     "group": [
@@ -3920,16 +3920,16 @@
   {
     "description": "Aligns text in the horizontal center of the container.\n",
     "commentRange": {
-      "start": 172,
-      "end": 173
+      "start": 182,
+      "end": 183
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextAlign--center",
       "value": "text-align: center !important;",
       "line": {
-        "start": 174,
-        "end": 829
+        "start": 184,
+        "end": 839
       }
     },
     "group": [
@@ -3944,16 +3944,16 @@
   {
     "description": "Aligns the contents of a box to the top if it's display\nproperty is `inline` or `table-cell`.\n",
     "commentRange": {
-      "start": 178,
-      "end": 180
+      "start": 188,
+      "end": 190
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-VerticalAlign--top",
       "value": "vertical-align: top !important;",
       "line": {
-        "start": 181,
-        "end": 829
+        "start": 191,
+        "end": 839
       }
     },
     "group": [
@@ -3968,16 +3968,16 @@
   {
     "description": "Aligns the contents of a box to the vertical middle if\nit's display property is `inline` or `table-cell`.\n",
     "commentRange": {
-      "start": 185,
-      "end": 187
+      "start": 195,
+      "end": 197
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-VerticalAlign--middle",
       "value": "vertical-align: middle !important;",
       "line": {
-        "start": 188,
-        "end": 829
+        "start": 198,
+        "end": 839
       }
     },
     "group": [
@@ -3992,16 +3992,16 @@
   {
     "description": "Aligns the contents of a box to the bottom if it's\ndisplay property is `inline` or `table-cell`.\n",
     "commentRange": {
-      "start": 192,
-      "end": 194
+      "start": 202,
+      "end": 204
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-VerticalAlign--bottom",
       "value": "vertical-align: bottom !important;",
       "line": {
-        "start": 195,
-        "end": 829
+        "start": 205,
+        "end": 839
       }
     },
     "group": [
@@ -4016,16 +4016,16 @@
   {
     "description": "Aligns the contents of a box to the baseline if it's\ndisplay property is `inline` or `table-cell`.\n",
     "commentRange": {
-      "start": 199,
-      "end": 201
+      "start": 209,
+      "end": 211
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-VerticalAlign--baseline",
       "value": "vertical-align: baseline !important;",
       "line": {
-        "start": 202,
-        "end": 829
+        "start": 212,
+        "end": 839
       }
     },
     "group": [
@@ -4290,14 +4290,14 @@
     }
   },
   {
-    "description": "Sets the margin on all sides to `64px`\n",
+    "description": "Sets the left and right padding to `16px`\n",
     "commentRange": {
-      "start": 13,
-      "end": 15
+      "start": 9,
+      "end": 11
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-mah",
+      "name": ".sprk-u-phm",
       "value": "padding-top: 0 !important;",
       "line": {
         "start": 19,
@@ -4314,14 +4314,14 @@
     }
   },
   {
-    "description": "Sets the left and right padding to `16px`\n",
+    "description": "Sets the margin on all sides to `64px`\n",
     "commentRange": {
-      "start": 9,
-      "end": 11
+      "start": 13,
+      "end": 15
     },
     "context": {
       "type": "css",
-      "name": ".sprk-u-phm",
+      "name": ".sprk-u-mah",
       "value": "padding-top: 0 !important;",
       "line": {
         "start": 19,
@@ -4554,110 +4554,14 @@
     }
   },
   {
-    "description": "When placed on an item, its width will be 3/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "description": "When placed on an item, its width will be 3/10\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
-      "start": 328,
-      "end": 331
+      "start": 333,
+      "end": 336
     },
     "context": {
       "type": "css",
-      "name": ".sprk-o-Stack__item--three-fifths@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "of its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 309,
-      "end": 311
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--third@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "When placed on an item, its width will be 1/2\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 313,
-      "end": 316
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--half@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "When placed on an item, its width will be 3/4\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 318,
-      "end": 321
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--three-fourths@xxs",
-      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
-      "line": {
-        "start": 344,
-        "end": 1397
-      }
-    },
-    "group": [
-      "stack"
-    ],
-    "access": "public",
-    "file": {
-      "path": "objects/_stack.scss",
-      "name": "_stack.scss"
-    }
-  },
-  {
-    "description": "When placed on an item, its width will be 2/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
-    "commentRange": {
-      "start": 323,
-      "end": 326
-    },
-    "context": {
-      "type": "css",
-      "name": ".sprk-o-Stack__item--two-fifths@xxs",
+      "name": ".sprk-o-Stack__item--three-tenths@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -4722,14 +4626,14 @@
     }
   },
   {
-    "description": "When placed on an item, its width will be 3/10\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "description": "When placed on an item, its width will be 1/6\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
-      "start": 333,
-      "end": 336
+      "start": 293,
+      "end": 296
     },
     "context": {
       "type": "css",
-      "name": ".sprk-o-Stack__item--three-tenths@xxs",
+      "name": ".sprk-o-Stack__item--sixth@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -4746,14 +4650,110 @@
     }
   },
   {
-    "description": "When placed on an item, its width will be 1/6\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "description": "When placed on an item, its width will be 2/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
     "commentRange": {
-      "start": 293,
-      "end": 296
+      "start": 323,
+      "end": 326
     },
     "context": {
       "type": "css",
-      "name": ".sprk-o-Stack__item--sixth@xxs",
+      "name": ".sprk-o-Stack__item--two-fifths@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 3/4\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 318,
+      "end": 321
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--three-fourths@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 1/2\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 313,
+      "end": 316
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--half@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "of its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 309,
+      "end": 311
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--third@xxs",
+      "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
+      "line": {
+        "start": 344,
+        "end": 1397
+      }
+    },
+    "group": [
+      "stack"
+    ],
+    "access": "public",
+    "file": {
+      "path": "objects/_stack.scss",
+      "name": "_stack.scss"
+    }
+  },
+  {
+    "description": "When placed on an item, its width will be 3/5\nof its container starting at the breakpoint\nspecified (xxs, xs, s, m, l, xl).\n",
+    "commentRange": {
+      "start": 328,
+      "end": 331
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-o-Stack__item--three-fifths@xxs",
       "value": "@media all and (min-width: $sprk-split-breakpoint-xxs) {\n    // At extra small breakpoint we switch from column to row\n    flex-direction: row;\n\n    // Remove bottom margin in new row formation\n    > .sprk-o-Stack__item {\n      margin-bottom: 0;\n    }\n\n    // Add spacing between items based on spacing size class\n    &.sprk-o-Stack--tiny > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-tiny;\n    }\n\n    &.sprk-o-Stack--small > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-small;\n    }\n\n    &.sprk-o-Stack--medium > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-medium;\n    }\n\n    &.sprk-o-Stack--large > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-large;\n    }\n\n    &.sprk-o-Stack--huge > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-huge;\n    }\n\n    /* stylelint-disable selector-class-pattern */\n    &.sprk-o-Stack--misc-a > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-a;\n    }\n\n    &.sprk-o-Stack--misc-b > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-b;\n    }\n\n    &.sprk-o-Stack--misc-c > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-c;\n    }\n\n    &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {\n      margin-right: $sprk-stack-spacing-misc-d;\n    }\n    \n    /* stylelint-enable selector-class-pattern */\n    > .sprk-o-Stack__item--sixth\\@xxs {\n      flex: 0 0 16.666666667%;\n      max-width: 16.666666667%;\n    }\n\n    > .sprk-o-Stack__item--fifth\\@xxs {\n      flex: 0 0 20%;\n      max-width: 20%;\n    }\n\n    > .sprk-o-Stack__item--fourth\\@xxs {\n      flex: 0 0 25%;\n      max-width: 25%;\n    }\n\n    > .sprk-o-Stack__item--third\\@xxs {\n      flex: 0 0 33.333333333%;\n      max-width: 33.333333333%;\n    }\n\n    > .sprk-o-Stack__item--half\\@xxs {\n      flex: 0 0 50%;\n      max-width: 50%;\n    }\n\n    > .sprk-o-Stack__item--three-fourths\\@xxs {\n      flex: 0 0 75%;\n      max-width: 75%;\n    }\n\n    > .sprk-o-Stack__item--three-fifths\\@xxs {\n      flex: 0 0 60%;\n      max-width: 60%;\n    }\n\n    > .sprk-o-Stack__item--three-tenths\\@xxs {\n      flex: 0 0 30%;\n      max-width: 30%;\n    }\n\n    > .sprk-o-Stack__item--seven-tenths\\@xxs {\n      flex: 0 0 70%;\n      max-width: 70%;\n    }\n\n    > .sprk-o-Stack__item--two-fifths\\@xxs {\n      flex: 0 0 40%;\n      max-width: 40%;\n    }\n  }",
       "line": {
         "start": 344,
@@ -5828,16 +5828,16 @@
   {
     "description": "Sets the font weight to bold.\n",
     "commentRange": {
-      "start": 210,
-      "end": 211
+      "start": 220,
+      "end": 221
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FontWeight--bold",
       "value": "font-weight: bold !important;",
       "line": {
-        "start": 212,
-        "end": 829
+        "start": 222,
+        "end": 839
       }
     },
     "group": [
@@ -5852,16 +5852,16 @@
   {
     "description": "Sets the font weight to normal.\n",
     "commentRange": {
-      "start": 216,
-      "end": 217
+      "start": 226,
+      "end": 227
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FontWeight--normal",
       "value": "font-weight: normal !important;",
       "line": {
-        "start": 218,
-        "end": 829
+        "start": 228,
+        "end": 839
       }
     },
     "group": [
@@ -5876,16 +5876,16 @@
   {
     "description": "Sets the font style to italic.\n",
     "commentRange": {
-      "start": 222,
-      "end": 223
+      "start": 232,
+      "end": 233
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FontStyle--italic",
       "value": "font-style: italic !important;",
       "line": {
-        "start": 224,
-        "end": 829
+        "start": 234,
+        "end": 839
       }
     },
     "group": [
@@ -5900,16 +5900,16 @@
   {
     "description": "Sets the font style to normal.\n",
     "commentRange": {
-      "start": 228,
-      "end": 229
+      "start": 238,
+      "end": 239
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FontStyle--normal",
       "value": "font-style: normal !important;",
       "line": {
-        "start": 230,
-        "end": 829
+        "start": 240,
+        "end": 839
       }
     },
     "group": [
@@ -5924,16 +5924,16 @@
   {
     "description": "Sets the text decoration to underline.\n",
     "commentRange": {
-      "start": 234,
-      "end": 235
+      "start": 244,
+      "end": 245
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextDecoration--underline",
       "value": "text-decoration: underline !important;",
       "line": {
-        "start": 236,
-        "end": 829
+        "start": 246,
+        "end": 839
       }
     },
     "group": [
@@ -5948,16 +5948,16 @@
   {
     "description": "Sets the text decoration to none.\n",
     "commentRange": {
-      "start": 240,
-      "end": 241
+      "start": 250,
+      "end": 251
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextDecoration--none",
       "value": "text-decoration: none !important;",
       "line": {
-        "start": 242,
-        "end": 829
+        "start": 252,
+        "end": 839
       }
     },
     "group": [
@@ -5972,16 +5972,16 @@
   {
     "description": "Transforms text to uppercase.\n",
     "commentRange": {
-      "start": 246,
-      "end": 247
+      "start": 256,
+      "end": 257
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextTransform--uppercase",
       "value": "text-transform: uppercase !important;",
       "line": {
-        "start": 248,
-        "end": 829
+        "start": 258,
+        "end": 839
       }
     },
     "group": [
@@ -5996,16 +5996,16 @@
   {
     "description": "Removes text transformation for text.\n",
     "commentRange": {
-      "start": 252,
-      "end": 253
+      "start": 262,
+      "end": 263
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextTransform--none",
       "value": "text-transform: none !important;",
       "line": {
-        "start": 254,
-        "end": 829
+        "start": 264,
+        "end": 839
       }
     },
     "group": [
@@ -6020,16 +6020,16 @@
   {
     "description": "Sets `word-wrap` to `break-word`.\n",
     "commentRange": {
-      "start": 271,
-      "end": 272
+      "start": 281,
+      "end": 282
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-WordWrap--break-word",
       "value": "word-wrap: break-word !important;",
       "line": {
-        "start": 273,
-        "end": 829
+        "start": 283,
+        "end": 839
       }
     },
     "group": [
@@ -6044,16 +6044,16 @@
   {
     "description": "Sets `white-space` to `nowrap`.\n",
     "commentRange": {
-      "start": 277,
-      "end": 278
+      "start": 287,
+      "end": 288
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-WhiteSpace--nowrap",
       "value": "white-space: nowrap !important;",
       "line": {
-        "start": 279,
-        "end": 829
+        "start": 289,
+        "end": 839
       }
     },
     "group": [
@@ -6068,16 +6068,16 @@
   {
     "description": "Sets a `max-width`, intended for text. Default value is\n`40 rem`.\n",
     "commentRange": {
-      "start": 283,
-      "end": 285
+      "start": 293,
+      "end": 295
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Measure",
       "value": "max-width: $sprk-measure !important;",
       "line": {
-        "start": 286,
-        "end": 829
+        "start": 296,
+        "end": 839
       }
     },
     "group": [
@@ -6092,16 +6092,16 @@
   {
     "description": "Sets a narrow `max-width`, intended for text. Default\nvalue is `25 rem`.\n",
     "commentRange": {
-      "start": 290,
-      "end": 292
+      "start": 300,
+      "end": 302
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Measure--narrow",
       "value": "max-width: $sprk-narrow-measure !important;",
       "line": {
-        "start": 293,
-        "end": 829
+        "start": 303,
+        "end": 839
       }
     },
     "group": [
@@ -24057,7 +24057,7 @@
       "value": "display: none !important;",
       "line": {
         "start": 26,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -24081,7 +24081,7 @@
       "value": "display: none !important;",
       "line": {
         "start": 26,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -24105,7 +24105,7 @@
       "value": "float: none !important;",
       "line": {
         "start": 69,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -24129,7 +24129,7 @@
       "value": "position: relative !important;",
       "line": {
         "start": 92,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -24153,7 +24153,7 @@
       "value": "height: 100% !important;",
       "line": {
         "start": 150,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -24168,16 +24168,40 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 158,
-      "end": 158
+      "start": 156,
+      "end": 156
+    },
+    "context": {
+      "type": "css",
+      "name": "/// Changes the max-width of the element to 100 percent.\n/// @group width\n.sprk-u-MaxWidth--100",
+      "value": "max-width: 100% !important;",
+      "line": {
+        "start": 160,
+        "end": 839
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "utilities/_utilities.scss",
+      "name": "_utilities.scss"
+    }
+  },
+  {
+    "description": "\n",
+    "commentRange": {
+      "start": 168,
+      "end": 168
     },
     "context": {
       "type": "css",
       "name": "/// Aligns text to the left of the container.\n/// @group position\n.sprk-u-TextAlign--left",
       "value": "text-align: left !important;",
       "line": {
-        "start": 162,
-        "end": 829
+        "start": 172,
+        "end": 839
       }
     },
     "access": "public",
@@ -24192,16 +24216,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 208,
-      "end": 208
+      "start": 218,
+      "end": 218
     },
     "context": {
       "type": "css",
       "name": "/// Sets the font weight to bold.\n/// @group typography\n.sprk-u-FontWeight--bold",
       "value": "font-weight: bold !important;",
       "line": {
-        "start": 212,
-        "end": 829
+        "start": 222,
+        "end": 839
       }
     },
     "access": "public",
@@ -24216,16 +24240,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 299,
-      "end": 299
+      "start": 309,
+      "end": 309
     },
     "context": {
       "type": "css",
       "name": "/// Content is not clipped and may be rendered outside\n/// the padding box.\n/// @group overflow\n.sprk-u-Overflow--visible",
       "value": "overflow: visible !important;",
       "line": {
-        "start": 304,
-        "end": 829
+        "start": 314,
+        "end": 839
       }
     },
     "access": "public",
@@ -24240,16 +24264,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 548,
-      "end": 548
+      "start": 558,
+      "end": 558
     },
     "context": {
       "type": "css",
       "name": "/// Sets the bottom margin to the current value of\n/// `$sprk-space-misc-a` (`24px`).\n/// @group misc-spacing\n/// @name sprk-u-MarginBottom--a\n\n/// Sets the padding on the left and right (horizontal)\n/// to `$sprk-space-misc-b` (`40px`).\n/// @group misc-spacing\n/// @name sprk-u-PaddingHorizontal--b\n\n/// Sets the margin on all sides to the current value\n/// of `$sprk-space-misc-d` (`80px`).\n/// @group misc-spacing\n/// @name sprk-u-MarginAll--d\n\n/* stylelint-disable  selector-class-pattern */\n// Misc Padding Spacing A\n.sprk-u-PaddingTop--a,\n.sprk-u-PaddingVertical--a,\n.sprk-u-PaddingAll--a",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
-        "start": 569,
-        "end": 829
+        "start": 579,
+        "end": 839
       }
     },
     "access": "public",
@@ -24264,40 +24288,40 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 774,
-      "end": 774
-    },
-    "context": {
-      "type": "css",
-      "name": "/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
-      "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
-      "line": {
-        "start": 779,
-        "end": 829
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "utilities/_utilities.scss",
-      "name": "_utilities.scss"
-    }
-  },
-  {
-    "description": "\n",
-    "commentRange": {
-      "start": 770,
-      "end": 770
+      "start": 780,
+      "end": 780
     },
     "context": {
       "type": "css",
       "name": "//\n// Accessibility\n///\n\n/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
       "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
       "line": {
-        "start": 779,
-        "end": 829
+        "start": 789,
+        "end": 839
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "utilities/_utilities.scss",
+      "name": "_utilities.scss"
+    }
+  },
+  {
+    "description": "\n",
+    "commentRange": {
+      "start": 784,
+      "end": 784
+    },
+    "context": {
+      "type": "css",
+      "name": "/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
+      "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
+      "line": {
+        "start": 789,
+        "end": 839
       }
     },
     "access": "public",
@@ -24357,6 +24381,30 @@
     "file": {
       "path": "settings/_colors.scss",
       "name": "_colors.scss"
+    }
+  },
+  {
+    "description": "Changes the max-width of the element to 100 percent.\n",
+    "commentRange": {
+      "start": 158,
+      "end": 159
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-u-MaxWidth--100",
+      "value": "max-width: 100% !important;",
+      "line": {
+        "start": 160,
+        "end": 839
+      }
+    },
+    "group": [
+      "width"
+    ],
+    "access": "public",
+    "file": {
+      "path": "utilities/_utilities.scss",
+      "name": "_utilities.scss"
     }
   },
   {

--- a/src/data/sass-utilities.json
+++ b/src/data/sass-utilities.json
@@ -2,16 +2,16 @@
   {
     "description": "Sets the font color to black.\n",
     "commentRange": {
-      "start": 332,
-      "end": 333
+      "start": 342,
+      "end": 343
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--black",
       "value": "color: $sprk-black !important;",
       "line": {
-        "start": 334,
-        "end": 829
+        "start": 344,
+        "end": 839
       }
     },
     "group": [
@@ -26,16 +26,16 @@
   {
     "description": "Sets the font color to blue.\n",
     "commentRange": {
-      "start": 339,
-      "end": 340
+      "start": 349,
+      "end": 350
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--blue",
       "value": "color: $sprk-blue !important;",
       "line": {
-        "start": 341,
-        "end": 829
+        "start": 351,
+        "end": 839
       }
     },
     "group": [
@@ -50,16 +50,16 @@
   {
     "description": "Sets the font color to gray.\n",
     "commentRange": {
-      "start": 346,
-      "end": 347
+      "start": 356,
+      "end": 357
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--gray",
       "value": "color: $sprk-gray !important;",
       "line": {
-        "start": 348,
-        "end": 829
+        "start": 358,
+        "end": 839
       }
     },
     "group": [
@@ -74,16 +74,16 @@
   {
     "description": "Sets the font color to green.\n",
     "commentRange": {
-      "start": 353,
-      "end": 354
+      "start": 363,
+      "end": 364
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--green",
       "value": "color: $sprk-green !important;",
       "line": {
-        "start": 355,
-        "end": 829
+        "start": 365,
+        "end": 839
       }
     },
     "group": [
@@ -98,16 +98,16 @@
   {
     "description": "Sets the font color to red.\n",
     "commentRange": {
-      "start": 360,
-      "end": 361
+      "start": 370,
+      "end": 371
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--red",
       "value": "color: $sprk-red !important;",
       "line": {
-        "start": 362,
-        "end": 829
+        "start": 372,
+        "end": 839
       }
     },
     "group": [
@@ -122,16 +122,16 @@
   {
     "description": "Sets the font color to red tinted at 75%.\n",
     "commentRange": {
-      "start": 366,
-      "end": 367
+      "start": 376,
+      "end": 377
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--red-tint-75",
       "value": "color: $sprk-red-tint-75 !important;",
       "line": {
-        "start": 368,
-        "end": 829
+        "start": 378,
+        "end": 839
       }
     },
     "group": [
@@ -146,16 +146,16 @@
   {
     "description": "Sets the font color to red tinted at 50%.\n",
     "commentRange": {
-      "start": 372,
-      "end": 373
+      "start": 382,
+      "end": 383
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--red-tint-50",
       "value": "color: $sprk-red-tint-50 !important;",
       "line": {
-        "start": 374,
-        "end": 829
+        "start": 384,
+        "end": 839
       }
     },
     "group": [
@@ -170,16 +170,16 @@
   {
     "description": "Sets the font color to red tinted at 25%.\n",
     "commentRange": {
-      "start": 378,
-      "end": 379
+      "start": 388,
+      "end": 389
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--red-tint-25",
       "value": "color: $sprk-red-tint-25 !important;",
       "line": {
-        "start": 380,
-        "end": 829
+        "start": 390,
+        "end": 839
       }
     },
     "group": [
@@ -194,16 +194,16 @@
   {
     "description": "Sets the font color to white.\n",
     "commentRange": {
-      "start": 385,
-      "end": 386
+      "start": 395,
+      "end": 396
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--white",
       "value": "color: $sprk-white !important;",
       "line": {
-        "start": 387,
-        "end": 829
+        "start": 397,
+        "end": 839
       }
     },
     "group": [
@@ -218,16 +218,16 @@
   {
     "description": "Sets the font color to yellow.\n",
     "commentRange": {
-      "start": 392,
-      "end": 393
+      "start": 402,
+      "end": 403
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Color--yellow",
       "value": "color: $sprk-yellow !important;",
       "line": {
-        "start": 394,
-        "end": 829
+        "start": 404,
+        "end": 839
       }
     },
     "group": [
@@ -242,16 +242,16 @@
   {
     "description": "Sets the background color to black.\n",
     "commentRange": {
-      "start": 400,
-      "end": 401
+      "start": 410,
+      "end": 411
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--black",
       "value": "background-color: $sprk-black !important;",
       "line": {
-        "start": 402,
-        "end": 829
+        "start": 412,
+        "end": 839
       }
     },
     "group": [
@@ -266,16 +266,16 @@
   {
     "description": "Sets the background color to black tinted at 75%.\n",
     "commentRange": {
-      "start": 406,
-      "end": 407
+      "start": 416,
+      "end": 417
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--black-tint-75",
       "value": "background-color: $sprk-black-tint-75 !important;",
       "line": {
-        "start": 408,
-        "end": 829
+        "start": 418,
+        "end": 839
       }
     },
     "group": [
@@ -290,16 +290,16 @@
   {
     "description": "Sets the background color to black tinted at 50%.\n",
     "commentRange": {
-      "start": 412,
-      "end": 413
+      "start": 422,
+      "end": 423
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--black-tint-50",
       "value": "background-color: $sprk-black-tint-50 !important;",
       "line": {
-        "start": 414,
-        "end": 829
+        "start": 424,
+        "end": 839
       }
     },
     "group": [
@@ -314,16 +314,16 @@
   {
     "description": "Sets the background color to black tinted at 25%.\n",
     "commentRange": {
-      "start": 418,
-      "end": 419
+      "start": 428,
+      "end": 429
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--black-tint-25",
       "value": "background-color: $sprk-black-tint-25 !important;",
       "line": {
-        "start": 420,
-        "end": 829
+        "start": 430,
+        "end": 839
       }
     },
     "group": [
@@ -338,16 +338,16 @@
   {
     "description": "Sets the background color to dark gray.\n",
     "commentRange": {
-      "start": 424,
-      "end": 425
+      "start": 434,
+      "end": 435
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--gray-dark",
       "value": "background-color: $sprk-gray-dark !important;",
       "line": {
-        "start": 426,
-        "end": 829
+        "start": 436,
+        "end": 839
       }
     },
     "group": [
@@ -362,16 +362,16 @@
   {
     "description": "Sets the background color to blue.\n",
     "commentRange": {
-      "start": 430,
-      "end": 431
+      "start": 440,
+      "end": 441
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--blue",
       "value": "background-color: $sprk-blue !important;",
       "line": {
-        "start": 432,
-        "end": 829
+        "start": 442,
+        "end": 839
       }
     },
     "group": [
@@ -386,16 +386,16 @@
   {
     "description": "Sets the background color to blue tinted at 75%.\n",
     "commentRange": {
-      "start": 436,
-      "end": 437
+      "start": 446,
+      "end": 447
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--blue-tint-75",
       "value": "background-color: $sprk-blue-tint-75 !important;",
       "line": {
-        "start": 438,
-        "end": 829
+        "start": 448,
+        "end": 839
       }
     },
     "group": [
@@ -410,16 +410,16 @@
   {
     "description": "Sets the background color to blue tinted at 50%.\n",
     "commentRange": {
-      "start": 442,
-      "end": 443
+      "start": 452,
+      "end": 453
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--blue-tint-50",
       "value": "background-color: $sprk-blue-tint-50 !important;",
       "line": {
-        "start": 444,
-        "end": 829
+        "start": 454,
+        "end": 839
       }
     },
     "group": [
@@ -434,16 +434,16 @@
   {
     "description": "Sets the background color to blue tinted at 25%.\n",
     "commentRange": {
-      "start": 448,
-      "end": 449
+      "start": 458,
+      "end": 459
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--blue-tint-25",
       "value": "background-color: $sprk-blue-tint-25 !important;",
       "line": {
-        "start": 450,
-        "end": 829
+        "start": 460,
+        "end": 839
       }
     },
     "group": [
@@ -458,16 +458,16 @@
   {
     "description": "Sets the background color to gray.\n",
     "commentRange": {
-      "start": 454,
-      "end": 455
+      "start": 464,
+      "end": 465
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--gray",
       "value": "background-color: $sprk-gray !important;",
       "line": {
-        "start": 456,
-        "end": 829
+        "start": 466,
+        "end": 839
       }
     },
     "group": [
@@ -482,16 +482,16 @@
   {
     "description": "Sets the background color to red.\n",
     "commentRange": {
-      "start": 460,
-      "end": 461
+      "start": 470,
+      "end": 471
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--red",
       "value": "background-color: $sprk-red !important;",
       "line": {
-        "start": 462,
-        "end": 829
+        "start": 472,
+        "end": 839
       }
     },
     "group": [
@@ -506,16 +506,16 @@
   {
     "description": "Sets the background color to red tinted at 75%.\n",
     "commentRange": {
-      "start": 466,
-      "end": 467
+      "start": 476,
+      "end": 477
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--red-tint-75",
       "value": "background-color: $sprk-red-tint-75 !important;",
       "line": {
-        "start": 468,
-        "end": 829
+        "start": 478,
+        "end": 839
       }
     },
     "group": [
@@ -530,16 +530,16 @@
   {
     "description": "Sets the background color to red tinted at 50%.\n",
     "commentRange": {
-      "start": 472,
-      "end": 473
+      "start": 482,
+      "end": 483
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--red-tint-50",
       "value": "background-color: $sprk-red-tint-50 !important;",
       "line": {
-        "start": 474,
-        "end": 829
+        "start": 484,
+        "end": 839
       }
     },
     "group": [
@@ -554,16 +554,16 @@
   {
     "description": "Sets the background color to red tinted at 25%.\n",
     "commentRange": {
-      "start": 478,
-      "end": 479
+      "start": 488,
+      "end": 489
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--red-tint-25",
       "value": "background-color: $sprk-red-tint-25 !important;",
       "line": {
-        "start": 480,
-        "end": 829
+        "start": 490,
+        "end": 839
       }
     },
     "group": [
@@ -578,16 +578,16 @@
   {
     "description": "Sets the background color to green.\n",
     "commentRange": {
-      "start": 484,
-      "end": 485
+      "start": 494,
+      "end": 495
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green",
       "value": "background-color: $sprk-green !important;",
       "line": {
-        "start": 486,
-        "end": 829
+        "start": 496,
+        "end": 839
       }
     },
     "group": [
@@ -602,16 +602,16 @@
   {
     "description": "Sets the background color to dark green.\n",
     "commentRange": {
-      "start": 490,
-      "end": 491
+      "start": 500,
+      "end": 501
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green-dark",
       "value": "background-color: $sprk-green-dark !important;",
       "line": {
-        "start": 492,
-        "end": 829
+        "start": 502,
+        "end": 839
       }
     },
     "group": [
@@ -626,16 +626,16 @@
   {
     "description": "Sets the background color to green tinted at 75%.\n",
     "commentRange": {
-      "start": 496,
-      "end": 497
+      "start": 506,
+      "end": 507
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green-tint-75",
       "value": "background-color: $sprk-green-tint-75 !important;",
       "line": {
-        "start": 498,
-        "end": 829
+        "start": 508,
+        "end": 839
       }
     },
     "group": [
@@ -650,16 +650,16 @@
   {
     "description": "Sets the background color to green tinted at 50%.\n",
     "commentRange": {
-      "start": 502,
-      "end": 503
+      "start": 512,
+      "end": 513
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green-tint-50",
       "value": "background-color: $sprk-green-tint-50 !important;",
       "line": {
-        "start": 504,
-        "end": 829
+        "start": 514,
+        "end": 839
       }
     },
     "group": [
@@ -674,16 +674,16 @@
   {
     "description": "Sets the background color to green tinted at 25%.\n",
     "commentRange": {
-      "start": 508,
-      "end": 509
+      "start": 518,
+      "end": 519
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--green-tint-25",
       "value": "background-color: $sprk-green-tint-25 !important;",
       "line": {
-        "start": 510,
-        "end": 829
+        "start": 520,
+        "end": 839
       }
     },
     "group": [
@@ -698,16 +698,16 @@
   {
     "description": "Sets the background color to white.\n",
     "commentRange": {
-      "start": 514,
-      "end": 515
+      "start": 524,
+      "end": 525
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--white",
       "value": "background-color: $sprk-white !important;",
       "line": {
-        "start": 516,
-        "end": 829
+        "start": 526,
+        "end": 839
       }
     },
     "group": [
@@ -722,16 +722,16 @@
   {
     "description": "Sets the background color to yellow.\n",
     "commentRange": {
-      "start": 520,
-      "end": 521
+      "start": 530,
+      "end": 531
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--yellow",
       "value": "background-color: $sprk-yellow !important;",
       "line": {
-        "start": 522,
-        "end": 829
+        "start": 532,
+        "end": 839
       }
     },
     "group": [
@@ -746,16 +746,16 @@
   {
     "description": "Sets the background color to yellow tinted at 75%.\n",
     "commentRange": {
-      "start": 526,
-      "end": 527
+      "start": 536,
+      "end": 537
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--yellow-tint-75",
       "value": "background-color: $sprk-yellow-tint-75 !important;",
       "line": {
-        "start": 528,
-        "end": 829
+        "start": 538,
+        "end": 839
       }
     },
     "group": [
@@ -770,16 +770,16 @@
   {
     "description": "Sets the background color to yellow tinted at 50%.\n",
     "commentRange": {
-      "start": 532,
-      "end": 533
+      "start": 542,
+      "end": 543
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--yellow-tint-50",
       "value": "background-color: $sprk-yellow-tint-50 !important;",
       "line": {
-        "start": 534,
-        "end": 829
+        "start": 544,
+        "end": 839
       }
     },
     "group": [
@@ -794,16 +794,16 @@
   {
     "description": "Sets the background color to yellow tinted at 25%.\n",
     "commentRange": {
-      "start": 538,
-      "end": 539
+      "start": 548,
+      "end": 549
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-BackgroundColor--yellow-tint-25",
       "value": "background-color: $sprk-yellow-tint-25 !important;",
       "line": {
-        "start": 540,
-        "end": 829
+        "start": 550,
+        "end": 839
       }
     },
     "group": [
@@ -827,7 +827,7 @@
       "value": "display: none !important;",
       "line": {
         "start": 26,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -851,7 +851,7 @@
       "value": "display: none !important;",
       "line": {
         "start": 26,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -875,7 +875,7 @@
       "value": "display: block !important;",
       "line": {
         "start": 33,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -899,7 +899,7 @@
       "value": "display: inline !important;",
       "line": {
         "start": 39,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -923,7 +923,7 @@
       "value": "display: inline-block !important;",
       "line": {
         "start": 46,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -947,7 +947,7 @@
       "value": "visibility: hidden !important;",
       "line": {
         "start": 53,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -971,7 +971,7 @@
       "value": "visibility: visible !important;",
       "line": {
         "start": 59,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -995,7 +995,7 @@
       "value": "height: 100% !important;",
       "line": {
         "start": 150,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1010,16 +1010,16 @@
   {
     "description": "Sets the padding on the left and right (horizontal)\nto `$sprk-space-misc-b` (`40px`).\n",
     "commentRange": {
-      "start": 555,
-      "end": 558
+      "start": 565,
+      "end": 568
     },
     "context": {
       "type": "css",
       "name": "sprk-u-PaddingHorizontal--b",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
-        "start": 569,
-        "end": 829
+        "start": 579,
+        "end": 839
       }
     },
     "group": [
@@ -1034,16 +1034,16 @@
   {
     "description": "Sets the bottom margin to the current value of\n`$sprk-space-misc-a` (`24px`).\n",
     "commentRange": {
-      "start": 550,
-      "end": 553
+      "start": 560,
+      "end": 563
     },
     "context": {
       "type": "css",
       "name": "sprk-u-MarginBottom--a",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
-        "start": 569,
-        "end": 829
+        "start": 579,
+        "end": 839
       }
     },
     "group": [
@@ -1058,16 +1058,16 @@
   {
     "description": "Sets the margin on all sides to the current value\nof `$sprk-space-misc-d` (`80px`).\n",
     "commentRange": {
-      "start": 560,
-      "end": 563
+      "start": 570,
+      "end": 573
     },
     "context": {
       "type": "css",
       "name": "sprk-u-MarginAll--d",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
-        "start": 569,
-        "end": 829
+        "start": 579,
+        "end": 839
       }
     },
     "group": [
@@ -1082,16 +1082,16 @@
   {
     "description": "Makes content invisible while still being read by a\nscreen reader.\n",
     "commentRange": {
-      "start": 776,
-      "end": 778
+      "start": 786,
+      "end": 788
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-ScreenReaderText",
       "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
       "line": {
-        "start": 779,
-        "end": 829
+        "start": 789,
+        "end": 839
       }
     },
     "group": [
@@ -1106,16 +1106,16 @@
   {
     "description": "When combined with `.sprk-u-ScreenReaderText` the element\nwill become visible on focus.\n",
     "commentRange": {
-      "start": 788,
-      "end": 790
+      "start": 798,
+      "end": 800
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-ShowOnFocus:focus",
       "value": "position: static;\n  width: auto;\n  height: auto;",
       "line": {
-        "start": 791,
-        "end": 829
+        "start": 801,
+        "end": 839
       }
     },
     "group": [
@@ -1154,16 +1154,16 @@
   {
     "description": "When placed on a container, its children will align\nin the absolute center (vertically and horizontally)\nof the box.\n",
     "commentRange": {
-      "start": 799,
-      "end": 802
+      "start": 809,
+      "end": 812
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-AbsoluteCenter",
       "value": "display: flex;\n  align-items: center;\n  justify-content: center;",
       "line": {
-        "start": 803,
-        "end": 829
+        "start": 813,
+        "end": 839
       }
     },
     "group": [
@@ -1178,16 +1178,16 @@
   {
     "description": "When placed on a container, it will cause it to fill\nthe viewport, even if it's inside a limiting container\n(such as `sprk-o-CenteredColumn`).\n",
     "commentRange": {
-      "start": 809,
-      "end": 812
+      "start": 819,
+      "end": 822
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FullWidth",
       "value": "width: 100vw;\n  left: 50%;\n  right: 50%;\n  margin-left: -50vw;\n  margin-right: -50vw;",
       "line": {
-        "start": 813,
-        "end": 829
+        "start": 823,
+        "end": 839
       }
     },
     "group": [
@@ -1202,16 +1202,16 @@
   {
     "description": "When placed on an element that contains text or any of\nthe typography classes, it will remove the text cropping\nand the negative margins applied by the crop.\n",
     "commentRange": {
-      "start": 258,
-      "end": 261
+      "start": 268,
+      "end": 271
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextCrop--none",
       "value": "&::before,\n  &::after {\n    content: none !important;\n    margin-bottom: 0 !important;\n    margin-top: 0 !important;\n  }",
       "line": {
-        "start": 262,
-        "end": 829
+        "start": 272,
+        "end": 839
       }
     },
     "group": [
@@ -1226,16 +1226,16 @@
   {
     "description": "When placed on an element that contains text, it will\nlimit the text to one line and adds an ellipsis when\nit overflows.\n",
     "commentRange": {
-      "start": 821,
-      "end": 824
+      "start": 831,
+      "end": 834
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Truncate",
       "value": "white-space: nowrap !important;\n  overflow: hidden !important;\n  text-overflow: ellipsis !important;",
       "line": {
-        "start": 825,
-        "end": 829
+        "start": 835,
+        "end": 839
       }
     },
     "group": [
@@ -1250,16 +1250,16 @@
   {
     "description": "Content is not clipped and may be rendered outside\nthe padding box.\n",
     "commentRange": {
-      "start": 301,
-      "end": 303
+      "start": 311,
+      "end": 313
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Overflow--visible",
       "value": "overflow: visible !important;",
       "line": {
-        "start": 304,
-        "end": 829
+        "start": 314,
+        "end": 839
       }
     },
     "group": [
@@ -1274,16 +1274,16 @@
   {
     "description": "Content is clipped if necessary to fit the padding\nbox. No scrollbars are provided.\n",
     "commentRange": {
-      "start": 308,
-      "end": 310
+      "start": 318,
+      "end": 320
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Overflow--hidden",
       "value": "overflow: hidden !important;",
       "line": {
-        "start": 311,
-        "end": 829
+        "start": 321,
+        "end": 839
       }
     },
     "group": [
@@ -1298,16 +1298,16 @@
   {
     "description": "Content is clipped if necessary to fit the padding\nbox. Browsers display scrollbars whether or not any\ncontent is actually clipped.\n",
     "commentRange": {
-      "start": 315,
-      "end": 318
+      "start": 325,
+      "end": 328
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Overflow--scroll",
       "value": "overflow: scroll !important;",
       "line": {
-        "start": 319,
-        "end": 829
+        "start": 329,
+        "end": 839
       }
     },
     "group": [
@@ -1322,16 +1322,16 @@
   {
     "description": "If content fits inside the padding box, it looks the\nsame as visible, but still establishes a new\nblock-formatting context.\n",
     "commentRange": {
-      "start": 323,
-      "end": 326
+      "start": 333,
+      "end": 336
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Overflow--auto",
       "value": "overflow: auto !important;",
       "line": {
-        "start": 327,
-        "end": 829
+        "start": 337,
+        "end": 839
       }
     },
     "group": [
@@ -1355,7 +1355,7 @@
       "value": "float: none !important;",
       "line": {
         "start": 69,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1379,7 +1379,7 @@
       "value": "float: left !important;",
       "line": {
         "start": 75,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1403,7 +1403,7 @@
       "value": "float: right !important;",
       "line": {
         "start": 81,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1427,7 +1427,7 @@
       "value": "position: relative !important;",
       "line": {
         "start": 92,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1451,7 +1451,7 @@
       "value": "position: absolute !important;",
       "line": {
         "start": 100,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1475,7 +1475,7 @@
       "value": "position: fixed !important;",
       "line": {
         "start": 109,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1499,7 +1499,7 @@
       "value": "position: static !important;",
       "line": {
         "start": 116,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1523,7 +1523,7 @@
       "value": "top: 0 !important;",
       "line": {
         "start": 122,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1547,7 +1547,7 @@
       "value": "bottom: 0 !important;",
       "line": {
         "start": 128,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1571,7 +1571,7 @@
       "value": "left: 0 !important;",
       "line": {
         "start": 134,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1595,7 +1595,7 @@
       "value": "right: 0 !important;",
       "line": {
         "start": 140,
-        "end": 829
+        "end": 839
       }
     },
     "group": [
@@ -1610,16 +1610,16 @@
   {
     "description": "Aligns text to the left of the container.\n",
     "commentRange": {
-      "start": 160,
-      "end": 161
+      "start": 170,
+      "end": 171
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextAlign--left",
       "value": "text-align: left !important;",
       "line": {
-        "start": 162,
-        "end": 829
+        "start": 172,
+        "end": 839
       }
     },
     "group": [
@@ -1634,16 +1634,16 @@
   {
     "description": "Aligns text to the right of the container.\n",
     "commentRange": {
-      "start": 166,
-      "end": 167
+      "start": 176,
+      "end": 177
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextAlign--right",
       "value": "text-align: right !important;",
       "line": {
-        "start": 168,
-        "end": 829
+        "start": 178,
+        "end": 839
       }
     },
     "group": [
@@ -1658,16 +1658,16 @@
   {
     "description": "Aligns text in the horizontal center of the container.\n",
     "commentRange": {
-      "start": 172,
-      "end": 173
+      "start": 182,
+      "end": 183
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextAlign--center",
       "value": "text-align: center !important;",
       "line": {
-        "start": 174,
-        "end": 829
+        "start": 184,
+        "end": 839
       }
     },
     "group": [
@@ -1682,16 +1682,16 @@
   {
     "description": "Aligns the contents of a box to the top if it's display\nproperty is `inline` or `table-cell`.\n",
     "commentRange": {
-      "start": 178,
-      "end": 180
+      "start": 188,
+      "end": 190
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-VerticalAlign--top",
       "value": "vertical-align: top !important;",
       "line": {
-        "start": 181,
-        "end": 829
+        "start": 191,
+        "end": 839
       }
     },
     "group": [
@@ -1706,16 +1706,16 @@
   {
     "description": "Aligns the contents of a box to the vertical middle if\nit's display property is `inline` or `table-cell`.\n",
     "commentRange": {
-      "start": 185,
-      "end": 187
+      "start": 195,
+      "end": 197
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-VerticalAlign--middle",
       "value": "vertical-align: middle !important;",
       "line": {
-        "start": 188,
-        "end": 829
+        "start": 198,
+        "end": 839
       }
     },
     "group": [
@@ -1730,16 +1730,16 @@
   {
     "description": "Aligns the contents of a box to the bottom if it's\ndisplay property is `inline` or `table-cell`.\n",
     "commentRange": {
-      "start": 192,
-      "end": 194
+      "start": 202,
+      "end": 204
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-VerticalAlign--bottom",
       "value": "vertical-align: bottom !important;",
       "line": {
-        "start": 195,
-        "end": 829
+        "start": 205,
+        "end": 839
       }
     },
     "group": [
@@ -1754,16 +1754,16 @@
   {
     "description": "Aligns the contents of a box to the baseline if it's\ndisplay property is `inline` or `table-cell`.\n",
     "commentRange": {
-      "start": 199,
-      "end": 201
+      "start": 209,
+      "end": 211
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-VerticalAlign--baseline",
       "value": "vertical-align: baseline !important;",
       "line": {
-        "start": 202,
-        "end": 829
+        "start": 212,
+        "end": 839
       }
     },
     "group": [
@@ -1850,16 +1850,16 @@
   {
     "description": "Sets the font weight to bold.\n",
     "commentRange": {
-      "start": 210,
-      "end": 211
+      "start": 220,
+      "end": 221
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FontWeight--bold",
       "value": "font-weight: bold !important;",
       "line": {
-        "start": 212,
-        "end": 829
+        "start": 222,
+        "end": 839
       }
     },
     "group": [
@@ -1874,16 +1874,16 @@
   {
     "description": "Sets the font weight to normal.\n",
     "commentRange": {
-      "start": 216,
-      "end": 217
+      "start": 226,
+      "end": 227
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FontWeight--normal",
       "value": "font-weight: normal !important;",
       "line": {
-        "start": 218,
-        "end": 829
+        "start": 228,
+        "end": 839
       }
     },
     "group": [
@@ -1898,16 +1898,16 @@
   {
     "description": "Sets the font style to italic.\n",
     "commentRange": {
-      "start": 222,
-      "end": 223
+      "start": 232,
+      "end": 233
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FontStyle--italic",
       "value": "font-style: italic !important;",
       "line": {
-        "start": 224,
-        "end": 829
+        "start": 234,
+        "end": 839
       }
     },
     "group": [
@@ -1922,16 +1922,16 @@
   {
     "description": "Sets the font style to normal.\n",
     "commentRange": {
-      "start": 228,
-      "end": 229
+      "start": 238,
+      "end": 239
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-FontStyle--normal",
       "value": "font-style: normal !important;",
       "line": {
-        "start": 230,
-        "end": 829
+        "start": 240,
+        "end": 839
       }
     },
     "group": [
@@ -1946,16 +1946,16 @@
   {
     "description": "Sets the text decoration to underline.\n",
     "commentRange": {
-      "start": 234,
-      "end": 235
+      "start": 244,
+      "end": 245
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextDecoration--underline",
       "value": "text-decoration: underline !important;",
       "line": {
-        "start": 236,
-        "end": 829
+        "start": 246,
+        "end": 839
       }
     },
     "group": [
@@ -1970,16 +1970,16 @@
   {
     "description": "Sets the text decoration to none.\n",
     "commentRange": {
-      "start": 240,
-      "end": 241
+      "start": 250,
+      "end": 251
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextDecoration--none",
       "value": "text-decoration: none !important;",
       "line": {
-        "start": 242,
-        "end": 829
+        "start": 252,
+        "end": 839
       }
     },
     "group": [
@@ -1994,16 +1994,16 @@
   {
     "description": "Transforms text to uppercase.\n",
     "commentRange": {
-      "start": 246,
-      "end": 247
+      "start": 256,
+      "end": 257
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextTransform--uppercase",
       "value": "text-transform: uppercase !important;",
       "line": {
-        "start": 248,
-        "end": 829
+        "start": 258,
+        "end": 839
       }
     },
     "group": [
@@ -2018,16 +2018,16 @@
   {
     "description": "Removes text transformation for text.\n",
     "commentRange": {
-      "start": 252,
-      "end": 253
+      "start": 262,
+      "end": 263
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-TextTransform--none",
       "value": "text-transform: none !important;",
       "line": {
-        "start": 254,
-        "end": 829
+        "start": 264,
+        "end": 839
       }
     },
     "group": [
@@ -2042,16 +2042,16 @@
   {
     "description": "Sets `word-wrap` to `break-word`.\n",
     "commentRange": {
-      "start": 271,
-      "end": 272
+      "start": 281,
+      "end": 282
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-WordWrap--break-word",
       "value": "word-wrap: break-word !important;",
       "line": {
-        "start": 273,
-        "end": 829
+        "start": 283,
+        "end": 839
       }
     },
     "group": [
@@ -2066,16 +2066,16 @@
   {
     "description": "Sets `white-space` to `nowrap`.\n",
     "commentRange": {
-      "start": 277,
-      "end": 278
+      "start": 287,
+      "end": 288
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-WhiteSpace--nowrap",
       "value": "white-space: nowrap !important;",
       "line": {
-        "start": 279,
-        "end": 829
+        "start": 289,
+        "end": 839
       }
     },
     "group": [
@@ -2090,16 +2090,16 @@
   {
     "description": "Sets a `max-width`, intended for text. Default value is\n`40 rem`.\n",
     "commentRange": {
-      "start": 283,
-      "end": 285
+      "start": 293,
+      "end": 295
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Measure",
       "value": "max-width: $sprk-measure !important;",
       "line": {
-        "start": 286,
-        "end": 829
+        "start": 296,
+        "end": 839
       }
     },
     "group": [
@@ -2114,16 +2114,16 @@
   {
     "description": "Sets a narrow `max-width`, intended for text. Default\nvalue is `25 rem`.\n",
     "commentRange": {
-      "start": 290,
-      "end": 292
+      "start": 300,
+      "end": 302
     },
     "context": {
       "type": "css",
       "name": ".sprk-u-Measure--narrow",
       "value": "max-width: $sprk-narrow-measure !important;",
       "line": {
-        "start": 293,
-        "end": 829
+        "start": 303,
+        "end": 839
       }
     },
     "group": [
@@ -2162,16 +2162,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 12,
-      "end": 12
+      "start": 16,
+      "end": 16
     },
     "context": {
       "type": "css",
-      "name": "//\n// Display and Visibility\n///\n\n/// Turns off the display of an element so that it has no effect on layout.\n/// @group display\n/// @name .sprk-u-JavaScript, .sprk-u-HideWhenJs\n\n/// Turns off the display of an element so that it has no effect on layout.\n/// @group display\n/// @name .sprk-u-Display--none\n.sprk-u-Display--none,\n.sprk-u-JavaScript .sprk-u-HideWhenJs",
+      "name": "/// Turns off the display of an element so that it has no effect on layout.\n/// @group display\n/// @name .sprk-u-JavaScript, .sprk-u-HideWhenJs\n\n/// Turns off the display of an element so that it has no effect on layout.\n/// @group display\n/// @name .sprk-u-Display--none\n.sprk-u-Display--none,\n.sprk-u-JavaScript .sprk-u-HideWhenJs",
       "value": "display: none !important;",
       "line": {
         "start": 26,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -2186,16 +2186,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 16,
-      "end": 16
+      "start": 12,
+      "end": 12
     },
     "context": {
       "type": "css",
-      "name": "/// Turns off the display of an element so that it has no effect on layout.\n/// @group display\n/// @name .sprk-u-JavaScript, .sprk-u-HideWhenJs\n\n/// Turns off the display of an element so that it has no effect on layout.\n/// @group display\n/// @name .sprk-u-Display--none\n.sprk-u-Display--none,\n.sprk-u-JavaScript .sprk-u-HideWhenJs",
+      "name": "//\n// Display and Visibility\n///\n\n/// Turns off the display of an element so that it has no effect on layout.\n/// @group display\n/// @name .sprk-u-JavaScript, .sprk-u-HideWhenJs\n\n/// Turns off the display of an element so that it has no effect on layout.\n/// @group display\n/// @name .sprk-u-Display--none\n.sprk-u-Display--none,\n.sprk-u-JavaScript .sprk-u-HideWhenJs",
       "value": "display: none !important;",
       "line": {
         "start": 26,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -2219,7 +2219,7 @@
       "value": "float: none !important;",
       "line": {
         "start": 69,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -2243,7 +2243,7 @@
       "value": "position: relative !important;",
       "line": {
         "start": 92,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -2267,7 +2267,7 @@
       "value": "height: 100% !important;",
       "line": {
         "start": 150,
-        "end": 829
+        "end": 839
       }
     },
     "access": "public",
@@ -2282,16 +2282,40 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 158,
-      "end": 158
+      "start": 156,
+      "end": 156
+    },
+    "context": {
+      "type": "css",
+      "name": "/// Changes the max-width of the element to 100 percent.\n/// @group width\n.sprk-u-MaxWidth--100",
+      "value": "max-width: 100% !important;",
+      "line": {
+        "start": 160,
+        "end": 839
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_utilities.scss",
+      "name": "_utilities.scss"
+    }
+  },
+  {
+    "description": "\n",
+    "commentRange": {
+      "start": 168,
+      "end": 168
     },
     "context": {
       "type": "css",
       "name": "/// Aligns text to the left of the container.\n/// @group position\n.sprk-u-TextAlign--left",
       "value": "text-align: left !important;",
       "line": {
-        "start": 162,
-        "end": 829
+        "start": 172,
+        "end": 839
       }
     },
     "access": "public",
@@ -2306,16 +2330,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 208,
-      "end": 208
+      "start": 218,
+      "end": 218
     },
     "context": {
       "type": "css",
       "name": "/// Sets the font weight to bold.\n/// @group typography\n.sprk-u-FontWeight--bold",
       "value": "font-weight: bold !important;",
       "line": {
-        "start": 212,
-        "end": 829
+        "start": 222,
+        "end": 839
       }
     },
     "access": "public",
@@ -2330,16 +2354,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 299,
-      "end": 299
+      "start": 309,
+      "end": 309
     },
     "context": {
       "type": "css",
       "name": "/// Content is not clipped and may be rendered outside\n/// the padding box.\n/// @group overflow\n.sprk-u-Overflow--visible",
       "value": "overflow: visible !important;",
       "line": {
-        "start": 304,
-        "end": 829
+        "start": 314,
+        "end": 839
       }
     },
     "access": "public",
@@ -2354,16 +2378,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 548,
-      "end": 548
+      "start": 558,
+      "end": 558
     },
     "context": {
       "type": "css",
       "name": "/// Sets the bottom margin to the current value of\n/// `$sprk-space-misc-a` (`24px`).\n/// @group misc-spacing\n/// @name sprk-u-MarginBottom--a\n\n/// Sets the padding on the left and right (horizontal)\n/// to `$sprk-space-misc-b` (`40px`).\n/// @group misc-spacing\n/// @name sprk-u-PaddingHorizontal--b\n\n/// Sets the margin on all sides to the current value\n/// of `$sprk-space-misc-d` (`80px`).\n/// @group misc-spacing\n/// @name sprk-u-MarginAll--d\n\n/* stylelint-disable  selector-class-pattern */\n// Misc Padding Spacing A\n.sprk-u-PaddingTop--a,\n.sprk-u-PaddingVertical--a,\n.sprk-u-PaddingAll--a",
       "value": "padding-top: $sprk-space-misc-a !important;",
       "line": {
-        "start": 569,
-        "end": 829
+        "start": 579,
+        "end": 839
       }
     },
     "access": "public",
@@ -2378,16 +2402,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 774,
-      "end": 774
+      "start": 784,
+      "end": 784
     },
     "context": {
       "type": "css",
       "name": "/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
       "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
       "line": {
-        "start": 779,
-        "end": 829
+        "start": 789,
+        "end": 839
       }
     },
     "access": "public",
@@ -2402,16 +2426,16 @@
   {
     "description": "\n",
     "commentRange": {
-      "start": 770,
-      "end": 770
+      "start": 780,
+      "end": 780
     },
     "context": {
       "type": "css",
       "name": "//\n// Accessibility\n///\n\n/// Makes content invisible while still being read by a\n/// screen reader.\n/// @group multi-accessibility\n.sprk-u-ScreenReaderText",
       "value": "position: absolute;\n  left: -10000px;\n  top: auto;\n  width: 1px;\n  height: 1px;\n  overflow: hidden;",
       "line": {
-        "start": 779,
-        "end": 829
+        "start": 789,
+        "end": 839
       }
     },
     "access": "public",
@@ -2445,6 +2469,30 @@
     "file": {
       "path": "_width.scss",
       "name": "_width.scss"
+    }
+  },
+  {
+    "description": "Changes the max-width of the element to 100 percent.\n",
+    "commentRange": {
+      "start": 158,
+      "end": 159
+    },
+    "context": {
+      "type": "css",
+      "name": ".sprk-u-MaxWidth--100",
+      "value": "max-width: 100% !important;",
+      "line": {
+        "start": 160,
+        "end": 839
+      }
+    },
+    "group": [
+      "width"
+    ],
+    "access": "public",
+    "file": {
+      "path": "_utilities.scss",
+      "name": "_utilities.scss"
     }
   },
   {

--- a/src/data/sass-vars.json
+++ b/src/data/sass-vars.json
@@ -7821,19 +7821,19 @@
     }
   },
   {
-    "description": "The max-width setting for Huge Inputs.\n",
+    "description": "The value used for the maximum width of an Input\ncontainer using the .sprk-b-InputContainer--full modifier.\n",
     "commentRange": {
-      "start": 821,
-      "end": 821
+      "start": 816,
+      "end": 817
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-container-huge-max-width",
-      "value": "37.5rem",
+      "name": "sprk-input-max-width-full",
+      "value": "100%",
       "scope": "default",
       "line": {
-        "start": 822,
-        "end": 822
+        "start": 818,
+        "end": 818
       }
     },
     "access": "public",
@@ -7846,15 +7846,15 @@
     }
   },
   {
-    "description": "The height value for Huge Inputs.\n",
+    "description": "The max-width setting for Huge Inputs.\n",
     "commentRange": {
       "start": 824,
       "end": 824
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-height",
-      "value": "$sprk-text-input-huge-height",
+      "name": "sprk-input-container-huge-max-width",
+      "value": "37.5rem",
       "scope": "default",
       "line": {
         "start": 825,
@@ -7871,15 +7871,15 @@
     }
   },
   {
-    "description": "The font size for Huge Inputs.\n",
+    "description": "The height value for Huge Inputs.\n",
     "commentRange": {
       "start": 827,
       "end": 827
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-font-size",
-      "value": "$sprk-text-input-huge-font-size",
+      "name": "sprk-input-huge-height",
+      "value": "$sprk-text-input-huge-height",
       "scope": "default",
       "line": {
         "start": 828,
@@ -7896,15 +7896,15 @@
     }
   },
   {
-    "description": "The label font size for Huge Inputs.\n",
+    "description": "The font size for Huge Inputs.\n",
     "commentRange": {
       "start": 830,
       "end": 830
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-label-font-size",
-      "value": "$sprk-text-input-huge-label-font-size",
+      "name": "sprk-input-huge-font-size",
+      "value": "$sprk-text-input-huge-font-size",
       "scope": "default",
       "line": {
         "start": 831,
@@ -7921,15 +7921,15 @@
     }
   },
   {
-    "description": "The border width for Huge Inputs.\n",
+    "description": "The label font size for Huge Inputs.\n",
     "commentRange": {
       "start": 833,
       "end": 833
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-border-width",
-      "value": "$sprk-text-input-huge-border-width",
+      "name": "sprk-input-huge-label-font-size",
+      "value": "$sprk-text-input-huge-label-font-size",
       "scope": "default",
       "line": {
         "start": 834,
@@ -7946,15 +7946,15 @@
     }
   },
   {
-    "description": "The padding for Huge Inputs.\n",
+    "description": "The border width for Huge Inputs.\n",
     "commentRange": {
       "start": 836,
       "end": 836
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-padding",
-      "value": "$sprk-text-input-huge-padding",
+      "name": "sprk-input-huge-border-width",
+      "value": "$sprk-text-input-huge-border-width",
       "scope": "default",
       "line": {
         "start": 837,
@@ -7971,10 +7971,35 @@
     }
   },
   {
+    "description": "The padding for Huge Inputs.\n",
+    "commentRange": {
+      "start": 839,
+      "end": 839
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-input-huge-padding",
+      "value": "$sprk-text-input-huge-padding",
+      "scope": "default",
+      "line": {
+        "start": 840,
+        "end": 840
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
     "description": "The padding right value for Huge Inputs.\n",
     "commentRange": {
-      "start": 838,
-      "end": 838
+      "start": 841,
+      "end": 841
     },
     "context": {
       "type": "variable",
@@ -7982,8 +8007,8 @@
       "value": "45px",
       "scope": "default",
       "line": {
-        "start": 839,
-        "end": 839
+        "start": 842,
+        "end": 842
       }
     },
     "access": "public",
@@ -7998,8 +8023,8 @@
   {
     "description": "The label padding value for Huge Inputs.\n",
     "commentRange": {
-      "start": 840,
-      "end": 840
+      "start": 843,
+      "end": 843
     },
     "context": {
       "type": "variable",
@@ -8007,8 +8032,8 @@
       "value": "0\n  ($sprk-space-misc-a + $sprk-input-huge-border-width)",
       "scope": "default",
       "line": {
-        "start": 841,
-        "end": 842
+        "start": 844,
+        "end": 845
       }
     },
     "access": "public",
@@ -8023,38 +8048,13 @@
   {
     "description": "The border width for Huge Inputs on focus.\n",
     "commentRange": {
-      "start": 844,
-      "end": 844
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-input-huge-focus-border-width",
-      "value": "$sprk-text-input-huge-focus-border-width",
-      "scope": "default",
-      "line": {
-        "start": 845,
-        "end": 845
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The transition value for Huge Inputs.\n",
-    "commentRange": {
       "start": 847,
       "end": 847
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-transition",
-      "value": "$sprk-text-input-huge-transition",
+      "name": "sprk-input-huge-focus-border-width",
+      "value": "$sprk-text-input-huge-focus-border-width",
       "scope": "default",
       "line": {
         "start": 848,
@@ -8071,15 +8071,15 @@
     }
   },
   {
-    "description": "The transition delay value for Huge Inputs.\n",
+    "description": "The transition value for Huge Inputs.\n",
     "commentRange": {
       "start": 850,
       "end": 850
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-transition-delay",
-      "value": "$sprk-text-input-huge-transition-delay",
+      "name": "sprk-input-huge-transition",
+      "value": "$sprk-text-input-huge-transition",
       "scope": "default",
       "line": {
         "start": 851,
@@ -8096,15 +8096,15 @@
     }
   },
   {
-    "description": "The transition placeholder delay value for Huge Inputs.\n",
+    "description": "The transition delay value for Huge Inputs.\n",
     "commentRange": {
       "start": 853,
       "end": 853
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-placeholder-transition-delay",
-      "value": "$sprk-text-input-huge-placeholder-transition-delay",
+      "name": "sprk-input-huge-transition-delay",
+      "value": "$sprk-text-input-huge-transition-delay",
       "scope": "default",
       "line": {
         "start": 854,
@@ -8121,15 +8121,15 @@
     }
   },
   {
-    "description": "The transition placeholder value for Huge Inputs.\n",
+    "description": "The transition placeholder delay value for Huge Inputs.\n",
     "commentRange": {
       "start": 856,
       "end": 856
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-placeholder-transition-property",
-      "value": "$sprk-text-input-huge-placeholder-transition-property",
+      "name": "sprk-input-huge-placeholder-transition-delay",
+      "value": "$sprk-text-input-huge-placeholder-transition-delay",
       "scope": "default",
       "line": {
         "start": 857,
@@ -8146,15 +8146,15 @@
     }
   },
   {
-    "description": "The placeholder opacity for Huge Inputs.\n",
+    "description": "The transition placeholder value for Huge Inputs.\n",
     "commentRange": {
       "start": 859,
       "end": 859
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-placeholder-opacity",
-      "value": "$sprk-text-input-huge-placeholder-opacity",
+      "name": "sprk-input-huge-placeholder-transition-property",
+      "value": "$sprk-text-input-huge-placeholder-transition-property",
       "scope": "default",
       "line": {
         "start": 860,
@@ -8171,15 +8171,15 @@
     }
   },
   {
-    "description": "The placeholder opacity for Huge Inputs when they are active.\n",
+    "description": "The placeholder opacity for Huge Inputs.\n",
     "commentRange": {
       "start": 862,
       "end": 862
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-placeholder-active-opacity",
-      "value": "$sprk-text-input-huge-placeholder-active-opacity",
+      "name": "sprk-input-huge-placeholder-opacity",
+      "value": "$sprk-text-input-huge-placeholder-opacity",
       "scope": "default",
       "line": {
         "start": 863,
@@ -8196,10 +8196,35 @@
     }
   },
   {
-    "description": "The top value for Huge Input labels.\nThis adjusts how far the label is from the top of the container.\n",
+    "description": "The placeholder opacity for Huge Inputs when they are active.\n",
     "commentRange": {
       "start": 865,
-      "end": 866
+      "end": 865
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-input-huge-placeholder-active-opacity",
+      "value": "$sprk-text-input-huge-placeholder-active-opacity",
+      "scope": "default",
+      "line": {
+        "start": 866,
+        "end": 866
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The top value for Huge Input labels.\nThis adjusts how far the label is from the top of the container.\n",
+    "commentRange": {
+      "start": 868,
+      "end": 869
     },
     "context": {
       "type": "variable",
@@ -8207,8 +8232,8 @@
       "value": "$sprk-text-input-huge-label-top",
       "scope": "default",
       "line": {
-        "start": 867,
-        "end": 867
+        "start": 870,
+        "end": 870
       }
     },
     "access": "public",
@@ -8223,38 +8248,13 @@
   {
     "description": "The top value for Huge Input labels when they are active.\nThis adjusts how far the label is from the top of the container.\n",
     "commentRange": {
-      "start": 869,
-      "end": 870
+      "start": 872,
+      "end": 873
     },
     "context": {
       "type": "variable",
       "name": "sprk-input-huge-label-active-top",
       "value": "$sprk-text-input-huge-label-active-top",
-      "scope": "default",
-      "line": {
-        "start": 871,
-        "end": 871
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding top value of active Huge Inputs.\n",
-    "commentRange": {
-      "start": 873,
-      "end": 873
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-input-huge-active-padding-top",
-      "value": "$sprk-text-input-huge-active-padding-top",
       "scope": "default",
       "line": {
         "start": 874,
@@ -8271,15 +8271,15 @@
     }
   },
   {
-    "description": "The label color value of Huge Inputs on focus.\n",
+    "description": "The padding top value of active Huge Inputs.\n",
     "commentRange": {
       "start": 876,
       "end": 876
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-focus-label-color",
-      "value": "$sprk-text-input-huge-focus-label-color",
+      "name": "sprk-input-huge-active-padding-top",
+      "value": "$sprk-text-input-huge-active-padding-top",
       "scope": "default",
       "line": {
         "start": 877,
@@ -8296,15 +8296,15 @@
     }
   },
   {
-    "description": "The label color value of Huge Inputs when they have an error.\n",
+    "description": "The label color value of Huge Inputs on focus.\n",
     "commentRange": {
       "start": 879,
       "end": 879
     },
     "context": {
       "type": "variable",
-      "name": "sprk-input-huge-error-focus-label-color",
-      "value": "$sprk-text-input-huge-error-focus-label-color",
+      "name": "sprk-input-huge-focus-label-color",
+      "value": "$sprk-text-input-huge-focus-label-color",
       "scope": "default",
       "line": {
         "start": 880,
@@ -8321,10 +8321,35 @@
     }
   },
   {
-    "description": "The label color when the Huge Input has a value\nand is not focused.\n",
+    "description": "The label color value of Huge Inputs when they have an error.\n",
     "commentRange": {
       "start": 882,
-      "end": 883
+      "end": 882
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-input-huge-error-focus-label-color",
+      "value": "$sprk-text-input-huge-error-focus-label-color",
+      "scope": "default",
+      "line": {
+        "start": 883,
+        "end": 883
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The label color when the Huge Input has a value\nand is not focused.\n",
+    "commentRange": {
+      "start": 885,
+      "end": 886
     },
     "context": {
       "type": "variable",
@@ -8332,8 +8357,8 @@
       "value": "$sprk-text-input-huge-complete-label-color",
       "scope": "default",
       "line": {
-        "start": 884,
-        "end": 884
+        "start": 887,
+        "end": 887
       }
     },
     "access": "public",
@@ -8348,8 +8373,8 @@
   {
     "description": "The box shadow value on Huge Inputs.\n",
     "commentRange": {
-      "start": 885,
-      "end": 885
+      "start": 888,
+      "end": 888
     },
     "context": {
       "type": "variable",
@@ -8357,8 +8382,8 @@
       "value": "0 3px 10px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
-        "start": 886,
-        "end": 886
+        "start": 889,
+        "end": 889
       }
     },
     "access": "public",
@@ -8373,8 +8398,8 @@
   {
     "description": "The margin-top value for icons in Huge Inputs.\n",
     "commentRange": {
-      "start": 887,
-      "end": 887
+      "start": 890,
+      "end": 890
     },
     "context": {
       "type": "variable",
@@ -8382,8 +8407,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 888,
-        "end": 888
+        "start": 891,
+        "end": 891
       }
     },
     "access": "public",
@@ -8398,8 +8423,8 @@
   {
     "description": "The top value for icons in Huge Inputs.\n",
     "commentRange": {
-      "start": 889,
-      "end": 889
+      "start": 892,
+      "end": 892
     },
     "context": {
       "type": "variable",
@@ -8407,8 +8432,8 @@
       "value": "50%",
       "scope": "default",
       "line": {
-        "start": 890,
-        "end": 890
+        "start": 893,
+        "end": 893
       }
     },
     "access": "public",
@@ -8423,8 +8448,8 @@
   {
     "description": "The margin-top value for icons in Huge Select Inputs.\n",
     "commentRange": {
-      "start": 891,
-      "end": 891
+      "start": 894,
+      "end": 894
     },
     "context": {
       "type": "variable",
@@ -8432,8 +8457,8 @@
       "value": "-((\n  $sprk-input-huge-height - $sprk-icon-m\n) / 2 + $sprk-icon-m)",
       "scope": "default",
       "line": {
-        "start": 892,
-        "end": 894
+        "start": 895,
+        "end": 897
       }
     },
     "access": "public",
@@ -8448,8 +8473,8 @@
   {
     "description": "The padding value for Huge Inputs with icons.\n",
     "commentRange": {
-      "start": 895,
-      "end": 895
+      "start": 898,
+      "end": 898
     },
     "context": {
       "type": "variable",
@@ -8457,8 +8482,8 @@
       "value": "0 40px",
       "scope": "default",
       "line": {
-        "start": 896,
-        "end": 896
+        "start": 899,
+        "end": 899
       }
     },
     "access": "public",
@@ -8473,8 +8498,8 @@
   {
     "description": "The font family for Inputs.\n",
     "commentRange": {
-      "start": 902,
-      "end": 902
+      "start": 905,
+      "end": 905
     },
     "context": {
       "type": "variable",
@@ -8482,8 +8507,8 @@
       "value": "$sprk-font-family-body-two",
       "scope": "default",
       "line": {
-        "start": 903,
-        "end": 903
+        "start": 906,
+        "end": 906
       }
     },
     "access": "public",
@@ -8498,8 +8523,8 @@
   {
     "description": "The font size for Inputs.\n",
     "commentRange": {
-      "start": 904,
-      "end": 904
+      "start": 907,
+      "end": 907
     },
     "context": {
       "type": "variable",
@@ -8507,8 +8532,8 @@
       "value": "1rem",
       "scope": "default",
       "line": {
-        "start": 905,
-        "end": 905
+        "start": 908,
+        "end": 908
       }
     },
     "access": "public",
@@ -8523,8 +8548,8 @@
   {
     "description": "The font weight for Inputs.\n",
     "commentRange": {
-      "start": 906,
-      "end": 906
+      "start": 909,
+      "end": 909
     },
     "context": {
       "type": "variable",
@@ -8532,8 +8557,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 907,
-        "end": 907
+        "start": 910,
+        "end": 910
       }
     },
     "access": "public",
@@ -8548,8 +8573,8 @@
   {
     "description": "The height setting for Inputs.\n",
     "commentRange": {
-      "start": 908,
-      "end": 908
+      "start": 911,
+      "end": 911
     },
     "context": {
       "type": "variable",
@@ -8557,8 +8582,8 @@
       "value": "48px",
       "scope": "default",
       "line": {
-        "start": 909,
-        "end": 909
+        "start": 912,
+        "end": 912
       }
     },
     "access": "public",
@@ -8573,8 +8598,8 @@
   {
     "description": "The line height setting for Inputs.\n",
     "commentRange": {
-      "start": 910,
-      "end": 910
+      "start": 913,
+      "end": 913
     },
     "context": {
       "type": "variable",
@@ -8582,8 +8607,8 @@
       "value": "1.3",
       "scope": "default",
       "line": {
-        "start": 911,
-        "end": 911
+        "start": 914,
+        "end": 914
       }
     },
     "access": "public",
@@ -8598,8 +8623,8 @@
   {
     "description": "The outline setting for Inputs.\n",
     "commentRange": {
-      "start": 912,
-      "end": 912
+      "start": 915,
+      "end": 915
     },
     "context": {
       "type": "variable",
@@ -8607,8 +8632,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 913,
-        "end": 913
+        "start": 916,
+        "end": 916
       }
     },
     "access": "public",
@@ -8623,8 +8648,8 @@
   {
     "description": "The color setting for Inputs.\n",
     "commentRange": {
-      "start": 914,
-      "end": 914
+      "start": 917,
+      "end": 917
     },
     "context": {
       "type": "variable",
@@ -8632,8 +8657,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 915,
-        "end": 915
+        "start": 918,
+        "end": 918
       }
     },
     "access": "public",
@@ -8648,8 +8673,8 @@
   {
     "description": "The border setting for Inputs.\n",
     "commentRange": {
-      "start": 916,
-      "end": 916
+      "start": 919,
+      "end": 919
     },
     "context": {
       "type": "variable",
@@ -8657,8 +8682,8 @@
       "value": "2px solid $sprk-gray-dark",
       "scope": "default",
       "line": {
-        "start": 917,
-        "end": 917
+        "start": 920,
+        "end": 920
       }
     },
     "access": "public",
@@ -8673,8 +8698,8 @@
   {
     "description": "The border radius for Inputs.\n",
     "commentRange": {
-      "start": 918,
-      "end": 918
+      "start": 921,
+      "end": 921
     },
     "context": {
       "type": "variable",
@@ -8682,8 +8707,8 @@
       "value": "4px",
       "scope": "default",
       "line": {
-        "start": 919,
-        "end": 919
+        "start": 922,
+        "end": 922
       }
     },
     "access": "public",
@@ -8698,8 +8723,8 @@
   {
     "description": "The box shadow for Inputs.\n",
     "commentRange": {
-      "start": 920,
-      "end": 920
+      "start": 923,
+      "end": 923
     },
     "context": {
       "type": "variable",
@@ -8707,8 +8732,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 921,
-        "end": 921
+        "start": 924,
+        "end": 924
       }
     },
     "access": "public",
@@ -8723,8 +8748,8 @@
   {
     "description": "The padding for Inputs.\n",
     "commentRange": {
-      "start": 922,
-      "end": 922
+      "start": 925,
+      "end": 925
     },
     "context": {
       "type": "variable",
@@ -8732,8 +8757,8 @@
       "value": "0 $sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 923,
-        "end": 923
+        "start": 926,
+        "end": 926
       }
     },
     "access": "public",
@@ -8748,8 +8773,8 @@
   {
     "description": "The border color on Inputs when focused.\n",
     "commentRange": {
-      "start": 924,
-      "end": 924
+      "start": 927,
+      "end": 927
     },
     "context": {
       "type": "variable",
@@ -8757,8 +8782,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 925,
-        "end": 925
+        "start": 928,
+        "end": 928
       }
     },
     "access": "public",
@@ -8773,8 +8798,8 @@
   {
     "description": "The border color on Inputs when there is an error.\n",
     "commentRange": {
-      "start": 926,
-      "end": 926
+      "start": 929,
+      "end": 929
     },
     "context": {
       "type": "variable",
@@ -8782,8 +8807,8 @@
       "value": "$sprk-yellow",
       "scope": "default",
       "line": {
-        "start": 927,
-        "end": 927
+        "start": 930,
+        "end": 930
       }
     },
     "access": "public",
@@ -8798,8 +8823,8 @@
   {
     "description": "The border color on disabled Inputs.\n",
     "commentRange": {
-      "start": 928,
-      "end": 928
+      "start": 931,
+      "end": 931
     },
     "context": {
       "type": "variable",
@@ -8807,8 +8832,8 @@
       "value": "$sprk-gray-dark",
       "scope": "default",
       "line": {
-        "start": 929,
-        "end": 929
+        "start": 932,
+        "end": 932
       }
     },
     "access": "public",
@@ -8823,8 +8848,8 @@
   {
     "description": "The background color on disabled Inputs.\n",
     "commentRange": {
-      "start": 930,
-      "end": 930
+      "start": 933,
+      "end": 933
     },
     "context": {
       "type": "variable",
@@ -8832,8 +8857,8 @@
       "value": "$sprk-gray-dark",
       "scope": "default",
       "line": {
-        "start": 931,
-        "end": 931
+        "start": 934,
+        "end": 934
       }
     },
     "access": "public",
@@ -8848,8 +8873,8 @@
   {
     "description": "The box shadow on disabled Inputs.\n",
     "commentRange": {
-      "start": 932,
-      "end": 932
+      "start": 935,
+      "end": 935
     },
     "context": {
       "type": "variable",
@@ -8857,8 +8882,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 933,
-        "end": 933
+        "start": 936,
+        "end": 936
       }
     },
     "access": "public",
@@ -8873,8 +8898,8 @@
   {
     "description": "The color setting on disabled Inputs.\n",
     "commentRange": {
-      "start": 934,
-      "end": 934
+      "start": 937,
+      "end": 937
     },
     "context": {
       "type": "variable",
@@ -8882,8 +8907,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 935,
-        "end": 935
+        "start": 938,
+        "end": 938
       }
     },
     "access": "public",
@@ -8898,8 +8923,8 @@
   {
     "description": "The border color setting on readonly Inputs.\n",
     "commentRange": {
-      "start": 936,
-      "end": 936
+      "start": 939,
+      "end": 939
     },
     "context": {
       "type": "variable",
@@ -8907,8 +8932,8 @@
       "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
-        "start": 937,
-        "end": 937
+        "start": 940,
+        "end": 940
       }
     },
     "access": "public",
@@ -8923,8 +8948,8 @@
   {
     "description": "The color setting on readonly Inputs.\n",
     "commentRange": {
-      "start": 938,
-      "end": 938
+      "start": 941,
+      "end": 941
     },
     "context": {
       "type": "variable",
@@ -8932,8 +8957,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 939,
-        "end": 939
+        "start": 942,
+        "end": 942
       }
     },
     "access": "public",
@@ -8948,8 +8973,8 @@
   {
     "description": "The transition setting Inputs.\n",
     "commentRange": {
-      "start": 940,
-      "end": 940
+      "start": 943,
+      "end": 943
     },
     "context": {
       "type": "variable",
@@ -8957,8 +8982,8 @@
       "value": "border-color 0.15s ease",
       "scope": "default",
       "line": {
-        "start": 941,
-        "end": 941
+        "start": 944,
+        "end": 944
       }
     },
     "access": "public",
@@ -8973,8 +8998,8 @@
   {
     "description": "The value for the appearance property for Selects.\n",
     "commentRange": {
-      "start": 947,
-      "end": 947
+      "start": 950,
+      "end": 950
     },
     "context": {
       "type": "variable",
@@ -8982,8 +9007,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 948,
-        "end": 948
+        "start": 951,
+        "end": 951
       }
     },
     "access": "public",
@@ -8998,8 +9023,8 @@
   {
     "description": "The background setting for Selects.\n",
     "commentRange": {
-      "start": 949,
-      "end": 949
+      "start": 952,
+      "end": 952
     },
     "context": {
       "type": "variable",
@@ -9007,8 +9032,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 950,
-        "end": 950
+        "start": 953,
+        "end": 953
       }
     },
     "access": "public",
@@ -9023,8 +9048,8 @@
   {
     "description": "The border setting for Selects.\n",
     "commentRange": {
-      "start": 951,
-      "end": 951
+      "start": 954,
+      "end": 954
     },
     "context": {
       "type": "variable",
@@ -9032,8 +9057,8 @@
       "value": "$sprk-text-input-border",
       "scope": "default",
       "line": {
-        "start": 952,
-        "end": 952
+        "start": 955,
+        "end": 955
       }
     },
     "access": "public",
@@ -9048,8 +9073,8 @@
   {
     "description": "The border color setting for Selects on focus.\n",
     "commentRange": {
-      "start": 953,
-      "end": 953
+      "start": 956,
+      "end": 956
     },
     "context": {
       "type": "variable",
@@ -9057,8 +9082,8 @@
       "value": "$sprk-text-input-focus-border-color",
       "scope": "default",
       "line": {
-        "start": 954,
-        "end": 954
+        "start": 957,
+        "end": 957
       }
     },
     "access": "public",
@@ -9073,8 +9098,8 @@
   {
     "description": "The border color setting for Selects when they have an error.\n",
     "commentRange": {
-      "start": 955,
-      "end": 955
+      "start": 958,
+      "end": 958
     },
     "context": {
       "type": "variable",
@@ -9082,8 +9107,8 @@
       "value": "$sprk-text-input-error-border-color",
       "scope": "default",
       "line": {
-        "start": 956,
-        "end": 956
+        "start": 959,
+        "end": 959
       }
     },
     "access": "public",
@@ -9098,8 +9123,8 @@
   {
     "description": "The border radius setting for Selects.\n",
     "commentRange": {
-      "start": 957,
-      "end": 957
+      "start": 960,
+      "end": 960
     },
     "context": {
       "type": "variable",
@@ -9107,8 +9132,8 @@
       "value": "$sprk-text-input-border-radius",
       "scope": "default",
       "line": {
-        "start": 958,
-        "end": 958
+        "start": 961,
+        "end": 961
       }
     },
     "access": "public",
@@ -9123,8 +9148,8 @@
   {
     "description": "The box shadow setting for Selects.\n",
     "commentRange": {
-      "start": 959,
-      "end": 959
+      "start": 962,
+      "end": 962
     },
     "context": {
       "type": "variable",
@@ -9132,8 +9157,8 @@
       "value": "$sprk-text-input-box-shadow",
       "scope": "default",
       "line": {
-        "start": 960,
-        "end": 960
+        "start": 963,
+        "end": 963
       }
     },
     "access": "public",
@@ -9148,8 +9173,8 @@
   {
     "description": "The value for the color property for Selects.\n",
     "commentRange": {
-      "start": 961,
-      "end": 961
+      "start": 964,
+      "end": 964
     },
     "context": {
       "type": "variable",
@@ -9157,8 +9182,8 @@
       "value": "$sprk-text-input-color",
       "scope": "default",
       "line": {
-        "start": 962,
-        "end": 962
+        "start": 965,
+        "end": 965
       }
     },
     "access": "public",
@@ -9173,8 +9198,8 @@
   {
     "description": "The font size of Selects.\n",
     "commentRange": {
-      "start": 963,
-      "end": 963
+      "start": 966,
+      "end": 966
     },
     "context": {
       "type": "variable",
@@ -9182,8 +9207,8 @@
       "value": "$sprk-text-input-font-size",
       "scope": "default",
       "line": {
-        "start": 964,
-        "end": 964
+        "start": 967,
+        "end": 967
       }
     },
     "access": "public",
@@ -9198,8 +9223,8 @@
   {
     "description": "The font family of Selects.\n",
     "commentRange": {
-      "start": 965,
-      "end": 965
+      "start": 968,
+      "end": 968
     },
     "context": {
       "type": "variable",
@@ -9207,8 +9232,8 @@
       "value": "$sprk-text-input-font-family",
       "scope": "default",
       "line": {
-        "start": 966,
-        "end": 966
+        "start": 969,
+        "end": 969
       }
     },
     "access": "public",
@@ -9223,8 +9248,8 @@
   {
     "description": "The font weight of Selects.\n",
     "commentRange": {
-      "start": 967,
-      "end": 967
+      "start": 970,
+      "end": 970
     },
     "context": {
       "type": "variable",
@@ -9232,8 +9257,8 @@
       "value": "$sprk-text-input-font-weight",
       "scope": "default",
       "line": {
-        "start": 968,
-        "end": 968
+        "start": 971,
+        "end": 971
       }
     },
     "access": "public",
@@ -9248,8 +9273,8 @@
   {
     "description": "The line height of Selects.\n",
     "commentRange": {
-      "start": 969,
-      "end": 969
+      "start": 972,
+      "end": 972
     },
     "context": {
       "type": "variable",
@@ -9257,8 +9282,8 @@
       "value": "$sprk-text-input-line-height",
       "scope": "default",
       "line": {
-        "start": 970,
-        "end": 970
+        "start": 973,
+        "end": 973
       }
     },
     "access": "public",
@@ -9273,8 +9298,8 @@
   {
     "description": "The outline setting for Selects.\n",
     "commentRange": {
-      "start": 971,
-      "end": 971
+      "start": 974,
+      "end": 974
     },
     "context": {
       "type": "variable",
@@ -9282,8 +9307,8 @@
       "value": "$sprk-text-input-outline",
       "scope": "default",
       "line": {
-        "start": 972,
-        "end": 972
+        "start": 975,
+        "end": 975
       }
     },
     "access": "public",
@@ -9298,8 +9323,8 @@
   {
     "description": "The padding of Selects.\n",
     "commentRange": {
-      "start": 973,
-      "end": 973
+      "start": 976,
+      "end": 976
     },
     "context": {
       "type": "variable",
@@ -9307,8 +9332,8 @@
       "value": "12px 45px 12px 13px",
       "scope": "default",
       "line": {
-        "start": 974,
-        "end": 974
+        "start": 977,
+        "end": 977
       }
     },
     "access": "public",
@@ -9323,8 +9348,8 @@
   {
     "description": "The value for margin-top on the icon in Selects.\n",
     "commentRange": {
-      "start": 975,
-      "end": 975
+      "start": 978,
+      "end": 978
     },
     "context": {
       "type": "variable",
@@ -9332,8 +9357,8 @@
       "value": "-31px",
       "scope": "default",
       "line": {
-        "start": 976,
-        "end": 976
+        "start": 979,
+        "end": 979
       }
     },
     "access": "public",
@@ -9348,8 +9373,8 @@
   {
     "description": "The value for margin-right on the icon in Selects.\n",
     "commentRange": {
-      "start": 977,
-      "end": 977
+      "start": 980,
+      "end": 980
     },
     "context": {
       "type": "variable",
@@ -9357,8 +9382,8 @@
       "value": "19px",
       "scope": "default",
       "line": {
-        "start": 978,
-        "end": 978
+        "start": 981,
+        "end": 981
       }
     },
     "access": "public",
@@ -9373,8 +9398,8 @@
   {
     "description": "The stroke width of the icon in Selects.\n",
     "commentRange": {
-      "start": 979,
-      "end": 979
+      "start": 982,
+      "end": 982
     },
     "context": {
       "type": "variable",
@@ -9382,8 +9407,8 @@
       "value": "6px",
       "scope": "default",
       "line": {
-        "start": 980,
-        "end": 980
+        "start": 983,
+        "end": 983
       }
     },
     "access": "public",
@@ -9398,8 +9423,8 @@
   {
     "description": "The border color of disabled Selects.\n",
     "commentRange": {
-      "start": 981,
-      "end": 981
+      "start": 984,
+      "end": 984
     },
     "context": {
       "type": "variable",
@@ -9407,8 +9432,8 @@
       "value": "$sprk-text-input-disabled-border-color",
       "scope": "default",
       "line": {
-        "start": 982,
-        "end": 982
+        "start": 985,
+        "end": 985
       }
     },
     "access": "public",
@@ -9423,8 +9448,8 @@
   {
     "description": "The background color of disabled Selects.\n",
     "commentRange": {
-      "start": 983,
-      "end": 983
+      "start": 986,
+      "end": 986
     },
     "context": {
       "type": "variable",
@@ -9432,8 +9457,8 @@
       "value": "$sprk-text-input-disabled-background-color",
       "scope": "default",
       "line": {
-        "start": 984,
-        "end": 984
+        "start": 987,
+        "end": 987
       }
     },
     "access": "public",
@@ -9448,8 +9473,8 @@
   {
     "description": "The color property value of disabled Selects.\n",
     "commentRange": {
-      "start": 985,
-      "end": 985
+      "start": 988,
+      "end": 988
     },
     "context": {
       "type": "variable",
@@ -9457,8 +9482,8 @@
       "value": "$sprk-text-input-disabled-color",
       "scope": "default",
       "line": {
-        "start": 986,
-        "end": 986
+        "start": 989,
+        "end": 989
       }
     },
     "access": "public",
@@ -9473,8 +9498,8 @@
   {
     "description": "The value for the Firefox specific -moz-focusring color setting.\n",
     "commentRange": {
-      "start": 987,
-      "end": 987
+      "start": 990,
+      "end": 990
     },
     "context": {
       "type": "variable",
@@ -9482,8 +9507,8 @@
       "value": "transparent",
       "scope": "default",
       "line": {
-        "start": 988,
-        "end": 988
+        "start": 991,
+        "end": 991
       }
     },
     "access": "public",
@@ -9498,8 +9523,8 @@
   {
     "description": "The value for the Firefox specific -moz-focusring text-shadow setting.\n",
     "commentRange": {
-      "start": 989,
-      "end": 989
+      "start": 992,
+      "end": 992
     },
     "context": {
       "type": "variable",
@@ -9507,8 +9532,8 @@
       "value": "0 0 0 $sprk-select-color",
       "scope": "default",
       "line": {
-        "start": 990,
-        "end": 990
+        "start": 993,
+        "end": 993
       }
     },
     "access": "public",
@@ -9523,8 +9548,8 @@
   {
     "description": "The minimum height of Textarea.\n",
     "commentRange": {
-      "start": 996,
-      "end": 996
+      "start": 999,
+      "end": 999
     },
     "context": {
       "type": "variable",
@@ -9532,8 +9557,8 @@
       "value": "125px",
       "scope": "default",
       "line": {
-        "start": 997,
-        "end": 997
+        "start": 1000,
+        "end": 1000
       }
     },
     "access": "public",
@@ -9548,8 +9573,8 @@
   {
     "description": "The margin surrounding Textarea.\n",
     "commentRange": {
-      "start": 998,
-      "end": 998
+      "start": 1001,
+      "end": 1001
     },
     "context": {
       "type": "variable",
@@ -9557,8 +9582,8 @@
       "value": "$sprk-space-stack-m",
       "scope": "default",
       "line": {
-        "start": 999,
-        "end": 999
+        "start": 1002,
+        "end": 1002
       }
     },
     "access": "public",
@@ -9573,8 +9598,8 @@
   {
     "description": "The padding inside Textarea.\n",
     "commentRange": {
-      "start": 1000,
-      "end": 1000
+      "start": 1003,
+      "end": 1003
     },
     "context": {
       "type": "variable",
@@ -9582,8 +9607,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1001,
-        "end": 1001
+        "start": 1004,
+        "end": 1004
       }
     },
     "access": "public",
@@ -9598,8 +9623,8 @@
   {
     "description": "Color setting for Inputs with errors.\n",
     "commentRange": {
-      "start": 1007,
-      "end": 1007
+      "start": 1010,
+      "end": 1010
     },
     "context": {
       "type": "variable",
@@ -9607,8 +9632,8 @@
       "value": "$sprk-yellow",
       "scope": "default",
       "line": {
-        "start": 1008,
-        "end": 1008
+        "start": 1011,
+        "end": 1011
       }
     },
     "access": "public",
@@ -9623,8 +9648,8 @@
   {
     "description": "Value for color on Inputs with errors.\n",
     "commentRange": {
-      "start": 1009,
-      "end": 1009
+      "start": 1012,
+      "end": 1012
     },
     "context": {
       "type": "variable",
@@ -9632,8 +9657,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1010,
-        "end": 1010
+        "start": 1013,
+        "end": 1013
       }
     },
     "access": "public",
@@ -9648,8 +9673,8 @@
   {
     "description": "The font family used for Input error text.\n",
     "commentRange": {
-      "start": 1011,
-      "end": 1011
+      "start": 1014,
+      "end": 1014
     },
     "context": {
       "type": "variable",
@@ -9657,8 +9682,8 @@
       "value": "$sprk-font-family-body-two",
       "scope": "default",
       "line": {
-        "start": 1012,
-        "end": 1012
+        "start": 1015,
+        "end": 1015
       }
     },
     "access": "public",
@@ -9673,8 +9698,8 @@
   {
     "description": "The font weight used for Input error text.\n",
     "commentRange": {
-      "start": 1013,
-      "end": 1013
+      "start": 1016,
+      "end": 1016
     },
     "context": {
       "type": "variable",
@@ -9682,8 +9707,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1014,
-        "end": 1014
+        "start": 1017,
+        "end": 1017
       }
     },
     "access": "public",
@@ -9698,8 +9723,8 @@
   {
     "description": "The font size used for Input error text.\n",
     "commentRange": {
-      "start": 1015,
-      "end": 1015
+      "start": 1018,
+      "end": 1018
     },
     "context": {
       "type": "variable",
@@ -9707,8 +9732,8 @@
       "value": "0.8125rem",
       "scope": "default",
       "line": {
-        "start": 1016,
-        "end": 1016
+        "start": 1019,
+        "end": 1019
       }
     },
     "access": "public",
@@ -9723,8 +9748,8 @@
   {
     "description": "The line height used for Input error text.\n",
     "commentRange": {
-      "start": 1017,
-      "end": 1017
+      "start": 1020,
+      "end": 1020
     },
     "context": {
       "type": "variable",
@@ -9732,8 +9757,8 @@
       "value": "1.4",
       "scope": "default",
       "line": {
-        "start": 1018,
-        "end": 1018
+        "start": 1021,
+        "end": 1021
       }
     },
     "access": "public",
@@ -9748,8 +9773,8 @@
   {
     "description": "The margin for Input error text.\n",
     "commentRange": {
-      "start": 1019,
-      "end": 1019
+      "start": 1022,
+      "end": 1022
     },
     "context": {
       "type": "variable",
@@ -9757,8 +9782,8 @@
       "value": "0 0 0 6px",
       "scope": "default",
       "line": {
-        "start": 1020,
-        "end": 1020
+        "start": 1023,
+        "end": 1023
       }
     },
     "access": "public",
@@ -9773,8 +9798,8 @@
   {
     "description": "The margin for Input containers that have an error.\n",
     "commentRange": {
-      "start": 1021,
-      "end": 1021
+      "start": 1024,
+      "end": 1024
     },
     "context": {
       "type": "variable",
@@ -9782,8 +9807,8 @@
       "value": "$sprk-space-s 0 0 0",
       "scope": "default",
       "line": {
-        "start": 1022,
-        "end": 1022
+        "start": 1025,
+        "end": 1025
       }
     },
     "access": "public",
@@ -9798,8 +9823,8 @@
   {
     "description": "The Input error icon size.\n",
     "commentRange": {
-      "start": 1023,
-      "end": 1023
+      "start": 1026,
+      "end": 1026
     },
     "context": {
       "type": "variable",
@@ -9807,8 +9832,8 @@
       "value": "1.25rem",
       "scope": "default",
       "line": {
-        "start": 1024,
-        "end": 1024
+        "start": 1027,
+        "end": 1027
       }
     },
     "access": "public",
@@ -9823,8 +9848,8 @@
   {
     "description": "The color of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1030,
-      "end": 1030
+      "start": 1033,
+      "end": 1033
     },
     "context": {
       "type": "variable",
@@ -9832,8 +9857,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1031,
-        "end": 1031
+        "start": 1034,
+        "end": 1034
       }
     },
     "access": "public",
@@ -9848,8 +9873,8 @@
   {
     "description": "The font size of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1032,
-      "end": 1032
+      "start": 1035,
+      "end": 1035
     },
     "context": {
       "type": "variable",
@@ -9857,8 +9882,8 @@
       "value": "0.8125rem",
       "scope": "default",
       "line": {
-        "start": 1033,
-        "end": 1033
+        "start": 1036,
+        "end": 1036
       }
     },
     "access": "public",
@@ -9873,8 +9898,8 @@
   {
     "description": "The font family of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1034,
-      "end": 1034
+      "start": 1037,
+      "end": 1037
     },
     "context": {
       "type": "variable",
@@ -9882,8 +9907,8 @@
       "value": "$sprk-text-input-font-family",
       "scope": "default",
       "line": {
-        "start": 1035,
-        "end": 1035
+        "start": 1038,
+        "end": 1038
       }
     },
     "access": "public",
@@ -9898,8 +9923,8 @@
   {
     "description": "The font weight of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1036,
-      "end": 1036
+      "start": 1039,
+      "end": 1039
     },
     "context": {
       "type": "variable",
@@ -9907,8 +9932,8 @@
       "value": "$sprk-text-input-font-weight",
       "scope": "default",
       "line": {
-        "start": 1037,
-        "end": 1037
+        "start": 1040,
+        "end": 1040
       }
     },
     "access": "public",
@@ -9923,8 +9948,8 @@
   {
     "description": "The line height of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1038,
-      "end": 1038
+      "start": 1041,
+      "end": 1041
     },
     "context": {
       "type": "variable",
@@ -9932,8 +9957,8 @@
       "value": "$sprk-text-input-line-height",
       "scope": "default",
       "line": {
-        "start": 1039,
-        "end": 1039
+        "start": 1042,
+        "end": 1042
       }
     },
     "access": "public",
@@ -9948,8 +9973,8 @@
   {
     "description": "The margin of the helper text for Inputs.\n",
     "commentRange": {
-      "start": 1040,
-      "end": 1040
+      "start": 1043,
+      "end": 1043
     },
     "context": {
       "type": "variable",
@@ -9957,8 +9982,8 @@
       "value": "$sprk-error-container-margin",
       "scope": "default",
       "line": {
-        "start": 1041,
-        "end": 1041
+        "start": 1044,
+        "end": 1044
       }
     },
     "access": "public",
@@ -9973,8 +9998,8 @@
   {
     "description": "The color of the placeholder for Inputs.\n",
     "commentRange": {
-      "start": 1047,
-      "end": 1047
+      "start": 1050,
+      "end": 1050
     },
     "context": {
       "type": "variable",
@@ -9982,8 +10007,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1048,
-        "end": 1048
+        "start": 1051,
+        "end": 1051
       }
     },
     "access": "public",
@@ -9998,8 +10023,8 @@
   {
     "description": "The font size of the placeholder for Inputs.\n",
     "commentRange": {
-      "start": 1049,
-      "end": 1049
+      "start": 1052,
+      "end": 1052
     },
     "context": {
       "type": "variable",
@@ -10007,8 +10032,8 @@
       "value": "$sprk-text-input-font-size",
       "scope": "default",
       "line": {
-        "start": 1050,
-        "end": 1050
+        "start": 1053,
+        "end": 1053
       }
     },
     "access": "public",
@@ -10023,8 +10048,8 @@
   {
     "description": "The font family of the placeholder for Inputs.\n",
     "commentRange": {
-      "start": 1051,
-      "end": 1051
+      "start": 1054,
+      "end": 1054
     },
     "context": {
       "type": "variable",
@@ -10032,8 +10057,8 @@
       "value": "$sprk-text-input-font-family",
       "scope": "default",
       "line": {
-        "start": 1052,
-        "end": 1052
+        "start": 1055,
+        "end": 1055
       }
     },
     "access": "public",
@@ -10048,8 +10073,8 @@
   {
     "description": "The font weight of the placeholder for Inputs.\n",
     "commentRange": {
-      "start": 1053,
-      "end": 1053
+      "start": 1056,
+      "end": 1056
     },
     "context": {
       "type": "variable",
@@ -10057,8 +10082,8 @@
       "value": "$sprk-text-input-font-weight",
       "scope": "default",
       "line": {
-        "start": 1054,
-        "end": 1054
+        "start": 1057,
+        "end": 1057
       }
     },
     "access": "public",
@@ -10073,8 +10098,8 @@
   {
     "description": "The margin of the selection container for Inputs.\n",
     "commentRange": {
-      "start": 1060,
-      "end": 1060
+      "start": 1063,
+      "end": 1063
     },
     "context": {
       "type": "variable",
@@ -10082,8 +10107,8 @@
       "value": "0 0 $sprk-space-m 0",
       "scope": "default",
       "line": {
-        "start": 1061,
-        "end": 1061
+        "start": 1064,
+        "end": 1064
       }
     },
     "access": "public",
@@ -10098,8 +10123,8 @@
   {
     "description": "The font weight of the label in the selection container for Inputs.\n",
     "commentRange": {
-      "start": 1062,
-      "end": 1062
+      "start": 1065,
+      "end": 1065
     },
     "context": {
       "type": "variable",
@@ -10107,8 +10132,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 1063,
-        "end": 1063
+        "start": 1066,
+        "end": 1066
       }
     },
     "access": "public",
@@ -10123,8 +10148,8 @@
   {
     "description": "The height of the selection container for Inputs.\n",
     "commentRange": {
-      "start": 1064,
-      "end": 1064
+      "start": 1067,
+      "end": 1067
     },
     "context": {
       "type": "variable",
@@ -10132,8 +10157,8 @@
       "value": "auto",
       "scope": "default",
       "line": {
-        "start": 1065,
-        "end": 1065
+        "start": 1068,
+        "end": 1068
       }
     },
     "access": "public",
@@ -10148,8 +10173,8 @@
   {
     "description": "The width of Input inside the selection container.\n",
     "commentRange": {
-      "start": 1066,
-      "end": 1066
+      "start": 1069,
+      "end": 1069
     },
     "context": {
       "type": "variable",
@@ -10157,8 +10182,8 @@
       "value": "auto",
       "scope": "default",
       "line": {
-        "start": 1067,
-        "end": 1067
+        "start": 1070,
+        "end": 1070
       }
     },
     "access": "public",
@@ -10173,8 +10198,8 @@
   {
     "description": "The margin of the Input inside the selection container.\n",
     "commentRange": {
-      "start": 1068,
-      "end": 1068
+      "start": 1071,
+      "end": 1071
     },
     "context": {
       "type": "variable",
@@ -10182,8 +10207,8 @@
       "value": "0 $sprk-space-s 0 0",
       "scope": "default",
       "line": {
-        "start": 1069,
-        "end": 1069
+        "start": 1072,
+        "end": 1072
       }
     },
     "access": "public",
@@ -10198,8 +10223,8 @@
   {
     "description": "The maximum width of the Date Picker popup.\n",
     "commentRange": {
-      "start": 1075,
-      "end": 1075
+      "start": 1078,
+      "end": 1078
     },
     "context": {
       "type": "variable",
@@ -10207,8 +10232,8 @@
       "value": "20rem",
       "scope": "default",
       "line": {
-        "start": 1076,
-        "end": 1076
+        "start": 1079,
+        "end": 1079
       }
     },
     "access": "public",
@@ -10223,8 +10248,8 @@
   {
     "description": "The border radius applied to the Date Picker popup.\n",
     "commentRange": {
-      "start": 1077,
-      "end": 1077
+      "start": 1080,
+      "end": 1080
     },
     "context": {
       "type": "variable",
@@ -10232,8 +10257,8 @@
       "value": "4px",
       "scope": "default",
       "line": {
-        "start": 1078,
-        "end": 1078
+        "start": 1081,
+        "end": 1081
       }
     },
     "access": "public",
@@ -10248,8 +10273,8 @@
   {
     "description": "The size of the buttons used internally by the Date Picker popup.\n",
     "commentRange": {
-      "start": 1079,
-      "end": 1079
+      "start": 1082,
+      "end": 1082
     },
     "context": {
       "type": "variable",
@@ -10257,8 +10282,8 @@
       "value": "2.25rem",
       "scope": "default",
       "line": {
-        "start": 1080,
-        "end": 1080
+        "start": 1083,
+        "end": 1083
       }
     },
     "access": "public",
@@ -10273,8 +10298,8 @@
   {
     "description": "The offset applied to columns used internally by the Date Picker.\n",
     "commentRange": {
-      "start": 1081,
-      "end": 1081
+      "start": 1084,
+      "end": 1084
     },
     "context": {
       "type": "variable",
@@ -10282,8 +10307,8 @@
       "value": "0.25rem",
       "scope": "default",
       "line": {
-        "start": 1082,
-        "end": 1082
+        "start": 1085,
+        "end": 1085
       }
     },
     "access": "public",
@@ -10298,8 +10323,8 @@
   {
     "description": "The box shadow of the Date Picker.\n",
     "commentRange": {
-      "start": 1083,
-      "end": 1083
+      "start": 1086,
+      "end": 1086
     },
     "context": {
       "type": "variable",
@@ -10307,8 +10332,8 @@
       "value": "0 4px 16px rgba(51, 51, 51, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1084,
-        "end": 1084
+        "start": 1087,
+        "end": 1087
       }
     },
     "access": "public",
@@ -10323,8 +10348,8 @@
   {
     "description": "The font family in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1085,
-      "end": 1085
+      "start": 1088,
+      "end": 1088
     },
     "context": {
       "type": "variable",
@@ -10332,8 +10357,8 @@
       "value": "$sprk-font-family-body-two",
       "scope": "default",
       "line": {
-        "start": 1086,
-        "end": 1086
+        "start": 1089,
+        "end": 1089
       }
     },
     "access": "public",
@@ -10348,8 +10373,8 @@
   {
     "description": "The font size of the Date Picker popup.\n",
     "commentRange": {
-      "start": 1087,
-      "end": 1087
+      "start": 1090,
+      "end": 1090
     },
     "context": {
       "type": "variable",
@@ -10357,8 +10382,8 @@
       "value": "1rem",
       "scope": "default",
       "line": {
-        "start": 1088,
-        "end": 1088
+        "start": 1091,
+        "end": 1091
       }
     },
     "access": "public",
@@ -10373,8 +10398,8 @@
   {
     "description": "The font weight of the Date Picker popup.\n",
     "commentRange": {
-      "start": 1089,
-      "end": 1089
+      "start": 1092,
+      "end": 1092
     },
     "context": {
       "type": "variable",
@@ -10382,8 +10407,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 1090,
-        "end": 1090
+        "start": 1093,
+        "end": 1093
       }
     },
     "access": "public",
@@ -10398,8 +10423,8 @@
   {
     "description": "Color used internally by Date Picker to highlight elements\n",
     "commentRange": {
-      "start": 1091,
-      "end": 1091
+      "start": 1094,
+      "end": 1094
     },
     "context": {
       "type": "variable",
@@ -10407,8 +10432,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 1092,
-        "end": 1092
+        "start": 1095,
+        "end": 1095
       }
     },
     "access": "public",
@@ -10423,8 +10448,8 @@
   {
     "description": "Font weight used by the currently selected day in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1093,
-      "end": 1093
+      "start": 1096,
+      "end": 1096
     },
     "context": {
       "type": "variable",
@@ -10432,8 +10457,8 @@
       "value": "500",
       "scope": "default",
       "line": {
-        "start": 1094,
-        "end": 1094
+        "start": 1097,
+        "end": 1097
       }
     },
     "access": "public",
@@ -10448,8 +10473,8 @@
   {
     "description": "The value for background in the Date Picker.\n",
     "commentRange": {
-      "start": 1095,
-      "end": 1095
+      "start": 1098,
+      "end": 1098
     },
     "context": {
       "type": "variable",
@@ -10457,8 +10482,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1096,
-        "end": 1096
+        "start": 1099,
+        "end": 1099
       }
     },
     "access": "public",
@@ -10473,8 +10498,8 @@
   {
     "description": "The value for padding in the Date Picker.\n",
     "commentRange": {
-      "start": 1097,
-      "end": 1097
+      "start": 1100,
+      "end": 1100
     },
     "context": {
       "type": "variable",
@@ -10482,8 +10507,8 @@
       "value": "$sprk-space-inset-s",
       "scope": "default",
       "line": {
-        "start": 1098,
-        "end": 1098
+        "start": 1101,
+        "end": 1101
       }
     },
     "access": "public",
@@ -10498,8 +10523,8 @@
   {
     "description": "The value for padding on wide viewports in the Date Picker.\n",
     "commentRange": {
-      "start": 1099,
-      "end": 1099
+      "start": 1102,
+      "end": 1102
     },
     "context": {
       "type": "variable",
@@ -10507,8 +10532,8 @@
       "value": "$sprk-space-inset-m",
       "scope": "default",
       "line": {
-        "start": 1100,
-        "end": 1100
+        "start": 1103,
+        "end": 1103
       }
     },
     "access": "public",
@@ -10523,8 +10548,8 @@
   {
     "description": "The border setting for the header in the Date Picker.\n",
     "commentRange": {
-      "start": 1101,
-      "end": 1101
+      "start": 1104,
+      "end": 1104
     },
     "context": {
       "type": "variable",
@@ -10532,8 +10557,8 @@
       "value": "1px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1102,
-        "end": 1102
+        "start": 1105,
+        "end": 1105
       }
     },
     "access": "public",
@@ -10548,8 +10573,8 @@
   {
     "description": "The font size for the header in the Date Picker.\n",
     "commentRange": {
-      "start": 1103,
-      "end": 1103
+      "start": 1106,
+      "end": 1106
     },
     "context": {
       "type": "variable",
@@ -10557,8 +10582,8 @@
       "value": "$sprk-font-size-body-three",
       "scope": "default",
       "line": {
-        "start": 1104,
-        "end": 1104
+        "start": 1107,
+        "end": 1107
       }
     },
     "access": "public",
@@ -10573,8 +10598,8 @@
   {
     "description": "The font weight for the header in the Date Picker.\n",
     "commentRange": {
-      "start": 1105,
-      "end": 1105
+      "start": 1108,
+      "end": 1108
     },
     "context": {
       "type": "variable",
@@ -10582,8 +10607,8 @@
       "value": "700",
       "scope": "default",
       "line": {
-        "start": 1106,
-        "end": 1106
+        "start": 1109,
+        "end": 1109
       }
     },
     "access": "public",
@@ -10598,8 +10623,8 @@
   {
     "description": "The padding for the header in the Date Picker.\n",
     "commentRange": {
-      "start": 1107,
-      "end": 1107
+      "start": 1110,
+      "end": 1110
     },
     "context": {
       "type": "variable",
@@ -10607,8 +10632,8 @@
       "value": "0 0 $sprk-space-s 0",
       "scope": "default",
       "line": {
-        "start": 1108,
-        "end": 1108
+        "start": 1111,
+        "end": 1111
       }
     },
     "access": "public",
@@ -10623,8 +10648,8 @@
   {
     "description": "The padding around the month header in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1109,
-      "end": 1109
+      "start": 1112,
+      "end": 1112
     },
     "context": {
       "type": "variable",
@@ -10632,8 +10657,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1110,
-        "end": 1110
+        "start": 1113,
+        "end": 1113
       }
     },
     "access": "public",
@@ -10648,8 +10673,8 @@
   {
     "description": "The padding around the day in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1111,
-      "end": 1111
+      "start": 1114,
+      "end": 1114
     },
     "context": {
       "type": "variable",
@@ -10657,8 +10682,8 @@
       "value": "6px",
       "scope": "default",
       "line": {
-        "start": 1112,
-        "end": 1112
+        "start": 1115,
+        "end": 1115
       }
     },
     "access": "public",
@@ -10673,8 +10698,8 @@
   {
     "description": "The margin around the day in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1113,
-      "end": 1113
+      "start": 1116,
+      "end": 1116
     },
     "context": {
       "type": "variable",
@@ -10682,8 +10707,8 @@
       "value": "0 2px",
       "scope": "default",
       "line": {
-        "start": 1114,
-        "end": 1114
+        "start": 1117,
+        "end": 1117
       }
     },
     "access": "public",
@@ -10698,8 +10723,8 @@
   {
     "description": "The color of the day in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1115,
-      "end": 1115
+      "start": 1118,
+      "end": 1118
     },
     "context": {
       "type": "variable",
@@ -10707,8 +10732,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1116,
-        "end": 1116
+        "start": 1119,
+        "end": 1119
       }
     },
     "access": "public",
@@ -10723,38 +10748,13 @@
   {
     "description": "The color of the day in the Date Picker popup on hover.\n",
     "commentRange": {
-      "start": 1117,
-      "end": 1117
+      "start": 1120,
+      "end": 1120
     },
     "context": {
       "type": "variable",
       "name": "sprk-date-picker-day-hover-color",
       "value": "$sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1118,
-        "end": 1118
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of days in the Date Picker\npopup that are in the next month or disabled.\n",
-    "commentRange": {
-      "start": 1119,
-      "end": 1120
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-date-picker-day-edge-day-color",
-      "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
         "start": 1121,
@@ -10771,10 +10771,35 @@
     }
   },
   {
-    "description": "The font size of the month and year in the Date Picker popup.\n",
+    "description": "The color of days in the Date Picker\npopup that are in the next month or disabled.\n",
     "commentRange": {
       "start": 1122,
-      "end": 1122
+      "end": 1123
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-date-picker-day-edge-day-color",
+      "value": "$sprk-black-tint-50",
+      "scope": "default",
+      "line": {
+        "start": 1124,
+        "end": 1124
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font size of the month and year in the Date Picker popup.\n",
+    "commentRange": {
+      "start": 1125,
+      "end": 1125
     },
     "context": {
       "type": "variable",
@@ -10782,8 +10807,8 @@
       "value": "$sprk-font-size-display-six",
       "scope": "default",
       "line": {
-        "start": 1123,
-        "end": 1123
+        "start": 1126,
+        "end": 1126
       }
     },
     "access": "public",
@@ -10798,8 +10823,8 @@
   {
     "description": "The color of the prev/next arrows in the Date Picker popup.\n",
     "commentRange": {
-      "start": 1124,
-      "end": 1124
+      "start": 1127,
+      "end": 1127
     },
     "context": {
       "type": "variable",
@@ -10807,8 +10832,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1125,
-        "end": 1125
+        "start": 1128,
+        "end": 1128
       }
     },
     "access": "public",
@@ -10823,8 +10848,8 @@
   {
     "description": "The margin applied to the Date Picker popup.\n",
     "commentRange": {
-      "start": 1126,
-      "end": 1126
+      "start": 1129,
+      "end": 1129
     },
     "context": {
       "type": "variable",
@@ -10832,8 +10857,8 @@
       "value": "$sprk-space-m 0 0 0",
       "scope": "default",
       "line": {
-        "start": 1127,
-        "end": 1127
+        "start": 1130,
+        "end": 1130
       }
     },
     "access": "public",
@@ -10848,8 +10873,8 @@
   {
     "description": "The margin applied to the Date Picker popup on wide viewports.\n",
     "commentRange": {
-      "start": 1128,
-      "end": 1128
+      "start": 1131,
+      "end": 1131
     },
     "context": {
       "type": "variable",
@@ -10857,8 +10882,8 @@
       "value": "2px",
       "scope": "default",
       "line": {
-        "start": 1129,
-        "end": 1129
+        "start": 1132,
+        "end": 1132
       }
     },
     "access": "public",
@@ -10873,8 +10898,8 @@
   {
     "description": "The z-index applied to the Date Picker popup.\n",
     "commentRange": {
-      "start": 1130,
-      "end": 1130
+      "start": 1133,
+      "end": 1133
     },
     "context": {
       "type": "variable",
@@ -10882,8 +10907,8 @@
       "value": "$sprk-layer-height-m",
       "scope": "default",
       "line": {
-        "start": 1131,
-        "end": 1131
+        "start": 1134,
+        "end": 1134
       }
     },
     "access": "public",
@@ -10898,8 +10923,8 @@
   {
     "description": "The value for max-height applied to the Date Picker popup.\n",
     "commentRange": {
-      "start": 1132,
-      "end": 1132
+      "start": 1135,
+      "end": 1135
     },
     "context": {
       "type": "variable",
@@ -10907,8 +10932,8 @@
       "value": "500px",
       "scope": "default",
       "line": {
-        "start": 1133,
-        "end": 1133
+        "start": 1136,
+        "end": 1136
       }
     },
     "access": "public",
@@ -10923,8 +10948,8 @@
   {
     "description": "The X offset of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1139,
-      "end": 1139
+      "start": 1142,
+      "end": 1142
     },
     "context": {
       "type": "variable",
@@ -10932,8 +10957,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1140,
-        "end": 1140
+        "start": 1143,
+        "end": 1143
       }
     },
     "access": "public",
@@ -10948,8 +10973,8 @@
   {
     "description": "The Y offset of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1141,
-      "end": 1141
+      "start": 1144,
+      "end": 1144
     },
     "context": {
       "type": "variable",
@@ -10957,8 +10982,8 @@
       "value": "2em",
       "scope": "default",
       "line": {
-        "start": 1142,
-        "end": 1142
+        "start": 1145,
+        "end": 1145
       }
     },
     "access": "public",
@@ -10973,8 +10998,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1143,
-      "end": 1143
+      "start": 1146,
+      "end": 1146
     },
     "context": {
       "type": "variable",
@@ -10982,8 +11007,8 @@
       "value": "1rem",
       "scope": "default",
       "line": {
-        "start": 1144,
-        "end": 1144
+        "start": 1147,
+        "end": 1147
       }
     },
     "access": "public",
@@ -10998,8 +11023,8 @@
   {
     "description": "The font weight of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1145,
-      "end": 1145
+      "start": 1148,
+      "end": 1148
     },
     "context": {
       "type": "variable",
@@ -11007,8 +11032,8 @@
       "value": "700",
       "scope": "default",
       "line": {
-        "start": 1146,
-        "end": 1146
+        "start": 1149,
+        "end": 1149
       }
     },
     "access": "public",
@@ -11023,8 +11048,8 @@
   {
     "description": "The top offset of the icon displayed on the right side of Inputs.\n",
     "commentRange": {
-      "start": 1147,
-      "end": 1147
+      "start": 1150,
+      "end": 1150
     },
     "context": {
       "type": "variable",
@@ -11032,8 +11057,8 @@
       "value": "38px",
       "scope": "default",
       "line": {
-        "start": 1148,
-        "end": 1148
+        "start": 1151,
+        "end": 1151
       }
     },
     "access": "public",
@@ -11048,8 +11073,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1149,
-      "end": 1149
+      "start": 1152,
+      "end": 1152
     },
     "context": {
       "type": "variable",
@@ -11057,8 +11082,8 @@
       "value": "71px",
       "scope": "default",
       "line": {
-        "start": 1150,
-        "end": 1150
+        "start": 1153,
+        "end": 1153
       }
     },
     "access": "public",
@@ -11073,8 +11098,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1151,
-      "end": 1151
+      "start": 1154,
+      "end": 1154
     },
     "context": {
       "type": "variable",
@@ -11082,8 +11107,8 @@
       "value": "0 0 1px 37px",
       "scope": "default",
       "line": {
-        "start": 1152,
-        "end": 1152
+        "start": 1155,
+        "end": 1155
       }
     },
     "access": "public",
@@ -11098,8 +11123,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1153,
-      "end": 1153
+      "start": 1156,
+      "end": 1156
     },
     "context": {
       "type": "variable",
@@ -11107,8 +11132,8 @@
       "value": "0 37px 1px 12px",
       "scope": "default",
       "line": {
-        "start": 1154,
-        "end": 1154
+        "start": 1157,
+        "end": 1157
       }
     },
     "access": "public",
@@ -11123,8 +11148,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1155,
-      "end": 1155
+      "start": 1158,
+      "end": 1158
     },
     "context": {
       "type": "variable",
@@ -11132,8 +11157,8 @@
       "value": "0 40px",
       "scope": "default",
       "line": {
-        "start": 1156,
-        "end": 1156
+        "start": 1159,
+        "end": 1159
       }
     },
     "access": "public",
@@ -11148,8 +11173,8 @@
   {
     "description": "The font size of text icons inside Inputs.\n",
     "commentRange": {
-      "start": 1157,
-      "end": 1157
+      "start": 1160,
+      "end": 1160
     },
     "context": {
       "type": "variable",
@@ -11157,8 +11182,8 @@
       "value": "$sprk-layer-height-xs",
       "scope": "default",
       "line": {
-        "start": 1158,
-        "end": 1158
+        "start": 1161,
+        "end": 1161
       }
     },
     "access": "public",
@@ -11173,8 +11198,8 @@
   {
     "description": "The X offset of icons inside Inputs.\n",
     "commentRange": {
-      "start": 1164,
-      "end": 1164
+      "start": 1167,
+      "end": 1167
     },
     "context": {
       "type": "variable",
@@ -11182,8 +11207,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1165,
-        "end": 1165
+        "start": 1168,
+        "end": 1168
       }
     },
     "access": "public",
@@ -11198,8 +11223,8 @@
   {
     "description": "The Y offset of icons inside Inputs.\n",
     "commentRange": {
-      "start": 1166,
-      "end": 1166
+      "start": 1169,
+      "end": 1169
     },
     "context": {
       "type": "variable",
@@ -11207,8 +11232,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1167,
-        "end": 1167
+        "start": 1170,
+        "end": 1170
       }
     },
     "access": "public",
@@ -11223,8 +11248,8 @@
   {
     "description": "The padding inside Inputs that contain icons.\n",
     "commentRange": {
-      "start": 1168,
-      "end": 1168
+      "start": 1171,
+      "end": 1171
     },
     "context": {
       "type": "variable",
@@ -11232,8 +11257,8 @@
       "value": "12px 0 12px 40px",
       "scope": "default",
       "line": {
-        "start": 1169,
-        "end": 1169
+        "start": 1172,
+        "end": 1172
       }
     },
     "access": "public",
@@ -11248,8 +11273,8 @@
   {
     "description": "The z-index applied to the icon inside Inputs.\n",
     "commentRange": {
-      "start": 1170,
-      "end": 1170
+      "start": 1173,
+      "end": 1173
     },
     "context": {
       "type": "variable",
@@ -11257,8 +11282,8 @@
       "value": "$sprk-layer-height-xs",
       "scope": "default",
       "line": {
-        "start": 1171,
-        "end": 1171
+        "start": 1174,
+        "end": 1174
       }
     },
     "access": "public",
@@ -11273,8 +11298,8 @@
   {
     "description": "The padding applied to Input labels.\n",
     "commentRange": {
-      "start": 1177,
-      "end": 1177
+      "start": 1180,
+      "end": 1180
     },
     "context": {
       "type": "variable",
@@ -11282,8 +11307,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1178,
-        "end": 1178
+        "start": 1181,
+        "end": 1181
       }
     },
     "access": "public",
@@ -11298,8 +11323,8 @@
   {
     "description": "The font family applied to Input labels.\n",
     "commentRange": {
-      "start": 1179,
-      "end": 1179
+      "start": 1182,
+      "end": 1182
     },
     "context": {
       "type": "variable",
@@ -11307,8 +11332,8 @@
       "value": "$sprk-font-family-body-two",
       "scope": "default",
       "line": {
-        "start": 1180,
-        "end": 1180
+        "start": 1183,
+        "end": 1183
       }
     },
     "access": "public",
@@ -11323,8 +11348,8 @@
   {
     "description": "The font size applied to Input labels.\n",
     "commentRange": {
-      "start": 1181,
-      "end": 1181
+      "start": 1184,
+      "end": 1184
     },
     "context": {
       "type": "variable",
@@ -11332,8 +11357,8 @@
       "value": "0.875rem",
       "scope": "default",
       "line": {
-        "start": 1182,
-        "end": 1182
+        "start": 1185,
+        "end": 1185
       }
     },
     "access": "public",
@@ -11348,8 +11373,8 @@
   {
     "description": "The font weight applied to Input labels.\n",
     "commentRange": {
-      "start": 1183,
-      "end": 1183
+      "start": 1186,
+      "end": 1186
     },
     "context": {
       "type": "variable",
@@ -11357,8 +11382,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1184,
-        "end": 1184
+        "start": 1187,
+        "end": 1187
       }
     },
     "access": "public",
@@ -11373,8 +11398,8 @@
   {
     "description": "The line height applied to Input labels.\n",
     "commentRange": {
-      "start": 1185,
-      "end": 1185
+      "start": 1188,
+      "end": 1188
     },
     "context": {
       "type": "variable",
@@ -11382,8 +11407,8 @@
       "value": "1",
       "scope": "default",
       "line": {
-        "start": 1186,
-        "end": 1186
+        "start": 1189,
+        "end": 1189
       }
     },
     "access": "public",
@@ -11398,8 +11423,8 @@
   {
     "description": "The margin applied to Input labels.\n",
     "commentRange": {
-      "start": 1187,
-      "end": 1187
+      "start": 1190,
+      "end": 1190
     },
     "context": {
       "type": "variable",
@@ -11407,8 +11432,8 @@
       "value": "0 0 $sprk-space-s 0",
       "scope": "default",
       "line": {
-        "start": 1188,
-        "end": 1188
+        "start": 1191,
+        "end": 1191
       }
     },
     "access": "public",
@@ -11423,8 +11448,8 @@
   {
     "description": "The margin surrounding visibility controls (Ex. 'Show SSN').\n",
     "commentRange": {
-      "start": 1189,
-      "end": 1189
+      "start": 1192,
+      "end": 1192
     },
     "context": {
       "type": "variable",
@@ -11432,8 +11457,8 @@
       "value": "6px 0 0 0",
       "scope": "default",
       "line": {
-        "start": 1190,
-        "end": 1190
+        "start": 1193,
+        "end": 1193
       }
     },
     "access": "public",
@@ -11448,8 +11473,8 @@
   {
     "description": "The font size used for visibility controls.\n",
     "commentRange": {
-      "start": 1191,
-      "end": 1191
+      "start": 1194,
+      "end": 1194
     },
     "context": {
       "type": "variable",
@@ -11457,8 +11482,8 @@
       "value": "$sprk-label-font-size",
       "scope": "default",
       "line": {
-        "start": 1192,
-        "end": 1192
+        "start": 1195,
+        "end": 1195
       }
     },
     "access": "public",
@@ -11473,8 +11498,8 @@
   {
     "description": "The color of the disabled Input labels.\n",
     "commentRange": {
-      "start": 1193,
-      "end": 1193
+      "start": 1196,
+      "end": 1196
     },
     "context": {
       "type": "variable",
@@ -11482,8 +11507,8 @@
       "value": "$sprk-gray-dark",
       "scope": "default",
       "line": {
-        "start": 1194,
-        "end": 1194
+        "start": 1197,
+        "end": 1197
       }
     },
     "access": "public",
@@ -11498,8 +11523,8 @@
   {
     "description": "The small Table padding.\n",
     "commentRange": {
-      "start": 1200,
-      "end": 1200
+      "start": 1203,
+      "end": 1203
     },
     "context": {
       "type": "variable",
@@ -11507,8 +11532,8 @@
       "value": "$sprk-space-inset-s",
       "scope": "default",
       "line": {
-        "start": 1201,
-        "end": 1201
+        "start": 1204,
+        "end": 1204
       }
     },
     "access": "public",
@@ -11523,8 +11548,8 @@
   {
     "description": "The medium Table padding.\n",
     "commentRange": {
-      "start": 1202,
-      "end": 1202
+      "start": 1205,
+      "end": 1205
     },
     "context": {
       "type": "variable",
@@ -11532,8 +11557,8 @@
       "value": "$sprk-space-inset-m",
       "scope": "default",
       "line": {
-        "start": 1203,
-        "end": 1203
+        "start": 1206,
+        "end": 1206
       }
     },
     "access": "public",
@@ -11548,8 +11573,8 @@
   {
     "description": "The large Table padding.\n",
     "commentRange": {
-      "start": 1204,
-      "end": 1204
+      "start": 1207,
+      "end": 1207
     },
     "context": {
       "type": "variable",
@@ -11557,8 +11582,8 @@
       "value": "$sprk-space-inset-l",
       "scope": "default",
       "line": {
-        "start": 1205,
-        "end": 1205
+        "start": 1208,
+        "end": 1208
       }
     },
     "access": "public",
@@ -11573,8 +11598,8 @@
   {
     "description": "The Table cell alignment.\n",
     "commentRange": {
-      "start": 1206,
-      "end": 1206
+      "start": 1209,
+      "end": 1209
     },
     "context": {
       "type": "variable",
@@ -11582,8 +11607,8 @@
       "value": "center",
       "scope": "default",
       "line": {
-        "start": 1207,
-        "end": 1207
+        "start": 1210,
+        "end": 1210
       }
     },
     "access": "public",
@@ -11598,8 +11623,8 @@
   {
     "description": "The stripe color or the striped Table.\n",
     "commentRange": {
-      "start": 1208,
-      "end": 1208
+      "start": 1211,
+      "end": 1211
     },
     "context": {
       "type": "variable",
@@ -11607,8 +11632,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1209,
-        "end": 1209
+        "start": 1212,
+        "end": 1212
       }
     },
     "access": "public",
@@ -11623,8 +11648,8 @@
   {
     "description": "The highlight background color of the sprk-b-TableHighlight.\n",
     "commentRange": {
-      "start": 1210,
-      "end": 1210
+      "start": 1213,
+      "end": 1213
     },
     "context": {
       "type": "variable",
@@ -11632,8 +11657,8 @@
       "value": "$sprk-red",
       "scope": "default",
       "line": {
-        "start": 1211,
-        "end": 1211
+        "start": 1214,
+        "end": 1214
       }
     },
     "access": "public",
@@ -11648,8 +11673,8 @@
   {
     "description": "The highlight text color of the sprk-b-TableHighlight.\n",
     "commentRange": {
-      "start": 1212,
-      "end": 1212
+      "start": 1215,
+      "end": 1215
     },
     "context": {
       "type": "variable",
@@ -11657,8 +11682,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1213,
-        "end": 1213
+        "start": 1216,
+        "end": 1216
       }
     },
     "access": "public",
@@ -11673,8 +11698,8 @@
   {
     "description": "The heading alignment of in Tables.\n",
     "commentRange": {
-      "start": 1214,
-      "end": 1214
+      "start": 1217,
+      "end": 1217
     },
     "context": {
       "type": "variable",
@@ -11682,8 +11707,8 @@
       "value": "center",
       "scope": "default",
       "line": {
-        "start": 1215,
-        "end": 1215
+        "start": 1218,
+        "end": 1218
       }
     },
     "access": "public",
@@ -11698,8 +11723,8 @@
   {
     "description": "The border width on Tables.\n",
     "commentRange": {
-      "start": 1216,
-      "end": 1216
+      "start": 1219,
+      "end": 1219
     },
     "context": {
       "type": "variable",
@@ -11707,8 +11732,8 @@
       "value": "1px",
       "scope": "default",
       "line": {
-        "start": 1217,
-        "end": 1217
+        "start": 1220,
+        "end": 1220
       }
     },
     "access": "public",
@@ -11723,8 +11748,8 @@
   {
     "description": "The border style of Tables.\n",
     "commentRange": {
-      "start": 1218,
-      "end": 1218
+      "start": 1221,
+      "end": 1221
     },
     "context": {
       "type": "variable",
@@ -11732,8 +11757,8 @@
       "value": "solid",
       "scope": "default",
       "line": {
-        "start": 1219,
-        "end": 1219
+        "start": 1222,
+        "end": 1222
       }
     },
     "access": "public",
@@ -11748,8 +11773,8 @@
   {
     "description": "The border color of Tables.\n",
     "commentRange": {
-      "start": 1220,
-      "end": 1220
+      "start": 1223,
+      "end": 1223
     },
     "context": {
       "type": "variable",
@@ -11757,8 +11782,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1221,
-        "end": 1221
+        "start": 1224,
+        "end": 1224
       }
     },
     "access": "public",
@@ -11773,8 +11798,8 @@
   {
     "description": "The border collapse setting of Tables.\n",
     "commentRange": {
-      "start": 1222,
-      "end": 1222
+      "start": 1225,
+      "end": 1225
     },
     "context": {
       "type": "variable",
@@ -11782,8 +11807,8 @@
       "value": "collapse",
       "scope": "default",
       "line": {
-        "start": 1223,
-        "end": 1223
+        "start": 1226,
+        "end": 1226
       }
     },
     "access": "public",
@@ -11798,8 +11823,8 @@
   {
     "description": "The width of the bottom border on Table rows.\n",
     "commentRange": {
-      "start": 1226,
-      "end": 1226
+      "start": 1229,
+      "end": 1229
     },
     "context": {
       "type": "variable",
@@ -11807,8 +11832,8 @@
       "value": "1px",
       "scope": "default",
       "line": {
-        "start": 1227,
-        "end": 1227
+        "start": 1230,
+        "end": 1230
       }
     },
     "access": "public",
@@ -11823,8 +11848,8 @@
   {
     "description": "The style of the bottom border on Table rows.\n",
     "commentRange": {
-      "start": 1228,
-      "end": 1228
+      "start": 1231,
+      "end": 1231
     },
     "context": {
       "type": "variable",
@@ -11832,8 +11857,8 @@
       "value": "solid",
       "scope": "default",
       "line": {
-        "start": 1229,
-        "end": 1229
+        "start": 1232,
+        "end": 1232
       }
     },
     "access": "public",
@@ -11848,8 +11873,8 @@
   {
     "description": "The color of the bottom border on Table rows.\n",
     "commentRange": {
-      "start": 1230,
-      "end": 1230
+      "start": 1233,
+      "end": 1233
     },
     "context": {
       "type": "variable",
@@ -11857,8 +11882,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1231,
-        "end": 1231
+        "start": 1234,
+        "end": 1234
       }
     },
     "access": "public",
@@ -11873,8 +11898,8 @@
   {
     "description": "The background color of the Table header.\n",
     "commentRange": {
-      "start": 1232,
-      "end": 1232
+      "start": 1235,
+      "end": 1235
     },
     "context": {
       "type": "variable",
@@ -11882,8 +11907,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1233,
-        "end": 1233
+        "start": 1236,
+        "end": 1236
       }
     },
     "access": "public",
@@ -11898,8 +11923,8 @@
   {
     "description": "The font color of the Table header.\n",
     "commentRange": {
-      "start": 1234,
-      "end": 1234
+      "start": 1237,
+      "end": 1237
     },
     "context": {
       "type": "variable",
@@ -11907,8 +11932,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1235,
-        "end": 1235
+        "start": 1238,
+        "end": 1238
       }
     },
     "access": "public",
@@ -11923,8 +11948,8 @@
   {
     "description": "The font size of the Table header.\n",
     "commentRange": {
-      "start": 1236,
-      "end": 1236
+      "start": 1239,
+      "end": 1239
     },
     "context": {
       "type": "variable",
@@ -11932,8 +11957,8 @@
       "value": "$sprk-font-size-body-one",
       "scope": "default",
       "line": {
-        "start": 1237,
-        "end": 1237
+        "start": 1240,
+        "end": 1240
       }
     },
     "access": "public",
@@ -11948,8 +11973,8 @@
   {
     "description": "The font weight of the Table header.\n",
     "commentRange": {
-      "start": 1238,
-      "end": 1238
+      "start": 1241,
+      "end": 1241
     },
     "context": {
       "type": "variable",
@@ -11957,8 +11982,8 @@
       "value": "$sprk-font-weight-body-one",
       "scope": "default",
       "line": {
-        "start": 1239,
-        "end": 1239
+        "start": 1242,
+        "end": 1242
       }
     },
     "access": "public",
@@ -11973,8 +11998,8 @@
   {
     "description": "The width of the right border on the Table header.\n",
     "commentRange": {
-      "start": 1240,
-      "end": 1240
+      "start": 1243,
+      "end": 1243
     },
     "context": {
       "type": "variable",
@@ -11982,8 +12007,8 @@
       "value": "2px",
       "scope": "default",
       "line": {
-        "start": 1241,
-        "end": 1241
+        "start": 1244,
+        "end": 1244
       }
     },
     "access": "public",
@@ -11998,8 +12023,8 @@
   {
     "description": "The color of the right border on the Table header.\n",
     "commentRange": {
-      "start": 1242,
-      "end": 1242
+      "start": 1245,
+      "end": 1245
     },
     "context": {
       "type": "variable",
@@ -12007,8 +12032,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1243,
-        "end": 1243
+        "start": 1246,
+        "end": 1246
       }
     },
     "access": "public",
@@ -12023,8 +12048,8 @@
   {
     "description": "The background color of empty Table headers.\n",
     "commentRange": {
-      "start": 1244,
-      "end": 1244
+      "start": 1247,
+      "end": 1247
     },
     "context": {
       "type": "variable",
@@ -12032,8 +12057,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1245,
-        "end": 1245
+        "start": 1248,
+        "end": 1248
       }
     },
     "access": "public",
@@ -12048,8 +12073,8 @@
   {
     "description": "The background color of Secondary Table headers.\n",
     "commentRange": {
-      "start": 1248,
-      "end": 1248
+      "start": 1251,
+      "end": 1251
     },
     "context": {
       "type": "variable",
@@ -12057,8 +12082,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1249,
-        "end": 1249
+        "start": 1252,
+        "end": 1252
       }
     },
     "access": "public",
@@ -12073,8 +12098,8 @@
   {
     "description": "The font color of Secondary Table headers.\n",
     "commentRange": {
-      "start": 1250,
-      "end": 1250
+      "start": 1253,
+      "end": 1253
     },
     "context": {
       "type": "variable",
@@ -12082,8 +12107,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1251,
-        "end": 1251
+        "start": 1254,
+        "end": 1254
       }
     },
     "access": "public",
@@ -12098,8 +12123,8 @@
   {
     "description": "The text alignment of Secondary Table headers.\n",
     "commentRange": {
-      "start": 1252,
-      "end": 1252
+      "start": 1255,
+      "end": 1255
     },
     "context": {
       "type": "variable",
@@ -12107,8 +12132,8 @@
       "value": "left",
       "scope": "default",
       "line": {
-        "start": 1253,
-        "end": 1253
+        "start": 1256,
+        "end": 1256
       }
     },
     "access": "public",
@@ -12123,8 +12148,8 @@
   {
     "description": "The text alignment of Secondary Table cells.\n",
     "commentRange": {
-      "start": 1254,
-      "end": 1254
+      "start": 1257,
+      "end": 1257
     },
     "context": {
       "type": "variable",
@@ -12132,8 +12157,8 @@
       "value": "left",
       "scope": "default",
       "line": {
-        "start": 1255,
-        "end": 1255
+        "start": 1258,
+        "end": 1258
       }
     },
     "access": "public",
@@ -12148,8 +12173,8 @@
   {
     "description": "The width of the right border on the Secondary Table header.\n",
     "commentRange": {
-      "start": 1256,
-      "end": 1256
+      "start": 1259,
+      "end": 1259
     },
     "context": {
       "type": "variable",
@@ -12157,8 +12182,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1257,
-        "end": 1257
+        "start": 1260,
+        "end": 1260
       }
     },
     "access": "public",
@@ -12173,8 +12198,8 @@
   {
     "description": "The color of the right border on the Secondary Table header.\n",
     "commentRange": {
-      "start": 1258,
-      "end": 1258
+      "start": 1261,
+      "end": 1261
     },
     "context": {
       "type": "variable",
@@ -12182,8 +12207,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1259,
-        "end": 1259
+        "start": 1262,
+        "end": 1262
       }
     },
     "access": "public",
@@ -12198,8 +12223,8 @@
   {
     "description": "The background color of the header in the Grouped Columns Table variant.\n",
     "commentRange": {
-      "start": 1262,
-      "end": 1262
+      "start": 1265,
+      "end": 1265
     },
     "context": {
       "type": "variable",
@@ -12207,8 +12232,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1263,
-        "end": 1263
+        "start": 1266,
+        "end": 1266
       }
     },
     "access": "public",
@@ -12223,8 +12248,8 @@
   {
     "description": "The font size of the header in the Grouped Columns Table variant.\n",
     "commentRange": {
-      "start": 1264,
-      "end": 1264
+      "start": 1267,
+      "end": 1267
     },
     "context": {
       "type": "variable",
@@ -12232,8 +12257,8 @@
       "value": "$sprk-font-size-body-four",
       "scope": "default",
       "line": {
-        "start": 1265,
-        "end": 1265
+        "start": 1268,
+        "end": 1268
       }
     },
     "access": "public",
@@ -12248,8 +12273,8 @@
   {
     "description": "The font weight of the header in the Grouped Columns Table variant.\n",
     "commentRange": {
-      "start": 1266,
-      "end": 1266
+      "start": 1269,
+      "end": 1269
     },
     "context": {
       "type": "variable",
@@ -12257,8 +12282,8 @@
       "value": "normal",
       "scope": "default",
       "line": {
-        "start": 1267,
-        "end": 1267
+        "start": 1270,
+        "end": 1270
       }
     },
     "access": "public",
@@ -12273,8 +12298,8 @@
   {
     "description": "The distance between the borders of\nadjacent cells in the Secondary Row\nComparison Table (horizontal | vertical).\n",
     "commentRange": {
-      "start": 1270,
-      "end": 1272
+      "start": 1273,
+      "end": 1275
     },
     "context": {
       "type": "variable",
@@ -12282,8 +12307,8 @@
       "value": "0 15px",
       "scope": "default",
       "line": {
-        "start": 1273,
-        "end": 1273
+        "start": 1276,
+        "end": 1276
       }
     },
     "access": "public",
@@ -12298,8 +12323,8 @@
   {
     "description": "The width of the borders in the Secondary Row Comparison Table cells.\n",
     "commentRange": {
-      "start": 1274,
-      "end": 1274
+      "start": 1277,
+      "end": 1277
     },
     "context": {
       "type": "variable",
@@ -12307,8 +12332,8 @@
       "value": "1px",
       "scope": "default",
       "line": {
-        "start": 1275,
-        "end": 1275
+        "start": 1278,
+        "end": 1278
       }
     },
     "access": "public",
@@ -12323,8 +12348,8 @@
   {
     "description": "The style of the borders in the Secondary Row Comparison Table cells.\n",
     "commentRange": {
-      "start": 1276,
-      "end": 1276
+      "start": 1279,
+      "end": 1279
     },
     "context": {
       "type": "variable",
@@ -12332,8 +12357,8 @@
       "value": "solid",
       "scope": "default",
       "line": {
-        "start": 1277,
-        "end": 1277
+        "start": 1280,
+        "end": 1280
       }
     },
     "access": "public",
@@ -12348,8 +12373,8 @@
   {
     "description": "The color of the borders in the Secondary Row Comparison Table cells.\n",
     "commentRange": {
-      "start": 1278,
-      "end": 1278
+      "start": 1281,
+      "end": 1281
     },
     "context": {
       "type": "variable",
@@ -12357,8 +12382,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1279,
-        "end": 1279
+        "start": 1282,
+        "end": 1282
       }
     },
     "access": "public",
@@ -12373,8 +12398,8 @@
   {
     "description": "The padding of the tiny Box object.\n",
     "commentRange": {
-      "start": 1285,
-      "end": 1285
+      "start": 1288,
+      "end": 1288
     },
     "context": {
       "type": "variable",
@@ -12382,8 +12407,8 @@
       "value": "$sprk-space-inset-xs",
       "scope": "default",
       "line": {
-        "start": 1286,
-        "end": 1286
+        "start": 1289,
+        "end": 1289
       }
     },
     "access": "public",
@@ -12398,8 +12423,8 @@
   {
     "description": "The padding of the small Box object.\n",
     "commentRange": {
-      "start": 1287,
-      "end": 1287
+      "start": 1290,
+      "end": 1290
     },
     "context": {
       "type": "variable",
@@ -12407,8 +12432,8 @@
       "value": "$sprk-space-inset-s",
       "scope": "default",
       "line": {
-        "start": 1288,
-        "end": 1288
+        "start": 1291,
+        "end": 1291
       }
     },
     "access": "public",
@@ -12423,8 +12448,8 @@
   {
     "description": "The padding of the default (medium) Box object.\n",
     "commentRange": {
-      "start": 1289,
-      "end": 1289
+      "start": 1292,
+      "end": 1292
     },
     "context": {
       "type": "variable",
@@ -12432,8 +12457,8 @@
       "value": "$sprk-space-inset-m",
       "scope": "default",
       "line": {
-        "start": 1290,
-        "end": 1290
+        "start": 1293,
+        "end": 1293
       }
     },
     "access": "public",
@@ -12448,8 +12473,8 @@
   {
     "description": "The padding of the large Box object.\n",
     "commentRange": {
-      "start": 1291,
-      "end": 1291
+      "start": 1294,
+      "end": 1294
     },
     "context": {
       "type": "variable",
@@ -12457,8 +12482,8 @@
       "value": "$sprk-space-inset-l",
       "scope": "default",
       "line": {
-        "start": 1292,
-        "end": 1292
+        "start": 1295,
+        "end": 1295
       }
     },
     "access": "public",
@@ -12473,8 +12498,8 @@
   {
     "description": "The padding of the huge Box object.\n",
     "commentRange": {
-      "start": 1293,
-      "end": 1293
+      "start": 1296,
+      "end": 1296
     },
     "context": {
       "type": "variable",
@@ -12482,8 +12507,8 @@
       "value": "$sprk-space-inset-xl",
       "scope": "default",
       "line": {
-        "start": 1294,
-        "end": 1294
+        "start": 1297,
+        "end": 1297
       }
     },
     "access": "public",
@@ -12498,8 +12523,8 @@
   {
     "description": "The gutter of the tiny Media object.\n",
     "commentRange": {
-      "start": 1300,
-      "end": 1300
+      "start": 1303,
+      "end": 1303
     },
     "context": {
       "type": "variable",
@@ -12507,8 +12532,8 @@
       "value": "$sprk-space-xs",
       "scope": "default",
       "line": {
-        "start": 1301,
-        "end": 1301
+        "start": 1304,
+        "end": 1304
       }
     },
     "access": "public",
@@ -12523,8 +12548,8 @@
   {
     "description": "The gutter of the small Media object.\n",
     "commentRange": {
-      "start": 1302,
-      "end": 1302
+      "start": 1305,
+      "end": 1305
     },
     "context": {
       "type": "variable",
@@ -12532,8 +12557,8 @@
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1303,
-        "end": 1303
+        "start": 1306,
+        "end": 1306
       }
     },
     "access": "public",
@@ -12548,8 +12573,8 @@
   {
     "description": "The gutter of the default (medium) Media object.\n",
     "commentRange": {
-      "start": 1304,
-      "end": 1304
+      "start": 1307,
+      "end": 1307
     },
     "context": {
       "type": "variable",
@@ -12557,8 +12582,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1305,
-        "end": 1305
+        "start": 1308,
+        "end": 1308
       }
     },
     "access": "public",
@@ -12573,8 +12598,8 @@
   {
     "description": "The gutter of the large Media object.\n",
     "commentRange": {
-      "start": 1306,
-      "end": 1306
+      "start": 1309,
+      "end": 1309
     },
     "context": {
       "type": "variable",
@@ -12582,8 +12607,8 @@
       "value": "$sprk-space-l",
       "scope": "default",
       "line": {
-        "start": 1307,
-        "end": 1307
+        "start": 1310,
+        "end": 1310
       }
     },
     "access": "public",
@@ -12598,8 +12623,8 @@
   {
     "description": "The gutter of the huge Media object.\n",
     "commentRange": {
-      "start": 1308,
-      "end": 1308
+      "start": 1311,
+      "end": 1311
     },
     "context": {
       "type": "variable",
@@ -12607,8 +12632,8 @@
       "value": "$sprk-space-xl",
       "scope": "default",
       "line": {
-        "start": 1309,
-        "end": 1309
+        "start": 1312,
+        "end": 1312
       }
     },
     "access": "public",
@@ -12623,8 +12648,8 @@
   {
     "description": "\nThe spacing of the tiny Stack object.\n",
     "commentRange": {
-      "start": 1313,
-      "end": 1314
+      "start": 1316,
+      "end": 1317
     },
     "context": {
       "type": "variable",
@@ -12632,8 +12657,8 @@
       "value": "$sprk-space-xs",
       "scope": "default",
       "line": {
-        "start": 1315,
-        "end": 1315
+        "start": 1318,
+        "end": 1318
       }
     },
     "access": "public",
@@ -12648,8 +12673,8 @@
   {
     "description": "The spacing of the small Stack object.\n",
     "commentRange": {
-      "start": 1316,
-      "end": 1316
+      "start": 1319,
+      "end": 1319
     },
     "context": {
       "type": "variable",
@@ -12657,8 +12682,8 @@
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1317,
-        "end": 1317
+        "start": 1320,
+        "end": 1320
       }
     },
     "access": "public",
@@ -12673,8 +12698,8 @@
   {
     "description": "The spacing of the medium Stack object.\n",
     "commentRange": {
-      "start": 1318,
-      "end": 1318
+      "start": 1321,
+      "end": 1321
     },
     "context": {
       "type": "variable",
@@ -12682,8 +12707,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1319,
-        "end": 1319
+        "start": 1322,
+        "end": 1322
       }
     },
     "access": "public",
@@ -12698,8 +12723,8 @@
   {
     "description": "The spacing of the large Stack object.\n",
     "commentRange": {
-      "start": 1320,
-      "end": 1320
+      "start": 1323,
+      "end": 1323
     },
     "context": {
       "type": "variable",
@@ -12707,8 +12732,8 @@
       "value": "$sprk-space-l",
       "scope": "default",
       "line": {
-        "start": 1321,
-        "end": 1321
+        "start": 1324,
+        "end": 1324
       }
     },
     "access": "public",
@@ -12723,8 +12748,8 @@
   {
     "description": "The spacing of the huge Stack object.\n",
     "commentRange": {
-      "start": 1322,
-      "end": 1322
+      "start": 1325,
+      "end": 1325
     },
     "context": {
       "type": "variable",
@@ -12732,8 +12757,8 @@
       "value": "$sprk-space-xl",
       "scope": "default",
       "line": {
-        "start": 1323,
-        "end": 1323
+        "start": 1326,
+        "end": 1326
       }
     },
     "access": "public",
@@ -12748,8 +12773,8 @@
   {
     "description": "The spacing of the Misc A Stack object.\n",
     "commentRange": {
-      "start": 1324,
-      "end": 1324
+      "start": 1327,
+      "end": 1327
     },
     "context": {
       "type": "variable",
@@ -12757,8 +12782,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 1325,
-        "end": 1325
+        "start": 1328,
+        "end": 1328
       }
     },
     "access": "public",
@@ -12773,8 +12798,8 @@
   {
     "description": "The spacing of the Misc B Stack object.\n",
     "commentRange": {
-      "start": 1326,
-      "end": 1326
+      "start": 1329,
+      "end": 1329
     },
     "context": {
       "type": "variable",
@@ -12782,8 +12807,8 @@
       "value": "$sprk-space-misc-b",
       "scope": "default",
       "line": {
-        "start": 1327,
-        "end": 1327
+        "start": 1330,
+        "end": 1330
       }
     },
     "access": "public",
@@ -12798,8 +12823,8 @@
   {
     "description": "The spacing of the Misc C Stack object.\n",
     "commentRange": {
-      "start": 1328,
-      "end": 1328
+      "start": 1331,
+      "end": 1331
     },
     "context": {
       "type": "variable",
@@ -12807,8 +12832,8 @@
       "value": "$sprk-space-misc-c",
       "scope": "default",
       "line": {
-        "start": 1329,
-        "end": 1329
+        "start": 1332,
+        "end": 1332
       }
     },
     "access": "public",
@@ -12823,38 +12848,13 @@
   {
     "description": "The spacing of the Misc D Stack object.\n",
     "commentRange": {
-      "start": 1330,
-      "end": 1330
+      "start": 1333,
+      "end": 1333
     },
     "context": {
       "type": "variable",
       "name": "sprk-stack-spacing-misc-d",
       "value": "$sprk-space-misc-d",
-      "scope": "default",
-      "line": {
-        "start": 1331,
-        "end": 1331
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The breakpoint for Stack objects\nthat split at the extra extra small point.\n",
-    "commentRange": {
-      "start": 1332,
-      "end": 1333
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-split-breakpoint-xxs",
-      "value": "20rem",
       "scope": "default",
       "line": {
         "start": 1334,
@@ -12871,15 +12871,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that\nsplit at the extra small point.\n",
+    "description": "The breakpoint for Stack objects\nthat split at the extra extra small point.\n",
     "commentRange": {
       "start": 1335,
       "end": 1336
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-xs",
-      "value": "30rem",
+      "name": "sprk-split-breakpoint-xxs",
+      "value": "20rem",
       "scope": "default",
       "line": {
         "start": 1337,
@@ -12896,15 +12896,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that split at the\nsmall point.\n",
+    "description": "The breakpoint for Stack objects that\nsplit at the extra small point.\n",
     "commentRange": {
       "start": 1338,
       "end": 1339
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-s",
-      "value": "42.5rem",
+      "name": "sprk-split-breakpoint-xs",
+      "value": "30rem",
       "scope": "default",
       "line": {
         "start": 1340,
@@ -12921,15 +12921,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that split at the\nmedium point.\n",
+    "description": "The breakpoint for Stack objects that split at the\nsmall point.\n",
     "commentRange": {
       "start": 1341,
       "end": 1342
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-m",
-      "value": "55rem",
+      "name": "sprk-split-breakpoint-s",
+      "value": "42.5rem",
       "scope": "default",
       "line": {
         "start": 1343,
@@ -12946,15 +12946,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that split at the\nlarge point.\n",
+    "description": "The breakpoint for Stack objects that split at the\nmedium point.\n",
     "commentRange": {
       "start": 1344,
       "end": 1345
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-l",
-      "value": "67.5rem",
+      "name": "sprk-split-breakpoint-m",
+      "value": "55rem",
       "scope": "default",
       "line": {
         "start": 1346,
@@ -12971,15 +12971,15 @@
     }
   },
   {
-    "description": "The breakpoint for Stack objects that split at the\nextra large point.\n",
+    "description": "The breakpoint for Stack objects that split at the\nlarge point.\n",
     "commentRange": {
       "start": 1347,
       "end": 1348
     },
     "context": {
       "type": "variable",
-      "name": "sprk-split-breakpoint-xl",
-      "value": "80rem",
+      "name": "sprk-split-breakpoint-l",
+      "value": "67.5rem",
       "scope": "default",
       "line": {
         "start": 1349,
@@ -12996,10 +12996,35 @@
     }
   },
   {
+    "description": "The breakpoint for Stack objects that split at the\nextra large point.\n",
+    "commentRange": {
+      "start": 1350,
+      "end": 1351
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-split-breakpoint-xl",
+      "value": "80rem",
+      "scope": "default",
+      "line": {
+        "start": 1352,
+        "end": 1352
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
     "description": "The value for color of Dividers.\n",
     "commentRange": {
-      "start": 1355,
-      "end": 1355
+      "start": 1358,
+      "end": 1358
     },
     "context": {
       "type": "variable",
@@ -13007,8 +13032,8 @@
       "value": "rgb(230, 230, 230)",
       "scope": "default",
       "line": {
-        "start": 1356,
-        "end": 1356
+        "start": 1359,
+        "end": 1359
       }
     },
     "access": "public",
@@ -13023,8 +13048,8 @@
   {
     "description": "The value of border for Dividers.\n",
     "commentRange": {
-      "start": 1357,
-      "end": 1357
+      "start": 1360,
+      "end": 1360
     },
     "context": {
       "type": "variable",
@@ -13032,8 +13057,8 @@
       "value": "2px solid $sprk-divider-color",
       "scope": "default",
       "line": {
-        "start": 1358,
-        "end": 1358
+        "start": 1361,
+        "end": 1361
       }
     },
     "access": "public",
@@ -13048,8 +13073,8 @@
   {
     "description": "The maximum width of Accordions.\n",
     "commentRange": {
-      "start": 1364,
-      "end": 1364
+      "start": 1367,
+      "end": 1367
     },
     "context": {
       "type": "variable",
@@ -13057,8 +13082,8 @@
       "value": "53.125rem",
       "scope": "default",
       "line": {
-        "start": 1365,
-        "end": 1365
+        "start": 1368,
+        "end": 1368
       }
     },
     "access": "public",
@@ -13073,8 +13098,8 @@
   {
     "description": "The border of Accordions.\n",
     "commentRange": {
-      "start": 1366,
-      "end": 1366
+      "start": 1369,
+      "end": 1369
     },
     "context": {
       "type": "variable",
@@ -13082,8 +13107,8 @@
       "value": "$sprk-divider-border",
       "scope": "default",
       "line": {
-        "start": 1367,
-        "end": 1367
+        "start": 1370,
+        "end": 1370
       }
     },
     "access": "public",
@@ -13098,8 +13123,8 @@
   {
     "description": "The font color of the Accordion item summary.\n",
     "commentRange": {
-      "start": 1368,
-      "end": 1368
+      "start": 1371,
+      "end": 1371
     },
     "context": {
       "type": "variable",
@@ -13107,8 +13132,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1369,
-        "end": 1369
+        "start": 1372,
+        "end": 1372
       }
     },
     "access": "public",
@@ -13123,8 +13148,8 @@
   {
     "description": "The background color of the Accordion item summary.\n",
     "commentRange": {
-      "start": 1370,
-      "end": 1370
+      "start": 1373,
+      "end": 1373
     },
     "context": {
       "type": "variable",
@@ -13132,8 +13157,8 @@
       "value": "transparent",
       "scope": "default",
       "line": {
-        "start": 1371,
-        "end": 1371
+        "start": 1374,
+        "end": 1374
       }
     },
     "access": "public",
@@ -13148,8 +13173,8 @@
   {
     "description": "The text-align value of the Accordion item summary.\n",
     "commentRange": {
-      "start": 1372,
-      "end": 1372
+      "start": 1375,
+      "end": 1375
     },
     "context": {
       "type": "variable",
@@ -13157,8 +13182,8 @@
       "value": "left",
       "scope": "default",
       "line": {
-        "start": 1373,
-        "end": 1373
+        "start": 1376,
+        "end": 1376
       }
     },
     "access": "public",
@@ -13173,38 +13198,13 @@
   {
     "description": "The border of the Accordion item summary.\n",
     "commentRange": {
-      "start": 1374,
-      "end": 1374
+      "start": 1377,
+      "end": 1377
     },
     "context": {
       "type": "variable",
       "name": "sprk-accordion-summary-border",
       "value": "none",
-      "scope": "default",
-      "line": {
-        "start": 1375,
-        "end": 1375
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the icon in the summary when the\nAccordion item is open or hovered.\n",
-    "commentRange": {
-      "start": 1376,
-      "end": 1377
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-accordion-summary-active-color",
-      "value": "$sprk-green",
       "scope": "default",
       "line": {
         "start": 1378,
@@ -13221,10 +13221,35 @@
     }
   },
   {
-    "description": "The padding of the Accordion summary.\n",
+    "description": "The color of the icon in the summary when the\nAccordion item is open or hovered.\n",
     "commentRange": {
       "start": 1379,
-      "end": 1379
+      "end": 1380
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-accordion-summary-active-color",
+      "value": "$sprk-green",
+      "scope": "default",
+      "line": {
+        "start": 1381,
+        "end": 1381
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The padding of the Accordion summary.\n",
+    "commentRange": {
+      "start": 1382,
+      "end": 1382
     },
     "context": {
       "type": "variable",
@@ -13232,8 +13257,8 @@
       "value": "$sprk-space-misc-a 0",
       "scope": "default",
       "line": {
-        "start": 1380,
-        "end": 1380
+        "start": 1383,
+        "end": 1383
       }
     },
     "access": "public",
@@ -13248,38 +13273,13 @@
   {
     "description": "The padding of the Accordion content.\n",
     "commentRange": {
-      "start": 1381,
-      "end": 1381
+      "start": 1384,
+      "end": 1384
     },
     "context": {
       "type": "variable",
       "name": "sprk-accordion-content-padding",
       "value": "0 0 $sprk-space-l",
-      "scope": "default",
-      "line": {
-        "start": 1382,
-        "end": 1382
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The background color used for hover\nand active on items in the Accordion.\n",
-    "commentRange": {
-      "start": 1383,
-      "end": 1384
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-accordion-active-background-color",
-      "value": "$sprk-gray",
       "scope": "default",
       "line": {
         "start": 1385,
@@ -13296,10 +13296,35 @@
     }
   },
   {
-    "description": "The text decoration of the Accordion item summary.\n",
+    "description": "The background color used for hover\nand active on items in the Accordion.\n",
     "commentRange": {
       "start": 1386,
-      "end": 1386
+      "end": 1387
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-accordion-active-background-color",
+      "value": "$sprk-gray",
+      "scope": "default",
+      "line": {
+        "start": 1388,
+        "end": 1388
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The text decoration of the Accordion item summary.\n",
+    "commentRange": {
+      "start": 1389,
+      "end": 1389
     },
     "context": {
       "type": "variable",
@@ -13307,8 +13332,8 @@
       "value": "none",
       "scope": "private",
       "line": {
-        "start": 1387,
-        "end": 1387
+        "start": 1390,
+        "end": 1390
       }
     },
     "access": "public",
@@ -13323,8 +13348,8 @@
   {
     "description": "The text decoration of the Accordion item summary when active.\n",
     "commentRange": {
-      "start": 1388,
-      "end": 1388
+      "start": 1391,
+      "end": 1391
     },
     "context": {
       "type": "variable",
@@ -13332,8 +13357,8 @@
       "value": "none",
       "scope": "private",
       "line": {
-        "start": 1389,
-        "end": 1389
+        "start": 1392,
+        "end": 1392
       }
     },
     "access": "public",
@@ -13348,8 +13373,8 @@
   {
     "description": "The top border style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1395,
-      "end": 1395
+      "start": 1398,
+      "end": 1398
     },
     "context": {
       "type": "variable",
@@ -13357,8 +13382,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1396,
-        "end": 1396
+        "start": 1399,
+        "end": 1399
       }
     },
     "access": "public",
@@ -13373,8 +13398,8 @@
   {
     "description": "The right border style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1397,
-      "end": 1397
+      "start": 1400,
+      "end": 1400
     },
     "context": {
       "type": "variable",
@@ -13382,8 +13407,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1398,
-        "end": 1398
+        "start": 1401,
+        "end": 1401
       }
     },
     "access": "public",
@@ -13398,8 +13423,8 @@
   {
     "description": "The bottom border style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1399,
-      "end": 1399
+      "start": 1402,
+      "end": 1402
     },
     "context": {
       "type": "variable",
@@ -13407,8 +13432,8 @@
       "value": "$sprk-link-has-icon-border-bottom",
       "scope": "default",
       "line": {
-        "start": 1400,
-        "end": 1400
+        "start": 1403,
+        "end": 1403
       }
     },
     "access": "public",
@@ -13423,8 +13448,8 @@
   {
     "description": "The left border style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1401,
-      "end": 1401
+      "start": 1404,
+      "end": 1404
     },
     "context": {
       "type": "variable",
@@ -13432,8 +13457,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1402,
-        "end": 1402
+        "start": 1405,
+        "end": 1405
       }
     },
     "access": "public",
@@ -13448,8 +13473,8 @@
   {
     "description": "The text decoration style Toggle Trigger.\n",
     "commentRange": {
-      "start": 1403,
-      "end": 1403
+      "start": 1406,
+      "end": 1406
     },
     "context": {
       "type": "variable",
@@ -13457,8 +13482,8 @@
       "value": "$sprk-link-text-decoration",
       "scope": "default",
       "line": {
-        "start": 1404,
-        "end": 1404
+        "start": 1407,
+        "end": 1407
       }
     },
     "access": "public",
@@ -13473,8 +13498,8 @@
   {
     "description": "The transition for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1405,
-      "end": 1405
+      "start": 1408,
+      "end": 1408
     },
     "context": {
       "type": "variable",
@@ -13482,8 +13507,8 @@
       "value": "$sprk-link-transition",
       "scope": "default",
       "line": {
-        "start": 1406,
-        "end": 1406
+        "start": 1409,
+        "end": 1409
       }
     },
     "access": "public",
@@ -13498,8 +13523,8 @@
   {
     "description": "The hover border bottom style for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1407,
-      "end": 1407
+      "start": 1410,
+      "end": 1410
     },
     "context": {
       "type": "variable",
@@ -13507,8 +13532,8 @@
       "value": "$sprk-link-has-icon-hover-border-bottom",
       "scope": "default",
       "line": {
-        "start": 1408,
-        "end": 1408
+        "start": 1411,
+        "end": 1411
       }
     },
     "access": "public",
@@ -13523,8 +13548,8 @@
   {
     "description": "The hover text color for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1409,
-      "end": 1409
+      "start": 1412,
+      "end": 1412
     },
     "context": {
       "type": "variable",
@@ -13532,8 +13557,8 @@
       "value": "$sprk-link-has-icon-hover-color-text",
       "scope": "default",
       "line": {
-        "start": 1410,
-        "end": 1410
+        "start": 1413,
+        "end": 1413
       }
     },
     "access": "public",
@@ -13548,8 +13573,8 @@
   {
     "description": "The background color for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1411,
-      "end": 1411
+      "start": 1414,
+      "end": 1414
     },
     "context": {
       "type": "variable",
@@ -13557,8 +13582,8 @@
       "value": "transparent",
       "scope": "default",
       "line": {
-        "start": 1412,
-        "end": 1412
+        "start": 1415,
+        "end": 1415
       }
     },
     "access": "public",
@@ -13573,8 +13598,8 @@
   {
     "description": "The padding top for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1413,
-      "end": 1413
+      "start": 1416,
+      "end": 1416
     },
     "context": {
       "type": "variable",
@@ -13582,8 +13607,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1414,
-        "end": 1414
+        "start": 1417,
+        "end": 1417
       }
     },
     "access": "public",
@@ -13598,8 +13623,8 @@
   {
     "description": "The padding right for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1415,
-      "end": 1415
+      "start": 1418,
+      "end": 1418
     },
     "context": {
       "type": "variable",
@@ -13607,8 +13632,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1416,
-        "end": 1416
+        "start": 1419,
+        "end": 1419
       }
     },
     "access": "public",
@@ -13623,8 +13648,8 @@
   {
     "description": "The padding bottom for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1417,
-      "end": 1417
+      "start": 1420,
+      "end": 1420
     },
     "context": {
       "type": "variable",
@@ -13632,8 +13657,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1418,
-        "end": 1418
+        "start": 1421,
+        "end": 1421
       }
     },
     "access": "public",
@@ -13648,8 +13673,8 @@
   {
     "description": "The padding left for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1419,
-      "end": 1419
+      "start": 1422,
+      "end": 1422
     },
     "context": {
       "type": "variable",
@@ -13657,8 +13682,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1420,
-        "end": 1420
+        "start": 1423,
+        "end": 1423
       }
     },
     "access": "public",
@@ -13673,8 +13698,8 @@
   {
     "description": "The text alignment for Toggle Trigger.\n",
     "commentRange": {
-      "start": 1421,
-      "end": 1421
+      "start": 1424,
+      "end": 1424
     },
     "context": {
       "type": "variable",
@@ -13682,8 +13707,8 @@
       "value": "left",
       "scope": "default",
       "line": {
-        "start": 1422,
-        "end": 1422
+        "start": 1425,
+        "end": 1425
       }
     },
     "access": "public",
@@ -13698,8 +13723,8 @@
   {
     "description": "The font size for small Toggle Trigger.\n",
     "commentRange": {
-      "start": 1423,
-      "end": 1423
+      "start": 1426,
+      "end": 1426
     },
     "context": {
       "type": "variable",
@@ -13707,8 +13732,8 @@
       "value": "$sprk-font-size-body-four",
       "scope": "default",
       "line": {
-        "start": 1424,
-        "end": 1424
+        "start": 1427,
+        "end": 1427
       }
     },
     "access": "public",
@@ -13723,8 +13748,8 @@
   {
     "description": "The font weight for small Toggle Trigger.\n",
     "commentRange": {
-      "start": 1425,
-      "end": 1425
+      "start": 1428,
+      "end": 1428
     },
     "context": {
       "type": "variable",
@@ -13732,8 +13757,8 @@
       "value": "normal",
       "scope": "default",
       "line": {
-        "start": 1426,
-        "end": 1426
+        "start": 1429,
+        "end": 1429
       }
     },
     "access": "public",
@@ -13748,8 +13773,8 @@
   {
     "description": "The transition timing for the\nrotation of the icon when the Toggle is opened.\n",
     "commentRange": {
-      "start": 1428,
-      "end": 1429
+      "start": 1431,
+      "end": 1432
     },
     "context": {
       "type": "variable",
@@ -13757,8 +13782,8 @@
       "value": "0.3s ease",
       "scope": "default",
       "line": {
-        "start": 1430,
-        "end": 1430
+        "start": 1433,
+        "end": 1433
       }
     },
     "access": "public",
@@ -13773,8 +13798,8 @@
   {
     "description": "Background color of the Dropdown items that\nare active or hovered.\n",
     "commentRange": {
-      "start": 1437,
-      "end": 1438
+      "start": 1440,
+      "end": 1441
     },
     "context": {
       "type": "variable",
@@ -13782,8 +13807,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1439,
-        "end": 1439
+        "start": 1442,
+        "end": 1442
       }
     },
     "access": "public",
@@ -13798,8 +13823,8 @@
   {
     "description": "The left border of the Dropdown item that is active.\n",
     "commentRange": {
-      "start": 1440,
-      "end": 1440
+      "start": 1443,
+      "end": 1443
     },
     "context": {
       "type": "variable",
@@ -13807,8 +13832,8 @@
       "value": "2.5px solid $sprk-green",
       "scope": "default",
       "line": {
-        "start": 1441,
-        "end": 1441
+        "start": 1444,
+        "end": 1444
       }
     },
     "access": "public",
@@ -13823,8 +13848,8 @@
   {
     "description": "The box-shadow of the Dropdown item that is active.\n",
     "commentRange": {
-      "start": 1442,
-      "end": 1442
+      "start": 1445,
+      "end": 1445
     },
     "context": {
       "type": "variable",
@@ -13832,8 +13857,8 @@
       "value": "-1px 0 0 0 $sprk-green",
       "scope": "default",
       "line": {
-        "start": 1443,
-        "end": 1443
+        "start": 1446,
+        "end": 1446
       }
     },
     "access": "public",
@@ -13848,8 +13873,8 @@
   {
     "description": "The border of the Dropdown.\n",
     "commentRange": {
-      "start": 1444,
-      "end": 1444
+      "start": 1447,
+      "end": 1447
     },
     "context": {
       "type": "variable",
@@ -13857,8 +13882,8 @@
       "value": "1px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1445,
-        "end": 1445
+        "start": 1448,
+        "end": 1448
       }
     },
     "access": "public",
@@ -13873,8 +13898,8 @@
   {
     "description": "The font size of the Dropdown.\n",
     "commentRange": {
-      "start": 1446,
-      "end": 1446
+      "start": 1449,
+      "end": 1449
     },
     "context": {
       "type": "variable",
@@ -13882,8 +13907,8 @@
       "value": "$sprk-font-size-body-one",
       "scope": "default",
       "line": {
-        "start": 1447,
-        "end": 1447
+        "start": 1450,
+        "end": 1450
       }
     },
     "access": "public",
@@ -13898,38 +13923,13 @@
   {
     "description": "The font weight of the Dropdown.\n",
     "commentRange": {
-      "start": 1448,
-      "end": 1448
+      "start": 1451,
+      "end": 1451
     },
     "context": {
       "type": "variable",
       "name": "sprk-dropdown-font-weight",
       "value": "400",
-      "scope": "default",
-      "line": {
-        "start": 1449,
-        "end": 1449
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding around the Informational Dropdown\nfooter.\n",
-    "commentRange": {
-      "start": 1450,
-      "end": 1451
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-dropdown-footer-padding",
-      "value": "$sprk-space-inset-short-l",
       "scope": "default",
       "line": {
         "start": 1452,
@@ -13946,10 +13946,35 @@
     }
   },
   {
-    "description": "The line height of the Dropdown.\n",
+    "description": "The padding around the Informational Dropdown\nfooter.\n",
     "commentRange": {
       "start": 1453,
-      "end": 1453
+      "end": 1454
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-dropdown-footer-padding",
+      "value": "$sprk-space-inset-short-l",
+      "scope": "default",
+      "line": {
+        "start": 1455,
+        "end": 1455
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The line height of the Dropdown.\n",
+    "commentRange": {
+      "start": 1456,
+      "end": 1456
     },
     "context": {
       "type": "variable",
@@ -13957,8 +13982,8 @@
       "value": "1",
       "scope": "default",
       "line": {
-        "start": 1454,
-        "end": 1454
+        "start": 1457,
+        "end": 1457
       }
     },
     "access": "public",
@@ -13973,8 +13998,8 @@
   {
     "description": "The max-width of the Dropdown.\n",
     "commentRange": {
-      "start": 1455,
-      "end": 1455
+      "start": 1458,
+      "end": 1458
     },
     "context": {
       "type": "variable",
@@ -13982,8 +14007,8 @@
       "value": "24rem",
       "scope": "default",
       "line": {
-        "start": 1456,
-        "end": 1456
+        "start": 1459,
+        "end": 1459
       }
     },
     "access": "public",
@@ -13998,8 +14023,8 @@
   {
     "description": "The padding around the Dropdown items.\n",
     "commentRange": {
-      "start": 1457,
-      "end": 1457
+      "start": 1460,
+      "end": 1460
     },
     "context": {
       "type": "variable",
@@ -14007,8 +14032,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 1458,
-        "end": 1458
+        "start": 1461,
+        "end": 1461
       }
     },
     "access": "public",
@@ -14023,8 +14048,8 @@
   {
     "description": "The box shadow of the Dropdown.\n",
     "commentRange": {
-      "start": 1459,
-      "end": 1459
+      "start": 1462,
+      "end": 1462
     },
     "context": {
       "type": "variable",
@@ -14032,8 +14057,8 @@
       "value": "0 0 40px 2px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1460,
-        "end": 1460
+        "start": 1463,
+        "end": 1463
       }
     },
     "access": "public",
@@ -14048,8 +14073,8 @@
   {
     "description": "The color of the Dropdown title.\n",
     "commentRange": {
-      "start": 1461,
-      "end": 1461
+      "start": 1464,
+      "end": 1464
     },
     "context": {
       "type": "variable",
@@ -14057,8 +14082,8 @@
       "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
-        "start": 1462,
-        "end": 1462
+        "start": 1465,
+        "end": 1465
       }
     },
     "access": "public",
@@ -14073,8 +14098,8 @@
   {
     "description": "The font size of the Dropdown title.\n",
     "commentRange": {
-      "start": 1463,
-      "end": 1463
+      "start": 1466,
+      "end": 1466
     },
     "context": {
       "type": "variable",
@@ -14082,8 +14107,8 @@
       "value": "$sprk-dropdown-font-size",
       "scope": "default",
       "line": {
-        "start": 1464,
-        "end": 1464
+        "start": 1467,
+        "end": 1467
       }
     },
     "access": "public",
@@ -14098,8 +14123,8 @@
   {
     "description": "The font weight of the Dropdown title.\n",
     "commentRange": {
-      "start": 1465,
-      "end": 1465
+      "start": 1468,
+      "end": 1468
     },
     "context": {
       "type": "variable",
@@ -14107,8 +14132,8 @@
       "value": "300",
       "scope": "default",
       "line": {
-        "start": 1466,
-        "end": 1466
+        "start": 1469,
+        "end": 1469
       }
     },
     "access": "public",
@@ -14123,8 +14148,8 @@
   {
     "description": "The color of the mask overlay that is shown behind the Modal.\n",
     "commentRange": {
-      "start": 1472,
-      "end": 1472
+      "start": 1475,
+      "end": 1475
     },
     "context": {
       "type": "variable",
@@ -14132,8 +14157,8 @@
       "value": "rgba(34, 34, 34, 0.35)",
       "scope": "default",
       "line": {
-        "start": 1473,
-        "end": 1473
+        "start": 1476,
+        "end": 1476
       }
     },
     "access": "public",
@@ -14148,8 +14173,8 @@
   {
     "description": "The background color of the Modal.\n",
     "commentRange": {
-      "start": 1474,
-      "end": 1474
+      "start": 1477,
+      "end": 1477
     },
     "context": {
       "type": "variable",
@@ -14157,8 +14182,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1475,
-        "end": 1475
+        "start": 1478,
+        "end": 1478
       }
     },
     "access": "public",
@@ -14173,8 +14198,8 @@
   {
     "description": "The maximum width of the Modal.\n",
     "commentRange": {
-      "start": 1476,
-      "end": 1476
+      "start": 1479,
+      "end": 1479
     },
     "context": {
       "type": "variable",
@@ -14182,8 +14207,8 @@
       "value": "43.75rem",
       "scope": "default",
       "line": {
-        "start": 1477,
-        "end": 1477
+        "start": 1480,
+        "end": 1480
       }
     },
     "access": "public",
@@ -14198,8 +14223,8 @@
   {
     "description": "The maximum height of the Modal.\n",
     "commentRange": {
-      "start": 1478,
-      "end": 1478
+      "start": 1481,
+      "end": 1481
     },
     "context": {
       "type": "variable",
@@ -14207,8 +14232,8 @@
       "value": "70%",
       "scope": "default",
       "line": {
-        "start": 1479,
-        "end": 1479
+        "start": 1482,
+        "end": 1482
       }
     },
     "access": "public",
@@ -14223,8 +14248,8 @@
   {
     "description": "Determines how far down\nfrom the top of the page the\nModal renders at the small breakpoint.\n",
     "commentRange": {
-      "start": 1480,
-      "end": 1482
+      "start": 1483,
+      "end": 1485
     },
     "context": {
       "type": "variable",
@@ -14232,8 +14257,8 @@
       "value": "25rem",
       "scope": "default",
       "line": {
-        "start": 1483,
-        "end": 1483
+        "start": 1486,
+        "end": 1486
       }
     },
     "access": "public",
@@ -14248,8 +14273,8 @@
   {
     "description": "Determines how far down\nfrom the top of the page the\nModal renders at the medium breakpoint.\n",
     "commentRange": {
-      "start": 1484,
-      "end": 1486
+      "start": 1487,
+      "end": 1489
     },
     "context": {
       "type": "variable",
@@ -14257,8 +14282,8 @@
       "value": "37.5rem",
       "scope": "default",
       "line": {
-        "start": 1487,
-        "end": 1487
+        "start": 1490,
+        "end": 1490
       }
     },
     "access": "public",
@@ -14273,8 +14298,8 @@
   {
     "description": "The box shadow on the Modal.\n",
     "commentRange": {
-      "start": 1488,
-      "end": 1488
+      "start": 1491,
+      "end": 1491
     },
     "context": {
       "type": "variable",
@@ -14282,8 +14307,8 @@
       "value": "0 4px 5px rgba(0, 0, 0, 0.6)",
       "scope": "default",
       "line": {
-        "start": 1489,
-        "end": 1489
+        "start": 1492,
+        "end": 1492
       }
     },
     "access": "public",
@@ -14298,8 +14323,8 @@
   {
     "description": "The border radius on the Modal.\n",
     "commentRange": {
-      "start": 1490,
-      "end": 1490
+      "start": 1493,
+      "end": 1493
     },
     "context": {
       "type": "variable",
@@ -14307,8 +14332,8 @@
       "value": "8px",
       "scope": "default",
       "line": {
-        "start": 1491,
-        "end": 1491
+        "start": 1494,
+        "end": 1494
       }
     },
     "access": "public",
@@ -14323,8 +14348,8 @@
   {
     "description": "The width of the menu icon on narrow viewports in the Masthead.\n",
     "commentRange": {
-      "start": 1497,
-      "end": 1497
+      "start": 1500,
+      "end": 1500
     },
     "context": {
       "type": "variable",
@@ -14332,8 +14357,8 @@
       "value": "$sprk-icon-l",
       "scope": "default",
       "line": {
-        "start": 1498,
-        "end": 1498
+        "start": 1501,
+        "end": 1501
       }
     },
     "access": "public",
@@ -14348,8 +14373,8 @@
   {
     "description": "The height of the menu icon on narrow viewports in the Masthead.\n",
     "commentRange": {
-      "start": 1499,
-      "end": 1499
+      "start": 1502,
+      "end": 1502
     },
     "context": {
       "type": "variable",
@@ -14357,8 +14382,8 @@
       "value": "$sprk-icon-l",
       "scope": "default",
       "line": {
-        "start": 1500,
-        "end": 1500
+        "start": 1503,
+        "end": 1503
       }
     },
     "access": "public",
@@ -14373,8 +14398,8 @@
   {
     "description": "The background color of the Masthead.\n",
     "commentRange": {
-      "start": 1501,
-      "end": 1501
+      "start": 1504,
+      "end": 1504
     },
     "context": {
       "type": "variable",
@@ -14382,8 +14407,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1502,
-        "end": 1502
+        "start": 1505,
+        "end": 1505
       }
     },
     "access": "public",
@@ -14398,37 +14423,12 @@
   {
     "description": "The padding of the Masthead content, menu, and branding sections.\n",
     "commentRange": {
-      "start": 1503,
-      "end": 1503
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-content-padding",
-      "value": "$sprk-space-s",
-      "scope": "default",
-      "line": {
-        "start": 1504,
-        "end": 1504
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The padding top around the content items in the\ncontent section of the Masthead.\n",
-    "commentRange": {
-      "start": 1505,
+      "start": 1506,
       "end": 1506
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-top",
+      "name": "sprk-masthead-content-padding",
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
@@ -14446,14 +14446,14 @@
     }
   },
   {
-    "description": "The padding bottom around the content\nitems in the content section of the Masthead.\n",
+    "description": "The padding top around the content items in the\ncontent section of the Masthead.\n",
     "commentRange": {
       "start": 1508,
       "end": 1509
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-bottom",
+      "name": "sprk-masthead-content-item-padding-top",
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
@@ -14471,14 +14471,14 @@
     }
   },
   {
-    "description": "The padding right around the content items in the\ncontent section of the Masthead.\n",
+    "description": "The padding bottom around the content\nitems in the content section of the Masthead.\n",
     "commentRange": {
       "start": 1511,
       "end": 1512
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-right",
+      "name": "sprk-masthead-content-item-padding-bottom",
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
@@ -14496,19 +14496,19 @@
     }
   },
   {
-    "description": "The padding around the content\nsection in the Masthead on wide viewports.\n",
+    "description": "The padding right around the content items in the\ncontent section of the Masthead.\n",
     "commentRange": {
-      "start": 1517,
-      "end": 1518
+      "start": 1514,
+      "end": 1515
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-padding-wide",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-content-item-padding-right",
+      "value": "$sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1519,
-        "end": 1519
+        "start": 1516,
+        "end": 1516
       }
     },
     "access": "public",
@@ -14521,15 +14521,15 @@
     }
   },
   {
-    "description": "The padding top of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The padding around the content\nsection in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1520,
       "end": 1521
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-top-wide",
-      "value": "$sprk-space-s",
+      "name": "sprk-masthead-content-padding-wide",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
         "start": 1522,
@@ -14546,14 +14546,14 @@
     }
   },
   {
-    "description": "The padding bottom of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The padding top of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1523,
       "end": 1524
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-bottom-wide",
+      "name": "sprk-masthead-content-item-padding-top-wide",
       "value": "$sprk-space-s",
       "scope": "default",
       "line": {
@@ -14571,15 +14571,15 @@
     }
   },
   {
-    "description": "The padding right of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The padding bottom of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1526,
       "end": 1527
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-right-wide",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-content-item-padding-bottom-wide",
+      "value": "$sprk-space-s",
       "scope": "default",
       "line": {
         "start": 1528,
@@ -14596,14 +14596,14 @@
     }
   },
   {
-    "description": "The padding left of the content\nitems in the content section in the Masthead on wide viewports.\n",
+    "description": "The padding right of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1529,
       "end": 1530
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-content-item-padding-left-wide",
+      "name": "sprk-masthead-content-item-padding-right-wide",
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
@@ -14621,10 +14621,35 @@
     }
   },
   {
-    "description": "The visited state color of Masthead links.\n",
+    "description": "The padding left of the content\nitems in the content section in the Masthead on wide viewports.\n",
     "commentRange": {
       "start": 1532,
-      "end": 1532
+      "end": 1533
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-content-item-padding-left-wide",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1534,
+        "end": 1534
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The visited state color of Masthead links.\n",
+    "commentRange": {
+      "start": 1535,
+      "end": 1535
     },
     "context": {
       "type": "variable",
@@ -14632,8 +14657,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1533,
-        "end": 1533
+        "start": 1536,
+        "end": 1536
       }
     },
     "access": "public",
@@ -14648,8 +14673,8 @@
   {
     "description": "The hover state color of Masthead links.\n",
     "commentRange": {
-      "start": 1534,
-      "end": 1534
+      "start": 1537,
+      "end": 1537
     },
     "context": {
       "type": "variable",
@@ -14657,8 +14682,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 1535,
-        "end": 1535
+        "start": 1538,
+        "end": 1538
       }
     },
     "access": "public",
@@ -14673,8 +14698,8 @@
   {
     "description": "The font weight for Masthead links.\n",
     "commentRange": {
-      "start": 1536,
-      "end": 1536
+      "start": 1539,
+      "end": 1539
     },
     "context": {
       "type": "variable",
@@ -14682,8 +14707,8 @@
       "value": "500",
       "scope": "default",
       "line": {
-        "start": 1537,
-        "end": 1537
+        "start": 1540,
+        "end": 1540
       }
     },
     "access": "public",
@@ -14698,8 +14723,8 @@
   {
     "description": "The size of the bottom border on the Masthead.\n",
     "commentRange": {
-      "start": 1538,
-      "end": 1538
+      "start": 1541,
+      "end": 1541
     },
     "context": {
       "type": "variable",
@@ -14707,8 +14732,8 @@
       "value": "1px",
       "scope": "default",
       "line": {
-        "start": 1539,
-        "end": 1539
+        "start": 1542,
+        "end": 1542
       }
     },
     "access": "public",
@@ -14723,8 +14748,8 @@
   {
     "description": "The bottom border on the Masthead.\n",
     "commentRange": {
-      "start": 1540,
-      "end": 1540
+      "start": 1543,
+      "end": 1543
     },
     "context": {
       "type": "variable",
@@ -14732,8 +14757,8 @@
       "value": "$sprk-masthead-border-bottom-size solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1541,
-        "end": 1541
+        "start": 1544,
+        "end": 1544
       }
     },
     "access": "public",
@@ -14748,8 +14773,8 @@
   {
     "description": "The bottom border on the Masthead on wide viewports.\n",
     "commentRange": {
-      "start": 1542,
-      "end": 1542
+      "start": 1545,
+      "end": 1545
     },
     "context": {
       "type": "variable",
@@ -14757,8 +14782,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1543,
-        "end": 1543
+        "start": 1546,
+        "end": 1546
       }
     },
     "access": "public",
@@ -14773,8 +14798,8 @@
   {
     "description": "The right border on the site links in the Masthead.\n",
     "commentRange": {
-      "start": 1544,
-      "end": 1544
+      "start": 1547,
+      "end": 1547
     },
     "context": {
       "type": "variable",
@@ -14782,8 +14807,8 @@
       "value": "2px solid $sprk-black-tint-25",
       "scope": "default",
       "line": {
-        "start": 1545,
-        "end": 1545
+        "start": 1548,
+        "end": 1548
       }
     },
     "access": "public",
@@ -14798,8 +14823,8 @@
   {
     "description": "The point at which the Masthead navigation switches\nfrom narrow viewport style to large viewport\nstyle.\n",
     "commentRange": {
-      "start": 1546,
-      "end": 1548
+      "start": 1549,
+      "end": 1551
     },
     "context": {
       "type": "variable",
@@ -14807,8 +14832,8 @@
       "value": "54rem",
       "scope": "default",
       "line": {
-        "start": 1549,
-        "end": 1549
+        "start": 1552,
+        "end": 1552
       }
     },
     "access": "public",
@@ -14823,8 +14848,8 @@
   {
     "description": "The maximum width of the Masthead.\n",
     "commentRange": {
-      "start": 1550,
-      "end": 1550
+      "start": 1553,
+      "end": 1553
     },
     "context": {
       "type": "variable",
@@ -14832,8 +14857,8 @@
       "value": "89rem",
       "scope": "default",
       "line": {
-        "start": 1551,
-        "end": 1551
+        "start": 1554,
+        "end": 1554
       }
     },
     "access": "public",
@@ -14848,8 +14873,8 @@
   {
     "description": "The maximum width of the logo in the Masthead.\n",
     "commentRange": {
-      "start": 1552,
-      "end": 1552
+      "start": 1555,
+      "end": 1555
     },
     "context": {
       "type": "variable",
@@ -14857,8 +14882,8 @@
       "value": "192px",
       "scope": "default",
       "line": {
-        "start": 1553,
-        "end": 1553
+        "start": 1556,
+        "end": 1556
       }
     },
     "access": "public",
@@ -14873,8 +14898,8 @@
   {
     "description": "The minimum width of the logo in the Masthead.\n",
     "commentRange": {
-      "start": 1554,
-      "end": 1554
+      "start": 1557,
+      "end": 1557
     },
     "context": {
       "type": "variable",
@@ -14882,8 +14907,8 @@
       "value": "174px",
       "scope": "default",
       "line": {
-        "start": 1555,
-        "end": 1555
+        "start": 1558,
+        "end": 1558
       }
     },
     "access": "public",
@@ -14898,8 +14923,8 @@
   {
     "description": "The box shadow of the Masthead.\n",
     "commentRange": {
-      "start": 1556,
-      "end": 1556
+      "start": 1559,
+      "end": 1559
     },
     "context": {
       "type": "variable",
@@ -14907,8 +14932,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1557,
-        "end": 1557
+        "start": 1560,
+        "end": 1560
       }
     },
     "access": "public",
@@ -14923,8 +14948,8 @@
   {
     "description": "The box shadow of the Masthead in wide viewports.\n",
     "commentRange": {
-      "start": 1558,
-      "end": 1558
+      "start": 1561,
+      "end": 1561
     },
     "context": {
       "type": "variable",
@@ -14932,8 +14957,8 @@
       "value": "none",
       "scope": "default",
       "line": {
-        "start": 1559,
-        "end": 1559
+        "start": 1562,
+        "end": 1562
       }
     },
     "access": "public",
@@ -14948,8 +14973,8 @@
   {
     "description": "The Masthead shadow that gets applied when the page is scrolled.\n",
     "commentRange": {
-      "start": 1560,
-      "end": 1560
+      "start": 1563,
+      "end": 1563
     },
     "context": {
       "type": "variable",
@@ -14957,8 +14982,8 @@
       "value": "0 0 40px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1561,
-        "end": 1561
+        "start": 1564,
+        "end": 1564
       }
     },
     "access": "public",
@@ -14973,38 +14998,13 @@
   {
     "description": "The border of the selector in the Masthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1562,
-      "end": 1562
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-selector-border",
-      "value": "2px solid $sprk-black-tint-25",
-      "scope": "default",
-      "line": {
-        "start": 1563,
-        "end": 1563
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border radius of the selector in the Masthead with Extended Navigation.\n",
-    "commentRange": {
       "start": 1565,
       "end": 1565
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-border-radius",
-      "value": "5px",
+      "name": "sprk-masthead-selector-border",
+      "value": "2px solid $sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1566,
@@ -15021,10 +15021,35 @@
     }
   },
   {
+    "description": "The border radius of the selector in the Masthead with Extended Navigation.\n",
+    "commentRange": {
+      "start": 1568,
+      "end": 1568
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-selector-border-radius",
+      "value": "5px",
+      "scope": "default",
+      "line": {
+        "start": 1569,
+        "end": 1569
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
     "description": "The bottom border that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1567,
-      "end": 1569
+      "start": 1570,
+      "end": 1572
     },
     "context": {
       "type": "variable",
@@ -15032,8 +15057,8 @@
       "value": "2px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1570,
-        "end": 1570
+        "start": 1573,
+        "end": 1573
       }
     },
     "access": "public",
@@ -15048,8 +15073,8 @@
   {
     "description": "The box shadow that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1571,
-      "end": 1573
+      "start": 1574,
+      "end": 1576
     },
     "context": {
       "type": "variable",
@@ -15057,8 +15082,8 @@
       "value": "0 5px 10px\n  rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1574,
-        "end": 1575
+        "start": 1577,
+        "end": 1578
       }
     },
     "access": "public",
@@ -15073,38 +15098,13 @@
   {
     "description": "The border color that gets applied to\nthe selector dropdown when open in the\nMasthead with Extended Navigation.\n",
     "commentRange": {
-      "start": 1576,
-      "end": 1578
+      "start": 1579,
+      "end": 1581
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-selector-border-color-mask-open",
       "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1579,
-        "end": 1579
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font color of the selector in\nthe Masthead with Extended Navigation.\n",
-    "commentRange": {
-      "start": 1580,
-      "end": 1581
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-selector-font-color",
-      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1582,
@@ -15121,15 +15121,15 @@
     }
   },
   {
-    "description": "The background color of the selector in\nthe Masthead with Extended Navigation.\n",
+    "description": "The font color of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1583,
       "end": 1584
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-bg-color",
-      "value": "$sprk-white",
+      "name": "sprk-masthead-selector-font-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1585,
@@ -15146,15 +15146,15 @@
     }
   },
   {
-    "description": "The padding of the selector in\nthe Masthead with Extended Navigation.\n",
+    "description": "The background color of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1586,
       "end": 1587
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-padding",
-      "value": "$sprk-space-inset-short-m",
+      "name": "sprk-masthead-selector-bg-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1588,
@@ -15171,15 +15171,15 @@
     }
   },
   {
-    "description": "The padding of the selector dropdown in\nthe Masthead with Extended Navigation.\n",
+    "description": "The padding of the selector in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1589,
       "end": 1590
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-dropdown-padding",
-      "value": "0",
+      "name": "sprk-masthead-selector-padding",
+      "value": "$sprk-space-inset-short-m",
       "scope": "default",
       "line": {
         "start": 1591,
@@ -15196,15 +15196,15 @@
     }
   },
   {
-    "description": "The minimum width of the selector\nin the Masthead with Extended Navigation.\n",
+    "description": "The padding of the selector dropdown in\nthe Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1592,
       "end": 1593
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-selector-min-width",
-      "value": "17rem",
+      "name": "sprk-masthead-selector-dropdown-padding",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1594,
@@ -15221,10 +15221,35 @@
     }
   },
   {
-    "description": "This is the height of the Masthead on\nnarrow viewports and is used to calculate\nhow far from the top the narrow\nnavigation items should be displayed.\n",
+    "description": "The minimum width of the selector\nin the Masthead with Extended Navigation.\n",
     "commentRange": {
       "start": 1595,
-      "end": 1598
+      "end": 1596
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-selector-min-width",
+      "value": "17rem",
+      "scope": "default",
+      "line": {
+        "start": 1597,
+        "end": 1597
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "This is the height of the Masthead on\nnarrow viewports and is used to calculate\nhow far from the top the narrow\nnavigation items should be displayed.\n",
+    "commentRange": {
+      "start": 1598,
+      "end": 1601
     },
     "context": {
       "type": "variable",
@@ -15232,8 +15257,8 @@
       "value": "81px",
       "scope": "default",
       "line": {
-        "start": 1599,
-        "end": 1599
+        "start": 1602,
+        "end": 1602
       }
     },
     "access": "public",
@@ -15248,8 +15273,8 @@
   {
     "description": "The color of the mask that\ngets applied when the Masthead selector\ndropdown is open on narrow screens.\n",
     "commentRange": {
-      "start": 1600,
-      "end": 1602
+      "start": 1603,
+      "end": 1605
     },
     "context": {
       "type": "variable",
@@ -15257,8 +15282,8 @@
       "value": "rgba(0, 0, 0, 0.5)",
       "scope": "default",
       "line": {
-        "start": 1603,
-        "end": 1603
+        "start": 1606,
+        "end": 1606
       }
     },
     "access": "public",
@@ -15273,38 +15298,13 @@
   {
     "description": "The transition applied to the Masthead.\n",
     "commentRange": {
-      "start": 1604,
-      "end": 1604
+      "start": 1607,
+      "end": 1607
     },
     "context": {
       "type": "variable",
       "name": "sprk-masthead-transition",
       "value": "all 0.3s ease-in",
-      "scope": "default",
-      "line": {
-        "start": 1605,
-        "end": 1605
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The transform length that gets applied\nwhen the Masthead scrolls out of view on narrow screens.\n",
-    "commentRange": {
-      "start": 1606,
-      "end": 1607
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-translateY",
-      "value": "translateY(-100%)",
       "scope": "default",
       "line": {
         "start": 1608,
@@ -15321,19 +15321,19 @@
     }
   },
   {
-    "description": "The maximum width of the\nbig navigation items in the\nnavigation bar in the Masthead Extended.\n",
+    "description": "The transform length that gets applied\nwhen the Masthead scrolls out of view on narrow screens.\n",
     "commentRange": {
-      "start": 1611,
-      "end": 1613
+      "start": 1609,
+      "end": 1610
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-column-width",
-      "value": "64rem",
+      "name": "sprk-masthead-translateY",
+      "value": "translateY(-100%)",
       "scope": "default",
       "line": {
-        "start": 1614,
-        "end": 1614
+        "start": 1611,
+        "end": 1611
       }
     },
     "access": "public",
@@ -15346,15 +15346,15 @@
     }
   },
   {
-    "description": "The background color of the big\nnavigation bar in the Masthead Extended.\n",
+    "description": "The maximum width of the\nbig navigation items in the\nnavigation bar in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1615,
+      "start": 1614,
       "end": 1616
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-bg",
-      "value": "$sprk-white",
+      "name": "sprk-big-nav-column-width",
+      "value": "64rem",
       "scope": "default",
       "line": {
         "start": 1617,
@@ -15371,15 +15371,15 @@
     }
   },
   {
-    "description": "The font weight of the big\nnavigation link in the Masthead Extended.\n",
+    "description": "The background color of the big\nnavigation bar in the Masthead Extended.\n",
     "commentRange": {
       "start": 1618,
       "end": 1619
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-link-font-weight",
-      "value": "400",
+      "name": "sprk-big-nav-bg",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1620,
@@ -15396,15 +15396,15 @@
     }
   },
   {
-    "description": "The padding of the big navigation\nlink in the Masthead Extended.\n",
+    "description": "The font weight of the big\nnavigation link in the Masthead Extended.\n",
     "commentRange": {
       "start": 1621,
       "end": 1622
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-link-padding",
-      "value": "0 $sprk-space-s",
+      "name": "sprk-big-nav-link-font-weight",
+      "value": "400",
       "scope": "default",
       "line": {
         "start": 1623,
@@ -15421,19 +15421,19 @@
     }
   },
   {
-    "description": "The color of the big navigation link in the Masthead Extended.\n",
+    "description": "The padding of the big navigation\nlink in the Masthead Extended.\n",
     "commentRange": {
       "start": 1624,
-      "end": 1624
+      "end": 1625
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-link-color",
-      "value": "$sprk-black",
+      "name": "sprk-big-nav-link-padding",
+      "value": "0 $sprk-space-s",
       "scope": "default",
       "line": {
-        "start": 1625,
-        "end": 1625
+        "start": 1626,
+        "end": 1626
       }
     },
     "access": "public",
@@ -15446,15 +15446,15 @@
     }
   },
   {
-    "description": "The text and underline color of\nthe active big navigation item in the Masthead Extended.\n",
+    "description": "The color of the big navigation link in the Masthead Extended.\n",
     "commentRange": {
-      "start": 1626,
+      "start": 1627,
       "end": 1627
     },
     "context": {
       "type": "variable",
-      "name": "sprk-big-nav-active-color",
-      "value": "$sprk-big-nav-link-color",
+      "name": "sprk-big-nav-link-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1628,
@@ -15471,10 +15471,35 @@
     }
   },
   {
-    "description": "The line height\nof the big navigation items\nin the Masthead Extended.\n",
+    "description": "The text and underline color of\nthe active big navigation item in the Masthead Extended.\n",
     "commentRange": {
       "start": 1629,
-      "end": 1631
+      "end": 1630
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-big-nav-active-color",
+      "value": "$sprk-big-nav-link-color",
+      "scope": "default",
+      "line": {
+        "start": 1631,
+        "end": 1631
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The line height\nof the big navigation items\nin the Masthead Extended.\n",
+    "commentRange": {
+      "start": 1632,
+      "end": 1634
     },
     "context": {
       "type": "variable",
@@ -15482,8 +15507,8 @@
       "value": "53px",
       "scope": "default",
       "line": {
-        "start": 1632,
-        "end": 1632
+        "start": 1635,
+        "end": 1635
       }
     },
     "access": "public",
@@ -15498,38 +15523,13 @@
   {
     "description": "The left border of the active item\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
-      "start": 1634,
-      "end": 1635
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-masthead-accordion-active-left-border",
-      "value": "3px solid $sprk-black",
-      "scope": "default",
-      "line": {
-        "start": 1636,
-        "end": 1636
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The font weight of the active item\nin the naviation links when masthead is on narrow viewports.\n",
-    "commentRange": {
       "start": 1637,
       "end": 1638
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-active-heading-font-weight",
-      "value": "400",
+      "name": "sprk-masthead-accordion-active-left-border",
+      "value": "3px solid $sprk-black",
       "scope": "default",
       "line": {
         "start": 1639,
@@ -15546,15 +15546,15 @@
     }
   },
   {
-    "description": "The color of the active item\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font weight of the active item\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1640,
       "end": 1641
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-active-heading-color",
-      "value": "$sprk-black",
+      "name": "sprk-masthead-accordion-active-heading-font-weight",
+      "value": "400",
       "scope": "default",
       "line": {
         "start": 1642,
@@ -15571,14 +15571,14 @@
     }
   },
   {
-    "description": "The color of the heading\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The color of the active item\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1643,
       "end": 1644
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-heading-color",
+      "name": "sprk-masthead-accordion-active-heading-color",
       "value": "$sprk-black",
       "scope": "default",
       "line": {
@@ -15596,15 +15596,15 @@
     }
   },
   {
-    "description": "The font weight of the heading\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The color of the heading\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1646,
       "end": 1647
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-heading-font-weight",
-      "value": "400",
+      "name": "sprk-masthead-accordion-heading-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1648,
@@ -15621,15 +15621,15 @@
     }
   },
   {
-    "description": "The font weight of the details\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font weight of the heading\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1649,
       "end": 1650
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-details-font-weight",
-      "value": "300",
+      "name": "sprk-masthead-accordion-heading-font-weight",
+      "value": "400",
       "scope": "default",
       "line": {
         "start": 1651,
@@ -15646,15 +15646,15 @@
     }
   },
   {
-    "description": "The font color of the details\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font weight of the details\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1652,
       "end": 1653
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-details-font-color",
-      "value": "$sprk-black",
+      "name": "sprk-masthead-accordion-details-font-weight",
+      "value": "300",
       "scope": "default",
       "line": {
         "start": 1654,
@@ -15671,15 +15671,15 @@
     }
   },
   {
-    "description": "The background color of the active\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font color of the details\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1655,
       "end": 1656
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-active-background-color",
-      "value": "$sprk-gray",
+      "name": "sprk-masthead-accordion-details-font-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1657,
@@ -15696,15 +15696,15 @@
     }
   },
   {
-    "description": "The font color of the active\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The background color of the active\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1658,
       "end": 1659
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-active-font-color",
-      "value": "$sprk-black",
+      "name": "sprk-masthead-accordion-active-background-color",
+      "value": "$sprk-gray",
       "scope": "default",
       "line": {
         "start": 1660,
@@ -15721,14 +15721,14 @@
     }
   },
   {
-    "description": "The font color of the text\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font color of the active\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1661,
       "end": 1662
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-font-color",
+      "name": "sprk-masthead-accordion-active-font-color",
       "value": "$sprk-black",
       "scope": "default",
       "line": {
@@ -15746,15 +15746,15 @@
     }
   },
   {
-    "description": "The color of the line on open items\nin the naviation links when masthead is on narrow viewports.\n",
+    "description": "The font color of the text\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1664,
       "end": 1665
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-open-line-background-color",
-      "value": "$sprk-black-tint-25",
+      "name": "sprk-masthead-accordion-font-color",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1666,
@@ -15771,15 +15771,15 @@
     }
   },
   {
-    "description": "The height of the line on open\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The color of the line on open items\nin the naviation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1667,
       "end": 1668
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-open-line-height",
-      "value": "2px",
+      "name": "sprk-masthead-accordion-item-open-line-background-color",
+      "value": "$sprk-black-tint-25",
       "scope": "default",
       "line": {
         "start": 1669,
@@ -15796,15 +15796,15 @@
     }
   },
   {
-    "description": "The padding of the items in the\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The height of the line on open\nnavigation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1670,
       "end": 1671
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-padding",
-      "value": "$sprk-space-m",
+      "name": "sprk-masthead-accordion-item-open-line-height",
+      "value": "2px",
       "scope": "default",
       "line": {
         "start": 1672,
@@ -15821,15 +15821,15 @@
     }
   },
   {
-    "description": "The text alignment of an item in the\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The padding of the items in the\nnavigation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1673,
       "end": 1674
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-text-align",
-      "value": "left",
+      "name": "sprk-masthead-accordion-item-padding",
+      "value": "$sprk-space-m",
       "scope": "default",
       "line": {
         "start": 1675,
@@ -15846,15 +15846,15 @@
     }
   },
   {
-    "description": "The border of an item in the\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The text alignment of an item in the\nnavigation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1676,
       "end": 1677
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-border",
-      "value": "0",
+      "name": "sprk-masthead-accordion-item-text-align",
+      "value": "left",
       "scope": "default",
       "line": {
         "start": 1678,
@@ -15871,15 +15871,15 @@
     }
   },
   {
-    "description": "The background of an item in the\nnavigation links when masthead is on narrow viewports.\n",
+    "description": "The border of an item in the\nnavigation links when masthead is on narrow viewports.\n",
     "commentRange": {
       "start": 1679,
       "end": 1680
     },
     "context": {
       "type": "variable",
-      "name": "sprk-masthead-accordion-item-background",
-      "value": "transparent",
+      "name": "sprk-masthead-accordion-item-border",
+      "value": "0",
       "scope": "default",
       "line": {
         "start": 1681,
@@ -15896,10 +15896,35 @@
     }
   },
   {
+    "description": "The background of an item in the\nnavigation links when masthead is on narrow viewports.\n",
+    "commentRange": {
+      "start": 1682,
+      "end": 1683
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-masthead-accordion-item-background",
+      "value": "transparent",
+      "scope": "default",
+      "line": {
+        "start": 1684,
+        "end": 1684
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
     "description": "The height and width of Spinners.\n",
     "commentRange": {
-      "start": 1687,
-      "end": 1687
+      "start": 1690,
+      "end": 1690
     },
     "context": {
       "type": "variable",
@@ -15907,8 +15932,8 @@
       "value": "1.3rem",
       "scope": "default",
       "line": {
-        "start": 1688,
-        "end": 1688
+        "start": 1691,
+        "end": 1691
       }
     },
     "access": "public",
@@ -15923,8 +15948,8 @@
   {
     "description": "The height and width of large Spinners.\n",
     "commentRange": {
-      "start": 1689,
-      "end": 1689
+      "start": 1692,
+      "end": 1692
     },
     "context": {
       "type": "variable",
@@ -15932,8 +15957,8 @@
       "value": "3rem",
       "scope": "default",
       "line": {
-        "start": 1690,
-        "end": 1690
+        "start": 1693,
+        "end": 1693
       }
     },
     "access": "public",
@@ -15948,8 +15973,8 @@
   {
     "description": "The speed of the animation for Spinners.\n",
     "commentRange": {
-      "start": 1691,
-      "end": 1691
+      "start": 1694,
+      "end": 1694
     },
     "context": {
       "type": "variable",
@@ -15957,8 +15982,8 @@
       "value": "1s",
       "scope": "default",
       "line": {
-        "start": 1692,
-        "end": 1692
+        "start": 1695,
+        "end": 1695
       }
     },
     "access": "public",
@@ -15973,8 +15998,8 @@
   {
     "description": "The thickness of Spinners.\n",
     "commentRange": {
-      "start": 1693,
-      "end": 1693
+      "start": 1696,
+      "end": 1696
     },
     "context": {
       "type": "variable",
@@ -15982,8 +16007,8 @@
       "value": "0.18rem",
       "scope": "default",
       "line": {
-        "start": 1694,
-        "end": 1694
+        "start": 1697,
+        "end": 1697
       }
     },
     "access": "public",
@@ -15998,8 +16023,8 @@
   {
     "description": "The color of Spinners.\n",
     "commentRange": {
-      "start": 1695,
-      "end": 1695
+      "start": 1698,
+      "end": 1698
     },
     "context": {
       "type": "variable",
@@ -16007,8 +16032,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1696,
-        "end": 1696
+        "start": 1699,
+        "end": 1699
       }
     },
     "access": "public",
@@ -16023,8 +16048,8 @@
   {
     "description": "The color of the dark Spinner.\n",
     "commentRange": {
-      "start": 1697,
-      "end": 1697
+      "start": 1700,
+      "end": 1700
     },
     "context": {
       "type": "variable",
@@ -16032,8 +16057,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1698,
-        "end": 1698
+        "start": 1701,
+        "end": 1701
       }
     },
     "access": "public",
@@ -16048,8 +16073,8 @@
   {
     "description": "The breakpoint at which the tabs\ngo from stacked layout to side by side in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1704,
-      "end": 1705
+      "start": 1707,
+      "end": 1708
     },
     "context": {
       "type": "variable",
@@ -16057,8 +16082,8 @@
       "value": "46rem",
       "scope": "default",
       "line": {
-        "start": 1706,
-        "end": 1706
+        "start": 1709,
+        "end": 1709
       }
     },
     "access": "public",
@@ -16073,8 +16098,8 @@
   {
     "description": "The tab button text color in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1707,
-      "end": 1707
+      "start": 1710,
+      "end": 1710
     },
     "context": {
       "type": "variable",
@@ -16082,8 +16107,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1708,
-        "end": 1708
+        "start": 1711,
+        "end": 1711
       }
     },
     "access": "public",
@@ -16098,8 +16123,8 @@
   {
     "description": "The tab button background color in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1709,
-      "end": 1709
+      "start": 1712,
+      "end": 1712
     },
     "context": {
       "type": "variable",
@@ -16107,8 +16132,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1710,
-        "end": 1710
+        "start": 1713,
+        "end": 1713
       }
     },
     "access": "public",
@@ -16123,38 +16148,13 @@
   {
     "description": "The border on the top of the button tabs in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1711,
-      "end": 1711
+      "start": 1714,
+      "end": 1714
     },
     "context": {
       "type": "variable",
       "name": "sprk-tab-navigation-btn-border-top",
       "value": "3px solid $sprk-gray",
-      "scope": "default",
-      "line": {
-        "start": 1712,
-        "end": 1712
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border on the top of the\nbutton tabs on hover in Tabbed Navigation.\n",
-    "commentRange": {
-      "start": 1713,
-      "end": 1714
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-tab-navigation-btn-hover-border-top",
-      "value": "3px solid $sprk-red",
       "scope": "default",
       "line": {
         "start": 1715,
@@ -16171,15 +16171,15 @@
     }
   },
   {
-    "description": "The button tab text color of the\ncurrently active tab in Tabbed Navigation.\n",
+    "description": "The border on the top of the\nbutton tabs on hover in Tabbed Navigation.\n",
     "commentRange": {
       "start": 1716,
       "end": 1717
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-color",
-      "value": "$sprk-red",
+      "name": "sprk-tab-navigation-btn-hover-border-top",
+      "value": "3px solid $sprk-red",
       "scope": "default",
       "line": {
         "start": 1718,
@@ -16196,15 +16196,15 @@
     }
   },
   {
-    "description": "The button tab top border of the\ncurrently active tab in Tabbed Navigation.\n",
+    "description": "The button tab text color of the\ncurrently active tab in Tabbed Navigation.\n",
     "commentRange": {
       "start": 1719,
       "end": 1720
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-border-top",
-      "value": "3px solid $sprk-red",
+      "name": "sprk-tab-navigation-btn-active-color",
+      "value": "$sprk-red",
       "scope": "default",
       "line": {
         "start": 1721,
@@ -16221,15 +16221,15 @@
     }
   },
   {
-    "description": "The button tab background color\nof the currently active tab in Tabbed Navigation.\n",
+    "description": "The button tab top border of the\ncurrently active tab in Tabbed Navigation.\n",
     "commentRange": {
       "start": 1722,
       "end": 1723
     },
     "context": {
       "type": "variable",
-      "name": "sprk-tab-navigation-btn-active-bg-color",
-      "value": "$sprk-white",
+      "name": "sprk-tab-navigation-btn-active-border-top",
+      "value": "3px solid $sprk-red",
       "scope": "default",
       "line": {
         "start": 1724,
@@ -16246,19 +16246,19 @@
     }
   },
   {
-    "description": "The background color of the Stepper.\n",
+    "description": "The button tab background color\nof the currently active tab in Tabbed Navigation.\n",
     "commentRange": {
-      "start": 1730,
-      "end": 1730
+      "start": 1725,
+      "end": 1726
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-bg",
-      "value": "transparent",
+      "name": "sprk-tab-navigation-btn-active-bg-color",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1731,
-        "end": 1731
+        "start": 1727,
+        "end": 1727
       }
     },
     "access": "public",
@@ -16271,15 +16271,15 @@
     }
   },
   {
-    "description": "The minimum width at which the Stepper\nswitches between narrow and wide layouts.\n",
+    "description": "The background color of the Stepper.\n",
     "commentRange": {
-      "start": 1732,
+      "start": 1733,
       "end": 1733
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-breakpoint",
-      "value": "$sprk-split-breakpoint-xl",
+      "name": "sprk-stepper-bg",
+      "value": "transparent",
       "scope": "default",
       "line": {
         "start": 1734,
@@ -16296,10 +16296,35 @@
     }
   },
   {
-    "description": "The maximum width of the Stepper.\n",
+    "description": "The minimum width at which the Stepper\nswitches between narrow and wide layouts.\n",
     "commentRange": {
       "start": 1735,
-      "end": 1735
+      "end": 1736
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-breakpoint",
+      "value": "$sprk-split-breakpoint-xl",
+      "scope": "default",
+      "line": {
+        "start": 1737,
+        "end": 1737
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The maximum width of the Stepper.\n",
+    "commentRange": {
+      "start": 1738,
+      "end": 1738
     },
     "context": {
       "type": "variable",
@@ -16307,8 +16332,8 @@
       "value": "480px",
       "scope": "default",
       "line": {
-        "start": 1736,
-        "end": 1736
+        "start": 1739,
+        "end": 1739
       }
     },
     "access": "public",
@@ -16323,8 +16348,8 @@
   {
     "description": "The border width of the Stepper icons.\n",
     "commentRange": {
-      "start": 1737,
-      "end": 1737
+      "start": 1740,
+      "end": 1740
     },
     "context": {
       "type": "variable",
@@ -16332,8 +16357,8 @@
       "value": "2px",
       "scope": "default",
       "line": {
-        "start": 1738,
-        "end": 1738
+        "start": 1741,
+        "end": 1741
       }
     },
     "access": "public",
@@ -16348,8 +16373,8 @@
   {
     "description": "The color of the border around the Stepper icon.\n",
     "commentRange": {
-      "start": 1739,
-      "end": 1739
+      "start": 1742,
+      "end": 1742
     },
     "context": {
       "type": "variable",
@@ -16357,8 +16382,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1740,
-        "end": 1740
+        "start": 1743,
+        "end": 1743
       }
     },
     "access": "public",
@@ -16373,8 +16398,8 @@
   {
     "description": "The color of the step icon when the step is selected in the Stepper.\n",
     "commentRange": {
-      "start": 1741,
-      "end": 1741
+      "start": 1744,
+      "end": 1744
     },
     "context": {
       "type": "variable",
@@ -16382,8 +16407,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 1742,
-        "end": 1742
+        "start": 1745,
+        "end": 1745
       }
     },
     "access": "public",
@@ -16398,8 +16423,8 @@
   {
     "description": "The color of the icon border when the\nStepper is on a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1743,
-      "end": 1745
+      "start": 1746,
+      "end": 1748
     },
     "context": {
       "type": "variable",
@@ -16407,8 +16432,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1746,
-        "end": 1746
+        "start": 1749,
+        "end": 1749
       }
     },
     "access": "public",
@@ -16423,8 +16448,8 @@
   {
     "description": "The height of the step icon in the Stepper.\n",
     "commentRange": {
-      "start": 1747,
-      "end": 1747
+      "start": 1750,
+      "end": 1750
     },
     "context": {
       "type": "variable",
@@ -16432,8 +16457,8 @@
       "value": "16px",
       "scope": "default",
       "line": {
-        "start": 1748,
-        "end": 1748
+        "start": 1751,
+        "end": 1751
       }
     },
     "access": "public",
@@ -16448,8 +16473,8 @@
   {
     "description": "The width of the step icon in the Stepper.\n",
     "commentRange": {
-      "start": 1749,
-      "end": 1749
+      "start": 1752,
+      "end": 1752
     },
     "context": {
       "type": "variable",
@@ -16457,8 +16482,8 @@
       "value": "16px",
       "scope": "default",
       "line": {
-        "start": 1750,
-        "end": 1750
+        "start": 1753,
+        "end": 1753
       }
     },
     "access": "public",
@@ -16473,38 +16498,13 @@
   {
     "description": "The color of the step icon in the Stepper.\n",
     "commentRange": {
-      "start": 1751,
-      "end": 1751
+      "start": 1754,
+      "end": 1754
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-icon-color",
       "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1752,
-        "end": 1752
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the step icon\nin the Stepper when hovered.\n",
-    "commentRange": {
-      "start": 1753,
-      "end": 1754
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-color-hover",
-      "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
         "start": 1755,
@@ -16521,19 +16521,19 @@
     }
   },
   {
-    "description": "The color of the Stepper step icon when the step is selected.\n",
+    "description": "The color of the step icon\nin the Stepper when hovered.\n",
     "commentRange": {
       "start": 1756,
-      "end": 1756
+      "end": 1757
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-color-selected",
-      "value": "$sprk-white",
+      "name": "sprk-stepper-icon-color-hover",
+      "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1757,
-        "end": 1757
+        "start": 1758,
+        "end": 1758
       }
     },
     "access": "public",
@@ -16546,15 +16546,15 @@
     }
   },
   {
-    "description": "The color of the step icon when the\nStepper has a dark background (sprk-c-Stepper--has-dark-bg).\n",
+    "description": "The color of the Stepper step icon when the step is selected.\n",
     "commentRange": {
-      "start": 1758,
+      "start": 1759,
       "end": 1759
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-dark-icon-color",
-      "value": "$sprk-blue",
+      "name": "sprk-stepper-icon-color-selected",
+      "value": "$sprk-white",
       "scope": "default",
       "line": {
         "start": 1760,
@@ -16571,10 +16571,35 @@
     }
   },
   {
-    "description": "The color of the Stepper step icon when the step\nis selected and the Stepper has a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
+    "description": "The color of the step icon when the\nStepper has a dark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
       "start": 1761,
-      "end": 1763
+      "end": 1762
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-dark-icon-color",
+      "value": "$sprk-blue",
+      "scope": "default",
+      "line": {
+        "start": 1763,
+        "end": 1763
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The color of the Stepper step icon when the step\nis selected and the Stepper has a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
+    "commentRange": {
+      "start": 1764,
+      "end": 1766
     },
     "context": {
       "type": "variable",
@@ -16582,8 +16607,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1764,
-        "end": 1764
+        "start": 1767,
+        "end": 1767
       }
     },
     "access": "public",
@@ -16598,38 +16623,13 @@
   {
     "description": "The color of the step icon on hover\nwhen the Stepper has a dark background\n(sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1765,
-      "end": 1767
+      "start": 1768,
+      "end": 1770
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-dark-icon-color-hover",
       "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1768,
-        "end": 1768
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The transition of the Stepper step icon.\n",
-    "commentRange": {
-      "start": 1770,
-      "end": 1770
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-icon-transition",
-      "value": "0.3s all ease-in-out",
       "scope": "default",
       "line": {
         "start": 1771,
@@ -16646,19 +16646,19 @@
     }
   },
   {
-    "description": "The z-index of the Stepper step icon.\n",
+    "description": "The transition of the Stepper step icon.\n",
     "commentRange": {
-      "start": 1772,
-      "end": 1772
+      "start": 1773,
+      "end": 1773
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-z-index",
-      "value": "$sprk-layer-height-xs",
+      "name": "sprk-stepper-icon-transition",
+      "value": "0.3s all ease-in-out",
       "scope": "default",
       "line": {
-        "start": 1773,
-        "end": 1773
+        "start": 1774,
+        "end": 1774
       }
     },
     "access": "public",
@@ -16671,15 +16671,15 @@
     }
   },
   {
-    "description": "The spread value of the icon box\nshadow when the Stepper step is selected.\n",
+    "description": "The z-index of the Stepper step icon.\n",
     "commentRange": {
-      "start": 1774,
+      "start": 1775,
       "end": 1775
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-icon-box-shadow-selected-spread",
-      "value": "8px",
+      "name": "sprk-stepper-icon-z-index",
+      "value": "$sprk-layer-height-xs",
       "scope": "default",
       "line": {
         "start": 1776,
@@ -16696,10 +16696,35 @@
     }
   },
   {
-    "description": "The box shadow of the Stepper step icon\nwhen the icon is selected.\n",
+    "description": "The spread value of the icon box\nshadow when the Stepper step is selected.\n",
     "commentRange": {
       "start": 1777,
       "end": 1778
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-icon-box-shadow-selected-spread",
+      "value": "8px",
+      "scope": "default",
+      "line": {
+        "start": 1779,
+        "end": 1779
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The box shadow of the Stepper step icon\nwhen the icon is selected.\n",
+    "commentRange": {
+      "start": 1780,
+      "end": 1781
     },
     "context": {
       "type": "variable",
@@ -16707,8 +16732,8 @@
       "value": "0 0 0\n  $sprk-stepper-icon-box-shadow-selected-spread\n  $sprk-stepper-icon-border-color-selected",
       "scope": "default",
       "line": {
-        "start": 1779,
-        "end": 1781
+        "start": 1782,
+        "end": 1784
       }
     },
     "access": "public",
@@ -16723,38 +16748,13 @@
   {
     "description": "The background color of the content in the Stepper step.\n",
     "commentRange": {
-      "start": 1782,
-      "end": 1782
+      "start": 1785,
+      "end": 1785
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-step-content-bg",
       "value": "transparent",
-      "scope": "default",
-      "line": {
-        "start": 1783,
-        "end": 1783
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The border radius of the Stepper step\ncontent box when it has a description.\n",
-    "commentRange": {
-      "start": 1784,
-      "end": 1785
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-description-border-radius",
-      "value": "5px",
       "scope": "default",
       "line": {
         "start": 1786,
@@ -16771,15 +16771,15 @@
     }
   },
   {
-    "description": "The box shadow of the Stepper step content\nbox when it has a description.\n",
+    "description": "The border radius of the Stepper step\ncontent box when it has a description.\n",
     "commentRange": {
       "start": 1787,
       "end": 1788
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-box-shadow",
-      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
+      "name": "sprk-stepper-step-description-border-radius",
+      "value": "5px",
       "scope": "default",
       "line": {
         "start": 1789,
@@ -16796,15 +16796,15 @@
     }
   },
   {
-    "description": "The spacing between the\nStepper step heading and description.\n",
+    "description": "The box shadow of the Stepper step content\nbox when it has a description.\n",
     "commentRange": {
       "start": 1790,
       "end": 1791
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-description-top-spacing",
-      "value": "$sprk-space-m",
+      "name": "sprk-stepper-step-description-box-shadow",
+      "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
         "start": 1792,
@@ -16821,10 +16821,35 @@
     }
   },
   {
-    "description": "The font weight of the Stepper step heading.\n",
+    "description": "The spacing between the\nStepper step heading and description.\n",
     "commentRange": {
       "start": 1793,
-      "end": 1793
+      "end": 1794
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-step-description-top-spacing",
+      "value": "$sprk-space-m",
+      "scope": "default",
+      "line": {
+        "start": 1795,
+        "end": 1795
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The font weight of the Stepper step heading.\n",
+    "commentRange": {
+      "start": 1796,
+      "end": 1796
     },
     "context": {
       "type": "variable",
@@ -16832,8 +16857,8 @@
       "value": "400",
       "scope": "default",
       "line": {
-        "start": 1794,
-        "end": 1794
+        "start": 1797,
+        "end": 1797
       }
     },
     "access": "public",
@@ -16848,8 +16873,8 @@
   {
     "description": "The font size of the Stepper step heading.\n",
     "commentRange": {
-      "start": 1795,
-      "end": 1795
+      "start": 1798,
+      "end": 1798
     },
     "context": {
       "type": "variable",
@@ -16857,8 +16882,8 @@
       "value": "$sprk-font-size-display-six",
       "scope": "default",
       "line": {
-        "start": 1796,
-        "end": 1796
+        "start": 1799,
+        "end": 1799
       }
     },
     "access": "public",
@@ -16873,8 +16898,8 @@
   {
     "description": "The color of the Stepper step heading.\n",
     "commentRange": {
-      "start": 1797,
-      "end": 1797
+      "start": 1800,
+      "end": 1800
     },
     "context": {
       "type": "variable",
@@ -16882,8 +16907,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1798,
-        "end": 1798
+        "start": 1801,
+        "end": 1801
       }
     },
     "access": "public",
@@ -16898,38 +16923,13 @@
   {
     "description": "The color of the Stepper step heading when\nthe Stepper is on a dark\nbackground (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1799,
-      "end": 1801
+      "start": 1802,
+      "end": 1804
     },
     "context": {
       "type": "variable",
       "name": "sprk-stepper-dark-step-heading-color",
       "value": "$sprk-white",
-      "scope": "default",
-      "line": {
-        "start": 1802,
-        "end": 1802
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The color of the Stepper\nstep heading when the step is selected.\n",
-    "commentRange": {
-      "start": 1803,
-      "end": 1804
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-stepper-step-heading-color-selected",
-      "value": "$sprk-black",
       "scope": "default",
       "line": {
         "start": 1805,
@@ -16946,19 +16946,19 @@
     }
   },
   {
-    "description": "The padding value for the Stepper step.\n",
+    "description": "The color of the Stepper\nstep heading when the step is selected.\n",
     "commentRange": {
       "start": 1806,
-      "end": 1806
+      "end": 1807
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-padding",
-      "value": "$sprk-space-misc-a",
+      "name": "sprk-stepper-step-heading-color-selected",
+      "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1807,
-        "end": 1807
+        "start": 1808,
+        "end": 1808
       }
     },
     "access": "public",
@@ -16971,15 +16971,15 @@
     }
   },
   {
-    "description": "The background color of the\nStepper step content box when the step is selected.\n",
+    "description": "The padding value for the Stepper step.\n",
     "commentRange": {
-      "start": 1808,
+      "start": 1809,
       "end": 1809
     },
     "context": {
       "type": "variable",
-      "name": "sprk-stepper-step-content-bg-selected",
-      "value": "transparent",
+      "name": "sprk-stepper-step-padding",
+      "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
         "start": 1810,
@@ -16996,10 +16996,35 @@
     }
   },
   {
-    "description": "The background color of the Stepper step\ncontent box when it has a\ndescription and when the step is selected.\n",
+    "description": "The background color of the\nStepper step content box when the step is selected.\n",
     "commentRange": {
       "start": 1811,
-      "end": 1813
+      "end": 1812
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-stepper-step-content-bg-selected",
+      "value": "transparent",
+      "scope": "default",
+      "line": {
+        "start": 1813,
+        "end": 1813
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The background color of the Stepper step\ncontent box when it has a\ndescription and when the step is selected.\n",
+    "commentRange": {
+      "start": 1814,
+      "end": 1816
     },
     "context": {
       "type": "variable",
@@ -17007,8 +17032,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1814,
-        "end": 1814
+        "start": 1817,
+        "end": 1817
       }
     },
     "access": "public",
@@ -17023,8 +17048,8 @@
   {
     "description": "The text color of a selected Stepper step's\ncontent and header when it has a\ndescription. This applies to\nsteppers with the sprk-c-Stepper--has-dark-bg class.\n",
     "commentRange": {
-      "start": 1815,
-      "end": 1818
+      "start": 1818,
+      "end": 1821
     },
     "context": {
       "type": "variable",
@@ -17032,8 +17057,8 @@
       "value": "$sprk-black",
       "scope": "default",
       "line": {
-        "start": 1819,
-        "end": 1819
+        "start": 1822,
+        "end": 1822
       }
     },
     "access": "public",
@@ -17048,8 +17073,8 @@
   {
     "description": "The color of the bar that connects the steps in the Stepper.\n",
     "commentRange": {
-      "start": 1820,
-      "end": 1820
+      "start": 1823,
+      "end": 1823
     },
     "context": {
       "type": "variable",
@@ -17057,8 +17082,8 @@
       "value": "$sprk-black-tint-50",
       "scope": "default",
       "line": {
-        "start": 1821,
-        "end": 1821
+        "start": 1824,
+        "end": 1824
       }
     },
     "access": "public",
@@ -17073,8 +17098,8 @@
   {
     "description": "The color of the bar that connects\nthe steps when the Stepper is on a\ndark background (sprk-c-Stepper--has-dark-bg).\n",
     "commentRange": {
-      "start": 1822,
-      "end": 1824
+      "start": 1825,
+      "end": 1827
     },
     "context": {
       "type": "variable",
@@ -17082,8 +17107,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1825,
-        "end": 1825
+        "start": 1828,
+        "end": 1828
       }
     },
     "access": "public",
@@ -17098,8 +17123,8 @@
   {
     "description": "The border value for the Carousel component.\n",
     "commentRange": {
-      "start": 1844,
-      "end": 1844
+      "start": 1847,
+      "end": 1847
     },
     "context": {
       "type": "variable",
@@ -17107,8 +17132,8 @@
       "value": "$sprk-stepper-icon-border-width solid\n  $sprk-stepper-dark-icon-border-color",
       "scope": "default",
       "line": {
-        "start": 1845,
-        "end": 1846
+        "start": 1848,
+        "end": 1849
       }
     },
     "access": "public",
@@ -17123,8 +17148,8 @@
   {
     "description": "The height of the dots in the Carousel component.\n",
     "commentRange": {
-      "start": 1847,
-      "end": 1847
+      "start": 1850,
+      "end": 1850
     },
     "context": {
       "type": "variable",
@@ -17132,8 +17157,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1848,
-        "end": 1848
+        "start": 1851,
+        "end": 1851
       }
     },
     "access": "public",
@@ -17148,8 +17173,8 @@
   {
     "description": "The width of the dots in the Carousel component.\n",
     "commentRange": {
-      "start": 1849,
-      "end": 1849
+      "start": 1852,
+      "end": 1852
     },
     "context": {
       "type": "variable",
@@ -17157,8 +17182,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1850,
-        "end": 1850
+        "start": 1853,
+        "end": 1853
       }
     },
     "access": "public",
@@ -17173,8 +17198,8 @@
   {
     "description": "The height of the dots in the Carousel component on wide viewports.\n",
     "commentRange": {
-      "start": 1851,
-      "end": 1851
+      "start": 1854,
+      "end": 1854
     },
     "context": {
       "type": "variable",
@@ -17182,8 +17207,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1852,
-        "end": 1852
+        "start": 1855,
+        "end": 1855
       }
     },
     "access": "public",
@@ -17198,8 +17223,8 @@
   {
     "description": "The width of the dots in the Carousel component on wide viewports.\n",
     "commentRange": {
-      "start": 1853,
-      "end": 1853
+      "start": 1856,
+      "end": 1856
     },
     "context": {
       "type": "variable",
@@ -17207,8 +17232,8 @@
       "value": "10px",
       "scope": "default",
       "line": {
-        "start": 1854,
-        "end": 1854
+        "start": 1857,
+        "end": 1857
       }
     },
     "access": "public",
@@ -17223,8 +17248,8 @@
   {
     "description": "The spacing between dots in the Carousel component.\n",
     "commentRange": {
-      "start": 1855,
-      "end": 1855
+      "start": 1858,
+      "end": 1858
     },
     "context": {
       "type": "variable",
@@ -17232,8 +17257,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1856,
-        "end": 1856
+        "start": 1859,
+        "end": 1859
       }
     },
     "access": "public",
@@ -17248,8 +17273,8 @@
   {
     "description": "The spacing between dots in the Carousel component on wide viewports.\n",
     "commentRange": {
-      "start": 1857,
-      "end": 1857
+      "start": 1860,
+      "end": 1860
     },
     "context": {
       "type": "variable",
@@ -17257,8 +17282,8 @@
       "value": "$sprk-carousel-dot-spacing",
       "scope": "default",
       "line": {
-        "start": 1858,
-        "end": 1858
+        "start": 1861,
+        "end": 1861
       }
     },
     "access": "public",
@@ -17273,8 +17298,8 @@
   {
     "description": "The box shadow of the active dot in the Carousel component.\n",
     "commentRange": {
-      "start": 1859,
-      "end": 1859
+      "start": 1862,
+      "end": 1862
     },
     "context": {
       "type": "variable",
@@ -17282,8 +17307,8 @@
       "value": "$sprk-stepper-icon-box-shadow-selected",
       "scope": "default",
       "line": {
-        "start": 1860,
-        "end": 1860
+        "start": 1863,
+        "end": 1863
       }
     },
     "access": "public",
@@ -17298,8 +17323,8 @@
   {
     "description": "The color of the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1861,
-      "end": 1861
+      "start": 1864,
+      "end": 1864
     },
     "context": {
       "type": "variable",
@@ -17307,8 +17332,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1862,
-        "end": 1862
+        "start": 1865,
+        "end": 1865
       }
     },
     "access": "public",
@@ -17323,8 +17348,8 @@
   {
     "description": "The spacing for the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1863,
-      "end": 1863
+      "start": 1866,
+      "end": 1866
     },
     "context": {
       "type": "variable",
@@ -17332,8 +17357,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1864,
-        "end": 1864
+        "start": 1867,
+        "end": 1867
       }
     },
     "access": "public",
@@ -17348,8 +17373,8 @@
   {
     "description": "The left and right values of the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1865,
-      "end": 1865
+      "start": 1868,
+      "end": 1868
     },
     "context": {
       "type": "variable",
@@ -17357,8 +17382,8 @@
       "value": "0",
       "scope": "default",
       "line": {
-        "start": 1866,
-        "end": 1866
+        "start": 1869,
+        "end": 1869
       }
     },
     "access": "public",
@@ -17373,8 +17398,8 @@
   {
     "description": "The padding value of the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1867,
-      "end": 1867
+      "start": 1870,
+      "end": 1870
     },
     "context": {
       "type": "variable",
@@ -17382,8 +17407,8 @@
       "value": "$sprk-space-m",
       "scope": "default",
       "line": {
-        "start": 1868,
-        "end": 1868
+        "start": 1871,
+        "end": 1871
       }
     },
     "access": "public",
@@ -17398,8 +17423,8 @@
   {
     "description": "The maximum width of the image in the Carousel component.\n",
     "commentRange": {
-      "start": 1869,
-      "end": 1869
+      "start": 1872,
+      "end": 1872
     },
     "context": {
       "type": "variable",
@@ -17407,8 +17432,8 @@
       "value": "18.75rem",
       "scope": "default",
       "line": {
-        "start": 1870,
-        "end": 1870
+        "start": 1873,
+        "end": 1873
       }
     },
     "access": "public",
@@ -17423,8 +17448,8 @@
   {
     "description": "The breakpoint for the arrows in the Carousel component.\n",
     "commentRange": {
-      "start": 1871,
-      "end": 1871
+      "start": 1874,
+      "end": 1874
     },
     "context": {
       "type": "variable",
@@ -17432,8 +17457,8 @@
       "value": "31.25rem",
       "scope": "default",
       "line": {
-        "start": 1872,
-        "end": 1872
+        "start": 1875,
+        "end": 1875
       }
     },
     "access": "public",
@@ -17448,8 +17473,8 @@
   {
     "description": "The padding value for the dots container in the Carousel component.\n",
     "commentRange": {
-      "start": 1873,
-      "end": 1873
+      "start": 1876,
+      "end": 1876
     },
     "context": {
       "type": "variable",
@@ -17457,8 +17482,8 @@
       "value": "$sprk-space-xs",
       "scope": "default",
       "line": {
-        "start": 1874,
-        "end": 1874
+        "start": 1877,
+        "end": 1877
       }
     },
     "access": "public",
@@ -17473,8 +17498,8 @@
   {
     "description": "The breakpoint for the Carousel component.\n",
     "commentRange": {
-      "start": 1875,
-      "end": 1875
+      "start": 1878,
+      "end": 1878
     },
     "context": {
       "type": "variable",
@@ -17482,8 +17507,8 @@
       "value": "$sprk-split-breakpoint-xl",
       "scope": "default",
       "line": {
-        "start": 1876,
-        "end": 1876
+        "start": 1879,
+        "end": 1879
       }
     },
     "access": "public",
@@ -17498,8 +17523,8 @@
   {
     "description": "The maximum width of the Card.\n",
     "commentRange": {
-      "start": 1882,
-      "end": 1882
+      "start": 1885,
+      "end": 1885
     },
     "context": {
       "type": "variable",
@@ -17507,8 +17532,8 @@
       "value": "26.5625rem",
       "scope": "default",
       "line": {
-        "start": 1883,
-        "end": 1883
+        "start": 1886,
+        "end": 1886
       }
     },
     "access": "public",
@@ -17523,8 +17548,8 @@
   {
     "description": "The main Card breakpoint.\n",
     "commentRange": {
-      "start": 1884,
-      "end": 1884
+      "start": 1887,
+      "end": 1887
     },
     "context": {
       "type": "variable",
@@ -17532,8 +17557,8 @@
       "value": "$sprk-split-breakpoint-s",
       "scope": "default",
       "line": {
-        "start": 1885,
-        "end": 1885
+        "start": 1888,
+        "end": 1888
       }
     },
     "access": "public",
@@ -17548,8 +17573,8 @@
   {
     "description": "The box shadow of the Card on narrow viewports.\n",
     "commentRange": {
-      "start": 1886,
-      "end": 1886
+      "start": 1889,
+      "end": 1889
     },
     "context": {
       "type": "variable",
@@ -17557,8 +17582,8 @@
       "value": "0 3px 10px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
-        "start": 1887,
-        "end": 1887
+        "start": 1890,
+        "end": 1890
       }
     },
     "access": "public",
@@ -17573,8 +17598,8 @@
   {
     "description": "The box shadow of the Card on wide viewports.\n",
     "commentRange": {
-      "start": 1888,
-      "end": 1888
+      "start": 1891,
+      "end": 1891
     },
     "context": {
       "type": "variable",
@@ -17582,8 +17607,8 @@
       "value": "0 3px 18px 1px rgba(0, 0, 0, 0.08)",
       "scope": "default",
       "line": {
-        "start": 1889,
-        "end": 1889
+        "start": 1892,
+        "end": 1892
       }
     },
     "access": "public",
@@ -17598,8 +17623,8 @@
   {
     "description": "The box shadow of the Standout Card variant on narrow viewports.\n",
     "commentRange": {
-      "start": 1890,
-      "end": 1890
+      "start": 1893,
+      "end": 1893
     },
     "context": {
       "type": "variable",
@@ -17607,8 +17632,8 @@
       "value": "0 4px 20px 2px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1891,
-        "end": 1891
+        "start": 1894,
+        "end": 1894
       }
     },
     "access": "public",
@@ -17623,8 +17648,8 @@
   {
     "description": "The box shadow of the Standout Card variant on wide viewports.\n",
     "commentRange": {
-      "start": 1892,
-      "end": 1892
+      "start": 1895,
+      "end": 1895
     },
     "context": {
       "type": "variable",
@@ -17632,8 +17657,8 @@
       "value": "0 4px 40px 2px rgba(0, 0, 0, 0.1)",
       "scope": "default",
       "line": {
-        "start": 1893,
-        "end": 1893
+        "start": 1896,
+        "end": 1896
       }
     },
     "access": "public",
@@ -17648,8 +17673,8 @@
   {
     "description": "The border radius of the Card.\n",
     "commentRange": {
-      "start": 1894,
-      "end": 1894
+      "start": 1897,
+      "end": 1897
     },
     "context": {
       "type": "variable",
@@ -17657,8 +17682,8 @@
       "value": "8px",
       "scope": "default",
       "line": {
-        "start": 1895,
-        "end": 1895
+        "start": 1898,
+        "end": 1898
       }
     },
     "access": "public",
@@ -17673,8 +17698,8 @@
   {
     "description": "The padding of the content inside the Card.\n",
     "commentRange": {
-      "start": 1896,
-      "end": 1896
+      "start": 1899,
+      "end": 1899
     },
     "context": {
       "type": "variable",
@@ -17682,8 +17707,8 @@
       "value": "$sprk-space-misc-a",
       "scope": "default",
       "line": {
-        "start": 1897,
-        "end": 1897
+        "start": 1900,
+        "end": 1900
       }
     },
     "access": "public",
@@ -17698,8 +17723,8 @@
   {
     "description": "The background color of the header area for the Highlighted Header Card.\n",
     "commentRange": {
-      "start": 1898,
-      "end": 1898
+      "start": 1901,
+      "end": 1901
     },
     "context": {
       "type": "variable",
@@ -17707,8 +17732,8 @@
       "value": "$sprk-green",
       "scope": "default",
       "line": {
-        "start": 1899,
-        "end": 1899
+        "start": 1902,
+        "end": 1902
       }
     },
     "access": "public",
@@ -17723,8 +17748,8 @@
   {
     "description": "The text color for the Highlighted Header Card.\n",
     "commentRange": {
-      "start": 1900,
-      "end": 1900
+      "start": 1903,
+      "end": 1903
     },
     "context": {
       "type": "variable",
@@ -17732,8 +17757,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1901,
-        "end": 1901
+        "start": 1904,
+        "end": 1904
       }
     },
     "access": "public",
@@ -17748,8 +17773,8 @@
   {
     "description": "The border surrounding the Dictionary.\n",
     "commentRange": {
-      "start": 1907,
-      "end": 1907
+      "start": 1910,
+      "end": 1910
     },
     "context": {
       "type": "variable",
@@ -17757,8 +17782,8 @@
       "value": "1px solid $sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1908,
-        "end": 1908
+        "start": 1911,
+        "end": 1911
       }
     },
     "access": "public",
@@ -17773,8 +17798,8 @@
   {
     "description": "The background color of the key value pairs in the striped Dictionary.\n",
     "commentRange": {
-      "start": 1909,
-      "end": 1909
+      "start": 1912,
+      "end": 1912
     },
     "context": {
       "type": "variable",
@@ -17782,8 +17807,8 @@
       "value": "$sprk-gray",
       "scope": "default",
       "line": {
-        "start": 1910,
-        "end": 1910
+        "start": 1913,
+        "end": 1913
       }
     },
     "access": "public",
@@ -17798,8 +17823,8 @@
   {
     "description": "The breakpoint of the Dictionary component.\n",
     "commentRange": {
-      "start": 1911,
-      "end": 1911
+      "start": 1914,
+      "end": 1914
     },
     "context": {
       "type": "variable",
@@ -17807,8 +17832,8 @@
       "value": "38.4375rem",
       "scope": "default",
       "line": {
-        "start": 1912,
-        "end": 1912
+        "start": 1915,
+        "end": 1915
       }
     },
     "access": "public",
@@ -17823,8 +17848,8 @@
   {
     "description": "The font size of the labels in the Dictionary.\n",
     "commentRange": {
-      "start": 1913,
-      "end": 1913
+      "start": 1916,
+      "end": 1916
     },
     "context": {
       "type": "variable",
@@ -17832,8 +17857,8 @@
       "value": "$sprk-font-size-body-one",
       "scope": "default",
       "line": {
-        "start": 1914,
-        "end": 1914
+        "start": 1917,
+        "end": 1917
       }
     },
     "access": "public",
@@ -17848,8 +17873,8 @@
   {
     "description": "The font weight of the labels in the Dictionary.\n",
     "commentRange": {
-      "start": 1915,
-      "end": 1915
+      "start": 1918,
+      "end": 1918
     },
     "context": {
       "type": "variable",
@@ -17857,8 +17882,8 @@
       "value": "$sprk-font-weight-body-one",
       "scope": "default",
       "line": {
-        "start": 1916,
-        "end": 1916
+        "start": 1919,
+        "end": 1919
       }
     },
     "access": "public",
@@ -17873,8 +17898,8 @@
   {
     "description": "The line height of the labels in the Dictionary.\n",
     "commentRange": {
-      "start": 1917,
-      "end": 1917
+      "start": 1920,
+      "end": 1920
     },
     "context": {
       "type": "variable",
@@ -17882,8 +17907,8 @@
       "value": "$sprk-line-height-body-one",
       "scope": "default",
       "line": {
-        "start": 1918,
-        "end": 1918
+        "start": 1921,
+        "end": 1921
       }
     },
     "access": "public",
@@ -17898,37 +17923,12 @@
   {
     "description": "The Highlight Board breakpoint at which styles change\nfor padding, font size and button width.\n",
     "commentRange": {
-      "start": 1924,
-      "end": 1925
-    },
-    "context": {
-      "type": "variable",
-      "name": "sprk-highlight-board-breakpoint",
-      "value": "30rem",
-      "scope": "default",
-      "line": {
-        "start": 1926,
-        "end": 1926
-      }
-    },
-    "access": "public",
-    "group": [
-      "undefined"
-    ],
-    "file": {
-      "path": "_settings.scss",
-      "name": "_settings.scss"
-    }
-  },
-  {
-    "description": "The maximum width of the content\nfor the Highlight Board when it has an image.\n",
-    "commentRange": {
       "start": 1927,
       "end": 1928
     },
     "context": {
       "type": "variable",
-      "name": "sprk-highlight-board-content-width",
+      "name": "sprk-highlight-board-breakpoint",
       "value": "30rem",
       "scope": "default",
       "line": {
@@ -17946,15 +17946,15 @@
     }
   },
   {
-    "description": "Percentage reduction value for the\nfont size in the Highlight Board in narrow viewports.\n",
+    "description": "The maximum width of the content\nfor the Highlight Board when it has an image.\n",
     "commentRange": {
       "start": 1930,
       "end": 1931
     },
     "context": {
       "type": "variable",
-      "name": "sprk-highlight-board-type-reduction-percentage",
-      "value": "0.8",
+      "name": "sprk-highlight-board-content-width",
+      "value": "30rem",
       "scope": "default",
       "line": {
         "start": 1932,
@@ -17971,10 +17971,35 @@
     }
   },
   {
-    "description": "The height of the Highlight Board image.\n",
+    "description": "Percentage reduction value for the\nfont size in the Highlight Board in narrow viewports.\n",
     "commentRange": {
       "start": 1933,
-      "end": 1933
+      "end": 1934
+    },
+    "context": {
+      "type": "variable",
+      "name": "sprk-highlight-board-type-reduction-percentage",
+      "value": "0.8",
+      "scope": "default",
+      "line": {
+        "start": 1935,
+        "end": 1935
+      }
+    },
+    "access": "public",
+    "group": [
+      "undefined"
+    ],
+    "file": {
+      "path": "_settings.scss",
+      "name": "_settings.scss"
+    }
+  },
+  {
+    "description": "The height of the Highlight Board image.\n",
+    "commentRange": {
+      "start": 1936,
+      "end": 1936
     },
     "context": {
       "type": "variable",
@@ -17982,8 +18007,8 @@
       "value": "31.25rem",
       "scope": "default",
       "line": {
-        "start": 1934,
-        "end": 1934
+        "start": 1937,
+        "end": 1937
       }
     },
     "access": "public",
@@ -17998,8 +18023,8 @@
   {
     "description": "The background color of the Highlight Board.\n",
     "commentRange": {
-      "start": 1935,
-      "end": 1935
+      "start": 1938,
+      "end": 1938
     },
     "context": {
       "type": "variable",
@@ -18007,8 +18032,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1936,
-        "end": 1936
+        "start": 1939,
+        "end": 1939
       }
     },
     "access": "public",
@@ -18023,8 +18048,8 @@
   {
     "description": "The background color of\nthe content box in the Highlight Board.\n",
     "commentRange": {
-      "start": 1937,
-      "end": 1938
+      "start": 1940,
+      "end": 1941
     },
     "context": {
       "type": "variable",
@@ -18032,8 +18057,8 @@
       "value": "$sprk-white",
       "scope": "default",
       "line": {
-        "start": 1939,
-        "end": 1939
+        "start": 1942,
+        "end": 1942
       }
     },
     "access": "public",


### PR DESCRIPTION
## What does this PR do?
Update footer on site for new QL stuff.
Add new max-width: 100% utility
Add full width modifier to inputs

### Associated Issue
Fixes #2965 
Fixes #3019 

### Documentation
 - [x] Update Spark Docs - Input Modifier
 - [x] Update Spark Docs - Utilities
 - [x] Update Spark Docs - Footer

### Code
 - [x] Build Component in HTML

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
Input Modifier:
![image](https://user-images.githubusercontent.com/15703773/79351305-83716700-7f06-11ea-97e8-d091e04cc180.png)
![image](https://user-images.githubusercontent.com/15703773/79351365-96843700-7f06-11ea-86fa-94f09e3fd64e.png)

Utility: 
![image](https://user-images.githubusercontent.com/15703773/79351450-b0be1500-7f06-11ea-8841-2ebf8367b846.png)

