### PR TITLE
revert label font size

### DIFF
--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -1238,7 +1238,7 @@ $sprk-label-padding: 0 !default;
 /// The font family applied to Input labels.
 $sprk-label-font-family: $sprk-font-family-body-two !default;
 /// The font size applied to Input labels.
-$sprk-label-font-size: 1rem !default;
+$sprk-label-font-size: 0.875rem !default;
 /// The font weight applied to Input labels.
 $sprk-label-font-weight: 400 !default;
 /// The line height applied to Input labels.


### PR DESCRIPTION
## What does this PR do?
Reverts label font size based on request from design.

### Associated Issue
Fixes #3115 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR
then please remove it.

### Code
 - [x] Build Component in HTML
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)

### Accessibility
- [x] New changes abide by [accessibility requirements](https://sparkdesignsystem.com/docs/accessibility)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)

### Design Review
 - [x] Design reviewed and approved

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
