### PR TITLE
update angular install guide to include adding the sprk-u-JavaScript class

### DIFF
--- a/src/pages/installing-spark/angular.mdx
+++ b/src/pages/installing-spark/angular.mdx
@@ -142,7 +142,7 @@ cropped, but that’s OK. It’s
 because we don’t yet have
 any layout on the page.
 
-7. Now let’s add some TypeScript
+7. Now, let’s add some TypeScript
 to trigger the Spinner
 behavior. Copy this code into
 the `AppComponent` class inside

--- a/src/pages/installing-spark/angular.mdx
+++ b/src/pages/installing-spark/angular.mdx
@@ -81,7 +81,11 @@ stylesheet. This file can be found in `your-app/src`.
 
 > Note: Importing Spark SCSS at the component level can lead to unexpected behavior.
 
-4. Back on the command line, build
+4. Then, add the `sprk-u-JavaScript` CSS class the root `<html>` element
+in your application. Usually, the `<html>`
+element is in the `index.html` file.
+
+5. Back on the command line, build
 and run your new application by running
 `npm run start` and opening `http://localhost:4200/`
 in your web browser. When Angular builds,
@@ -138,7 +142,7 @@ cropped, but that’s OK. It’s
 because we don’t yet have
 any layout on the page.
 
-6. Now let’s add some TypeScript
+7. Now let’s add some TypeScript
 to trigger the Spinner
 behavior. Copy this code into
 the `AppComponent` class inside
@@ -158,7 +162,7 @@ export class AppComponent {
 }
 ```
 
-7. Finally, import the `setSpinning`
+8. Finally, import the `setSpinning`
 utility function from the Spark
 library. This goes at the top
 of your component’s `.ts` file,
@@ -168,7 +172,7 @@ in our case `app.component.ts`.
 import { setSpinning } from '@sparkdesignsystem/spark';
 ```
 
-8. Head back to your web browser and
+9. Head back to your web browser and
 click the Spark Button that you
 added earlier. If everything's
 working correctly, the text

--- a/src/pages/installing-spark/angular.mdx
+++ b/src/pages/installing-spark/angular.mdx
@@ -81,7 +81,7 @@ stylesheet. This file can be found in `your-app/src`.
 
 > Note: Importing Spark SCSS at the component level can lead to unexpected behavior.
 
-4. Then, add the `sprk-u-JavaScript` CSS class the root `<html>` element
+4. Then, add the `sprk-u-JavaScript` CSS class to the root `<html>` element
 in your application. Usually, the `<html>`
 element is in the `index.html` file.
 


### PR DESCRIPTION
## What does this PR do?
Stepper and Tabs uses the class "sprk-u-HideWhenJs", which is dependent on if JS class is present. We used to have this step in our old docs but it got lost. Adding it back for now is a temp fix to get teams running until we decide to drop the hidewhenjs and use display--none instead OR we update angular pkg to add it automatically. 

### Associated Issue
Fixes https://github.com/sparkdesignsystem/Backlog/issues/1052

### Documentation
 - [x] Update Spark Docs