### PR TITLE
add note about sticky masthead/IE11 to story files

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -64,6 +64,8 @@ into the component template.
     of the mobile version of the masthead (typically a sign in link)
 - The Masthead is a navigation landmark for accessibility
 tools. The attribute \`role=”banner”\` must be present.
+- The Masthead will be "sticky" on small viewports in all browsers
+except for IE11.
 `,
     docs: { iframeHeight: 300 },
   },

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -42,6 +42,8 @@ fit in one row, the Extended Masthead utilizes a second row,
 the big nav, to display the navigation items.
 - The Masthead is a navigation landmark for accessibility
 tools. The attribute \`role=”banner”\` must be present.
+- The Masthead will be "sticky" on small viewports in all browsers
+except for IE11.
 `,
   },
 };

--- a/react/src/components/masthead/SprkMasthead.stories.js
+++ b/react/src/components/masthead/SprkMasthead.stories.js
@@ -63,6 +63,8 @@ fit in one row, the Extended Masthead utilizes a second row,
 the big nav, to display the navigation items.
 - The Masthead is a navigation landmark for accessibility
 tools. The attribute \`role=”banner”\` must be present.
+- The Masthead will be "sticky" on small viewports in all browsers
+except for IE11.
 `,
   },
 };


### PR DESCRIPTION
## What does this PR do?
Adds note about sticky masthead/IE11 to story files to let users know to except the masthead to not be sticky in IE11.

### Associated Issue
Fixes #3154 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Documentation
 - [x] Update Spark Docs

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)