### PR TITLE
Gatsby background

### DIFF
--- a/src/scss/_spark-theme.scss
+++ b/src/scss/_spark-theme.scss
@@ -11,7 +11,7 @@ body {
   background-color: white;
 }
 
-  /* stylelint-disable selector-class-pattern */
+/* stylelint-disable selector-class-pattern */
 // SprkTables only allow
 // class to be added on table container
 // unless you go full-control mode

--- a/src/scss/_spark-theme.scss
+++ b/src/scss/_spark-theme.scss
@@ -7,7 +7,11 @@ $sprk-webfonts:
   ((url('https://spark-assets.netlify.app/RocketSans-Regular.woff2') format('woff2'), url('https://spark-assets.netlify.app/RocketSans-Regular.woff') format('woff')), RocketSans, 400),
   ((url('https://spark-assets.netlify.app/RocketSans-Light.woff2') format('woff2'), url('https://spark-assets.netlify.app/RocketSans-Light.woff') format('woff')), RocketSans, 300);
 
-/* stylelint-disable selector-class-pattern */
+body {
+  background-color: white;
+}
+
+  /* stylelint-disable selector-class-pattern */
 // SprkTables only allow
 // class to be added on table container
 // unless you go full-control mode


### PR DESCRIPTION
## What does this PR do?
Adds a background color to the gatsby site so when in dark mode you can still read our content.

### Associated Issue
Fixes #3088 

### Documentation
 - [x] Update Spark Docs

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
