### PR TITLE
React link hotfix

### DIFF
--- a/react/package-lock.json
+++ b/react/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkdesignsystem/spark-react",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/react/package.json
+++ b/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkdesignsystem/spark-react",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "A collection of Spark Design System components in React 16+",
   "main": "dist/index.js",
   "scripts": {

--- a/react/src/base/links/SprkLink.js
+++ b/react/src/base/links/SprkLink.js
@@ -20,7 +20,7 @@ const SprkLink = (props) => {
     'sprk-b-Link--simple': variant === 'simple',
     'sprk-b-Link--plain': variant === 'plain',
     'sprk-b-Link--disabled': variant === 'disabled',
-    'sprk-b-Link--simple sprk-b-Link--has-icon': variant === 'has-icon' || 'hasIcon',
+    'sprk-b-Link--simple sprk-b-Link--has-icon': variant === 'has-icon' || variant === 'hasIcon',
   });
 
   let link;

--- a/react/src/base/links/SprkLink.test.js
+++ b/react/src/base/links/SprkLink.test.js
@@ -10,12 +10,16 @@ describe('SprkLink:', () => {
     + ' is not unstyled', () => {
     const wrapper = shallow(<SprkLink />);
     expect(wrapper.find('a.sprk-b-Link').length).toBe(1);
+    expect(wrapper.find('a').hasClass('sprk-b-Link--simple')).toBe(false);
+    expect(wrapper.find('a').hasClass('sprk-b-Link--has-icon')).toBe(false);
   });
 
   it('should display a link element without the sprk-b-Link class if the'
     + ' variant is unstyled', () => {
     const wrapper = shallow(<SprkLink variant="unstyled" />);
     expect(wrapper.find('a').hasClass('sprk-b-Link')).toBe(false);
+    expect(wrapper.find('a').hasClass('sprk-b-Link--simple')).toBe(false);
+    expect(wrapper.find('a').hasClass('sprk-b-Link--has-icon')).toBe(false);
   });
 
   it('should display a link element with correct classes when variant'
@@ -23,6 +27,7 @@ describe('SprkLink:', () => {
     const wrapper = shallow(<SprkLink variant="simple" />);
     expect(wrapper.find('a').hasClass('sprk-b-Link')).toBe(true);
     expect(wrapper.find('a').hasClass('sprk-b-Link--simple')).toBe(true);
+    expect(wrapper.find('a').hasClass('sprk-b-Link--has-icon')).toBe(false);
   });
 
   it('should display a link element with correct classes when variant is '
@@ -46,6 +51,8 @@ describe('SprkLink:', () => {
     const wrapper = shallow(<SprkLink variant="plain" />);
     expect(wrapper.find('a').hasClass('sprk-b-Link')).toBe(true);
     expect(wrapper.find('a').hasClass('sprk-b-Link--plain')).toBe(true);
+    expect(wrapper.find('a').hasClass('sprk-b-Link--simple')).toBe(false);
+    expect(wrapper.find('a').hasClass('sprk-b-Link--has-icon')).toBe(false);
   });
 
   it('should display a link element with correct classes when variant is'


### PR DESCRIPTION
## What does this PR do?
Updates a faulty OR conditional in the React SprkLink component file that resulted in extra CSS classes being added to SprkLink components. Adds some extra expectations to jest teests

### Associated Issue
Fixes #3104 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
