### PR TITLE
Correct api to isDisabled

### DIFF
--- a/react/src/base/inputs/SprkCheckbox.stories.js
+++ b/react/src/base/inputs/SprkCheckbox.stories.js
@@ -107,12 +107,12 @@ invalidCheckbox.story = {
 };
 
 export const disabledCheckbox = () => (
-  <SprkCheckboxGroup disabled>
+  <SprkCheckboxGroup isDisabled>
     <SprkFieldset>
-      <SprkLegend disabled>Group Label Name</SprkLegend>
-      <SprkCheckboxItem disabled>Checkbox Item 1</SprkCheckboxItem>
-      <SprkCheckboxItem disabled>Checkbox Item 2</SprkCheckboxItem>
-      <SprkCheckboxItem disabled>Checkbox Item 3</SprkCheckboxItem>
+      <SprkLegend isDisabled>Group Label Name</SprkLegend>
+      <SprkCheckboxItem isDisabled>Checkbox Item 1</SprkCheckboxItem>
+      <SprkCheckboxItem isDisabled>Checkbox Item 2</SprkCheckboxItem>
+      <SprkCheckboxItem isDisabled>Checkbox Item 3</SprkCheckboxItem>
     </SprkFieldset>
   </SprkCheckboxGroup>
 );
@@ -185,27 +185,27 @@ hugeInvalid.story = {
 };
 
 export const hugeDisabled = () => (
-  <SprkCheckboxGroup variant="huge" disabled>
+  <SprkCheckboxGroup variant="huge" isDisabled>
     <SprkFieldset>
-      <SprkLegend disabled>Group Label Name</SprkLegend>
+      <SprkLegend isDisabled>Group Label Name</SprkLegend>
       <SprkCheckboxItem
         variant="huge"
         ariaDescribedBy="checkbox-error-container"
-        disabled
+        isDisabled
       >
         Checkbox Item 1
       </SprkCheckboxItem>
       <SprkCheckboxItem
         variant="huge"
         ariaDescribedBy="checkbox-error-container"
-        disabled
+        isDisabled
       >
         Checkbox Item 2
       </SprkCheckboxItem>
       <SprkCheckboxItem
         variant="huge"
         ariaDescribedBy="checkbox-error-container"
-        disabled
+        isDisabled
       >
         Checkbox Item 3
       </SprkCheckboxItem>

--- a/react/src/base/inputs/SprkCheckbox/SprkCheckboxItem/SprkCheckboxItem.js
+++ b/react/src/base/inputs/SprkCheckbox/SprkCheckboxItem/SprkCheckboxItem.js
@@ -14,7 +14,7 @@ const SprkCheckboxItem = (props) => {
     labelAdditionalClasses,
     name,
     value,
-    disabled,
+    isDisabled,
     onChangeFunc,
     id,
     ariaDescribedBy,
@@ -40,7 +40,7 @@ const SprkCheckboxItem = (props) => {
           checkboxAdditionalClasses,
         )}
         data-id={idString}
-        disabled={disabled}
+        disabled={isDisabled}
         id={id || internalId}
         name={name}
         onChange={onChangeFunc}
@@ -53,7 +53,7 @@ const SprkCheckboxItem = (props) => {
           'sprk-b-Label sprk-b-Label--inline sprk-b-Checkbox__label',
           labelAdditionalClasses,
           {
-            'sprk-b-Label--disabled': disabled,
+            'sprk-b-Label--disabled': isDisabled,
           },
         )}
         htmlFor={id || internalId}
@@ -129,7 +129,7 @@ SprkCheckboxItem.propTypes = {
   /**
    * Will render the component in its disabled state.
    */
-  disabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   /**
    * Passes in a function that handles the onChange of the input.
    */

--- a/react/src/base/inputs/SprkCheckbox/SprkCheckboxItem/SprkCheckboxItem.test.js
+++ b/react/src/base/inputs/SprkCheckbox/SprkCheckboxItem/SprkCheckboxItem.test.js
@@ -27,7 +27,7 @@ describe('SprkCheckboxItem:', () => {
   });
 
   it('should apply disabled to the input/label if supplied', () => {
-    const wrapper = shallow(<SprkCheckboxItem disabled />);
+    const wrapper = shallow(<SprkCheckboxItem isDisabled />);
     expect(wrapper.find('.sprk-b-Checkbox__input').prop('disabled')).toBe(true);
     expect(
       wrapper.find('.sprk-b-Label').hasClass('sprk-b-Label--disabled'),

--- a/react/src/base/inputs/SprkLegend/SprkLegend.js
+++ b/react/src/base/inputs/SprkLegend/SprkLegend.js
@@ -8,14 +8,14 @@ const SprkLegend = (props) => {
     idString,
     analyticsString,
     additionalClasses,
-    disabled,
+    isDisabled,
     ...other
   } = props;
 
   return (
     <legend
       className={classnames('sprk-b-Legend sprk-b-Label', additionalClasses, {
-        'sprk-b-Label--disabled': disabled,
+        'sprk-b-Label--disabled': isDisabled,
       })}
       data-analytics={analyticsString}
       data-id={idString}
@@ -47,7 +47,7 @@ SprkLegend.propTypes = {
   /**
    * Will render the component in its disabled state.
    */
-  disabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 export default SprkLegend;

--- a/react/src/base/inputs/SprkLegend/SprkLegend.test.js
+++ b/react/src/base/inputs/SprkLegend/SprkLegend.test.js
@@ -13,7 +13,7 @@ describe('SprkLegend:', () => {
   });
 
   it('should apply disabled classes', () => {
-    const wrapper = shallow(<SprkLegend disabled />);
+    const wrapper = shallow(<SprkLegend isDisabled />);
     expect(
       wrapper.find('.sprk-b-Legend').hasClass('sprk-b-Label--disabled'),
     ).toEqual(true);

--- a/react/src/base/inputs/SprkRadio.stories.js
+++ b/react/src/base/inputs/SprkRadio.stories.js
@@ -104,14 +104,14 @@ invalidRadio.story = {
 export const disabledRadio = () => (
   <SprkRadioGroup>
     <SprkFieldset>
-      <SprkLegend disabled>Group Label Name</SprkLegend>
-      <SprkRadioItem name="radio" disabled>
+      <SprkLegend isDisabled>Group Label Name</SprkLegend>
+      <SprkRadioItem name="radio" isDisabled>
         Radio Item 1
       </SprkRadioItem>
-      <SprkRadioItem name="radio" disabled>
+      <SprkRadioItem name="radio" isDisabled>
         Radio Item 2
       </SprkRadioItem>
-      <SprkRadioItem name="radio" disabled>
+      <SprkRadioItem name="radio" isDisabled>
         Radio Item 3
       </SprkRadioItem>
     </SprkFieldset>
@@ -205,14 +205,14 @@ hugeInvalid.story = {
 };
 
 export const hugeDisabled = () => (
-  <SprkRadioGroup variant="huge" disabled>
+  <SprkRadioGroup variant="huge" isDisabled>
     <SprkFieldset>
       <SprkLegend>Group Label Name</SprkLegend>
       <SprkRadioItem
         name="radio"
         variant="huge"
         ariaDescribedBy="radio-error-container"
-        disabled
+        isDisabled
       >
         Radio Item 1
       </SprkRadioItem>
@@ -220,7 +220,7 @@ export const hugeDisabled = () => (
         name="radio"
         variant="huge"
         ariaDescribedBy="radio-error-container"
-        disabled
+        isDisabled
       >
         Radio Item 2
       </SprkRadioItem>
@@ -228,7 +228,7 @@ export const hugeDisabled = () => (
         name="radio"
         variant="huge"
         ariaDescribedBy="radio-error-container"
-        disabled
+        isDisabled
       >
         Radio Item 3
       </SprkRadioItem>

--- a/react/src/base/inputs/SprkRadio/SprkRadioItem/SprkRadioItem.js
+++ b/react/src/base/inputs/SprkRadio/SprkRadioItem/SprkRadioItem.js
@@ -14,7 +14,7 @@ const SprkRadioItem = (props) => {
     labelAdditionalClasses,
     name,
     value,
-    disabled,
+    isDisabled,
     onChangeFunc,
     id,
     ariaDescribedBy,
@@ -37,7 +37,7 @@ const SprkRadioItem = (props) => {
         aria-describedby={ariaDescribedBy}
         className={classnames('sprk-b-Radio__input', radioAdditionalClasses)}
         data-id={idString}
-        disabled={disabled}
+        disabled={isDisabled}
         id={id || internalId}
         name={name}
         onChange={onChangeFunc}
@@ -50,7 +50,7 @@ const SprkRadioItem = (props) => {
           'sprk-b-Label sprk-b-Label--inline sprk-b-Radio__label',
           labelAdditionalClasses,
           {
-            'sprk-b-Label--disabled': disabled,
+            'sprk-b-Label--disabled': isDisabled,
           },
         )}
         htmlFor={id || internalId}
@@ -117,7 +117,7 @@ SprkRadioItem.propTypes = {
   /**
    * Will render the component in its disabled state.
    */
-  disabled: PropTypes.bool,
+  isDisabled: PropTypes.bool,
   /**
    * Passes in a function that handles the onChange of the input.
    */

--- a/react/src/base/inputs/SprkRadio/SprkRadioItem/SprkRadioItem.test.js
+++ b/react/src/base/inputs/SprkRadio/SprkRadioItem/SprkRadioItem.test.js
@@ -25,7 +25,7 @@ describe('SprkRadioItem:', () => {
   });
 
   it('should apply disabled to the input/label if supplied', () => {
-    const wrapper = shallow(<SprkRadioItem disabled />);
+    const wrapper = shallow(<SprkRadioItem isDisabled />);
     expect(wrapper.find('.sprk-b-Radio__input').prop('disabled')).toBe(true);
     expect(
       wrapper.find('.sprk-b-Label').hasClass('sprk-b-Label--disabled'),


### PR DESCRIPTION
## What does this PR do?
Correct api to be more consistent with the direction we're going in 
from `disabled` to `isDisabled`
### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

