### PR TITLE
Guide typo

### DIFF
--- a/src/pages/installing-spark/react.mdx
+++ b/src/pages/installing-spark/react.mdx
@@ -39,7 +39,7 @@ body {
 ```
 5. In `App.scss`, import this new file:
 ``` javascript
-@import ‘./styles.scss’;
+@import './styles.scss';
 ```
 
 If your React server has stopped, restart it now and view your compiled


### PR DESCRIPTION
Fixes a typo in the React Installation guide