### PR TITLE
tooltip spacing at narrow layouts (HTML and React)

### DIFF
--- a/html/components/tooltip.js
+++ b/html/components/tooltip.js
@@ -25,17 +25,18 @@ const addPositioningClass = (trigger, tooltip) => {
   const maxWidth = 328;
   const triggerWidth = 16;
   const tooltipBorderWidth = 16;
+  const tooltipSpacing = 16;
   let calculatedWidth;
 
   if (elemX > viewportWidth / 2) {
-    calculatedWidth = elemX + triggerWidth + tooltipBorderWidth;
+    calculatedWidth = elemX + triggerWidth + tooltipBorderWidth - tooltipSpacing;
     if (elemY > viewportHeight / 2) {
       tooltip.classList.add('sprk-c-Tooltip--top-left');
     } else {
       tooltip.classList.add('sprk-c-Tooltip--bottom-left');
     }
   } else {
-    calculatedWidth = viewportWidth - elemX + tooltipBorderWidth;
+    calculatedWidth = viewportWidth - elemX + tooltipBorderWidth - tooltipSpacing;
     if (elemY > viewportHeight / 2) {
       tooltip.classList.add('sprk-c-Tooltip--top-right');
     } else {

--- a/react/src/components/tooltip/SprkTooltip.js
+++ b/react/src/components/tooltip/SprkTooltip.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
 import SprkIcon from '../icons/SprkIcon';
+import { tooltip } from '../../../../html/components/tooltip';
 
 class SprkTooltip extends Component {
   constructor(props) {
@@ -46,17 +47,19 @@ class SprkTooltip extends Component {
     const maxWidth = 328;
     const triggerWidth = 16;
     const tooltipBorderWidth = 16;
+    const tooltipSpacing = 16;
+
     let calculatedWidth;
 
     if (elemX > viewportWidth / 2) {
-      calculatedWidth = elemX + triggerWidth + tooltipBorderWidth;
+      calculatedWidth = elemX + triggerWidth + tooltipBorderWidth - tooltipSpacing;
       if (elemY > viewportHeight / 2) {
         this.setState({ position: 'topleft' });
       } else {
         this.setState({ position: 'bottomleft' });
       }
     } else {
-      calculatedWidth = viewportWidth - elemX + tooltipBorderWidth;
+      calculatedWidth = viewportWidth - elemX + tooltipBorderWidth - tooltipSpacing;
       if (elemY > viewportHeight / 2) {
         this.setState({ position: 'topright' });
       } else {

--- a/react/src/components/tooltip/SprkTooltip.js
+++ b/react/src/components/tooltip/SprkTooltip.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import uniqueId from 'lodash/uniqueId';
 import SprkIcon from '../icons/SprkIcon';
-import { tooltip } from '../../../../html/components/tooltip';
 
 class SprkTooltip extends Component {
   constructor(props) {


### PR DESCRIPTION
Adds a 16px margin to the vertical edge of the tooltip that is furthest from the chevron at widths smaller than 328px.

Before:
![image](https://user-images.githubusercontent.com/1424560/87190264-2ba58a80-c2c0-11ea-8af4-b0fec880daa9.png)


After:
![image](https://user-images.githubusercontent.com/1424560/87190221-17fa2400-c2c0-11ea-9a9d-ff8e53a8080f.png)
