### PR TITLE
Update font size of input labels

### DIFF
--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -1182,7 +1182,7 @@ $sprk-label-padding: 0 !default;
 /// The font family applied to Input labels.
 $sprk-label-font-family: $sprk-font-family-body-two !default;
 /// The font size applied to Input labels.
-$sprk-label-font-size: 0.875rem !default;
+$sprk-label-font-size: 1rem !default;
 /// The font weight applied to Input labels.
 $sprk-label-font-weight: 400 !default;
 /// The line height applied to Input labels.

--- a/src/data/sass-modifiers.json
+++ b/src/data/sass-modifiers.json
@@ -17279,7 +17279,7 @@
     "context": {
       "type": "variable",
       "name": "sprk-label-font-size",
-      "value": "0.875rem",
+      "value": "1rem",
       "scope": "default",
       "line": {
         "start": 1185,

--- a/src/data/sass-vars.json
+++ b/src/data/sass-vars.json
@@ -11354,7 +11354,7 @@
     "context": {
       "type": "variable",
       "name": "sprk-label-font-size",
-      "value": "0.875rem",
+      "value": "1rem",
       "scope": "default",
       "line": {
         "start": 1185,


### PR DESCRIPTION
## What does this PR do?
Update input labels from 14px to 16px
<img width="1004" alt="Screen Shot 2020-04-20 at 4 41 04 PM" src="https://user-images.githubusercontent.com/4342363/79801418-20c80300-832c-11ea-9778-fc2d4ae683ee.png">

### Associated Issue
Fixes #3067 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)

### Design Review
 - [x] Design reviewed and approved
