### PR TITLE
Replace shown trigger text with the title rather than the value

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.spec.ts
@@ -15,8 +15,8 @@ describe('SprkDropdownComponent', () => {
       declarations: [
         SprkDropdownComponent,
         SprkIconComponent,
-        SprkLinkDirective
-      ]
+        SprkLinkDirective,
+      ],
     }).compileComponents();
   }));
 
@@ -36,7 +36,7 @@ describe('SprkDropdownComponent', () => {
   it('should add the correct classes if additionalClasses are supplied', () => {
     component.additionalClasses = 'sprk-u-pam sprk-u-man';
     expect(component.getClasses()).toEqual(
-      'sprk-c-Dropdown sprk-u-pam sprk-u-man'
+      'sprk-c-Dropdown sprk-u-pam sprk-u-man',
     );
   });
 
@@ -86,11 +86,11 @@ describe('SprkDropdownComponent', () => {
         content: {
           title: 'Choice Title',
           infoLine1: 'Information about this choice',
-          infoLine2: 'More Information'
+          infoLine2: 'More Information',
         },
         value: 'Choice Title 1',
-        active: false
-      }
+        active: false,
+      },
     ];
     fixture.detectChanges();
     dropdownTriggerElement.click();
@@ -110,10 +110,10 @@ describe('SprkDropdownComponent', () => {
         content: {
           title: 'Choice Title',
           infoLine1: 'Information about this choice',
-          infoLine2: 'More Information'
+          infoLine2: 'More Information',
         },
-        value: 'Choice Title 1'
-      }
+        value: 'Choice Title 1',
+      },
     ];
     dropdownTriggerElement.click();
     fixture.detectChanges();
@@ -129,12 +129,12 @@ describe('SprkDropdownComponent', () => {
     component.choices = [
       {
         text: 'Option 1',
-        value: 'Option 1'
+        value: 'Option 1',
       },
       {
         text: 'Option 2',
-        value: 'Option 2'
-      }
+        value: 'Option 2',
+      },
     ];
     dropdownTriggerElement.click();
     fixture.detectChanges();
@@ -149,7 +149,7 @@ describe('SprkDropdownComponent', () => {
     component.additionalTriggerClasses = 'sprk-u-man';
     fixture.detectChanges();
     expect(dropdownTriggerElement.classList.contains('sprk-u-man')).toEqual(
-      true
+      true,
     );
   });
 
@@ -157,7 +157,7 @@ describe('SprkDropdownComponent', () => {
     component.additionalTriggerTextClasses = 'sprk-u-man';
     fixture.detectChanges();
     expect(dropdownTriggerTextElement.classList.contains('sprk-u-man')).toEqual(
-      true
+      true,
     );
   });
 
@@ -165,25 +165,25 @@ describe('SprkDropdownComponent', () => {
     component.triggerText = 'test';
     component.screenReaderText = '';
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('a').getAttribute('aria-label')).toEqual(
-      'test'
-    );
+    expect(
+      fixture.nativeElement.querySelector('a').getAttribute('aria-label'),
+    ).toEqual('test');
   });
 
   it('should apply aria-label when screenReaderText is provided', () => {
     component.triggerText = '';
     component.screenReaderText = 'test';
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('a').getAttribute('aria-label')).toEqual(
-      'test'
-    );
+    expect(
+      fixture.nativeElement.querySelector('a').getAttribute('aria-label'),
+    ).toEqual('test');
   });
 
   it('should apply a default aria-label when none is provided', () => {
     fixture.detectChanges();
-    expect(fixture.nativeElement.querySelector('a').getAttribute('aria-label')).toEqual(
-      'Choose One'
-    );
+    expect(
+      fixture.nativeElement.querySelector('a').getAttribute('aria-label'),
+    ).toEqual('Choose One');
   });
 
   it('should apply an aria-label to listbox when title provided', () => {
@@ -192,7 +192,9 @@ describe('SprkDropdownComponent', () => {
     dropdownTriggerElement.click();
 
     fixture.detectChanges();
-    const listBoxAria = fixture.nativeElement.querySelector('.sprk-c-Dropdown__links').getAttribute('aria-label');
+    const listBoxAria = fixture.nativeElement
+      .querySelector('.sprk-c-Dropdown__links')
+      .getAttribute('aria-label');
     expect(listBoxAria).toEqual('test');
   });
 
@@ -202,17 +204,41 @@ describe('SprkDropdownComponent', () => {
     dropdownTriggerElement.click();
 
     fixture.detectChanges();
-    const listBoxAria = fixture.nativeElement.querySelector('.sprk-c-Dropdown__links').getAttribute('aria-label');
+    const listBoxAria = fixture.nativeElement
+      .querySelector('.sprk-c-Dropdown__links')
+      .getAttribute('aria-label');
     expect(listBoxAria).toEqual('test');
   });
 
   it('should apply a default aria-label to listbox when none is provided', () => {
     dropdownTriggerElement.click();
     fixture.detectChanges();
-    const listBoxAria = fixture.nativeElement.querySelector('.sprk-c-Dropdown__links').getAttribute('aria-label');
-    expect(listBoxAria).toEqual(
-      'My Choices'
-    );
+    const listBoxAria = fixture.nativeElement
+      .querySelector('.sprk-c-Dropdown__links')
+      .getAttribute('aria-label');
+    expect(listBoxAria).toEqual('My Choices');
+  });
 
+  it('should update the trigger text to the title of the choice clicked', () => {
+    component.dropdownType = 'informational';
+    component.choices = [
+      {
+        content: {
+          title: 'Title Test',
+          infoLine1: 'Information about this choice',
+          infoLine2: 'More Information',
+        },
+        value: 'Value Test',
+        active: false,
+      },
+    ];
+    fixture.detectChanges();
+    dropdownTriggerElement.click();
+    fixture.detectChanges();
+    expect(component.isOpen).toEqual(true);
+    const listElement = fixture.nativeElement.querySelectorAll('li')[0];
+    listElement.dispatchEvent(new Event('click'));
+    fixture.detectChanges();
+    expect(dropdownTriggerElement.textContent).toEqual('Title Test');
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -4,7 +4,7 @@ import {
   Output,
   ElementRef,
   HostListener,
-  EventEmitter
+  EventEmitter,
 } from '@angular/core';
 import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
 
@@ -25,7 +25,9 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
           [analyticsString]="analyticsString"
           aria-haspopup="listbox"
           href="#"
-          [attr.aria-label]="triggerText ? triggerText : (screenReaderText || 'Choose One')"
+          [attr.aria-label]="
+            triggerText ? triggerText : screenReaderText || 'Choose One'
+          "
         >
           <span [ngClass]="getTriggerTextClasses()">{{ triggerText }}</span>
           <span class="sprk-u-ScreenReaderText">{{ screenReaderText }}</span>
@@ -72,7 +74,7 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
         <ul
           class="sprk-c-Dropdown__links"
           role="listbox"
-          [attr.aria-label]="title ? title : (screenReaderText || 'My Choices')"
+          [attr.aria-label]="title ? title : screenReaderText || 'My Choices'"
         >
           <li
             class="sprk-c-Dropdown__item"
@@ -119,7 +121,7 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
         <ng-content select="[sprkDropdownFooter]"></ng-content>
       </div>
     </div>
-  `
+  `,
 })
 export class SprkDropdownComponent {
   /**
@@ -262,7 +264,7 @@ export class SprkDropdownComponent {
   choiceClick(event) {
     this.clearActiveChoices();
     const choiceIndex = event.currentTarget.getAttribute(
-      'data-sprk-dropdown-choice-index'
+      'data-sprk-dropdown-choice-index',
     );
     const clickedChoice = this.choices[choiceIndex];
     if (
@@ -280,18 +282,20 @@ export class SprkDropdownComponent {
    */
   setActiveChoice(event): void {
     const choiceIndex = event.currentTarget.getAttribute(
-      'data-sprk-dropdown-choice-index'
+      'data-sprk-dropdown-choice-index',
     );
     this.choices[choiceIndex]['active'] = true;
   }
   /**
    * @ignore
+   * This method is only for when the Dropdown
+   * has a text trigger and not an icon trigger.
    */
   updateTriggerText(event): void {
     const choiceIndex = event.currentTarget.getAttribute(
-      'data-sprk-dropdown-choice-index'
+      'data-sprk-dropdown-choice-index',
     );
-    this.triggerText = this.choices[choiceIndex]['value'];
+    this.triggerText = this.choices[choiceIndex].content.title;
   }
 
   /**
@@ -317,7 +321,7 @@ export class SprkDropdownComponent {
     const classArray: string[] = ['sprk-c-Dropdown'];
 
     if (this.additionalClasses) {
-      this.additionalClasses.split(' ').forEach(className => {
+      this.additionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }
@@ -332,7 +336,7 @@ export class SprkDropdownComponent {
     const classArray: string[] = [];
 
     if (this.additionalTriggerClasses) {
-      this.additionalTriggerClasses.split(' ').forEach(className => {
+      this.additionalTriggerClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }
@@ -347,7 +351,7 @@ export class SprkDropdownComponent {
     const classArray: string[] = [''];
 
     if (this.additionalTriggerTextClasses) {
-      this.additionalTriggerTextClasses.split(' ').forEach(className => {
+      this.additionalTriggerTextClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.stories.ts
@@ -9,10 +9,8 @@ export default {
   component: SprkDropdownComponent,
   decorators: [
     storyWrapper(
-      storyContent => (
-        `<div class="sprk-o-Box">${ storyContent }<div>`
-      )
-    )
+      (storyContent) => `<div class="sprk-o-Box">${storyContent}<div>`,
+    ),
   ],
   parameters: {
     info: `
@@ -26,10 +24,7 @@ element has a popup menu.
 };
 
 const modules = {
-  imports: [
-    SprkDropdownModule,
-    SprkLinkDirectiveModule,
-  ],
+  imports: [SprkDropdownModule, SprkLinkDirectiveModule],
 };
 
 export const defaultStory = () => ({
@@ -52,14 +47,14 @@ export const defaultStory = () => ({
       ]"
     >
     </sprk-dropdown>
-  `
+  `,
 });
 
 defaultStory.story = {
   name: 'Default',
   parameters: {
     jest: ['sprk-dropdown.component'],
-  }
+  },
 };
 
 export const informational = () => ({
@@ -77,7 +72,7 @@ export const informational = () => ({
           infoLine1: 'Information about this choice',
           infoLine2: 'More Information'
         },
-        value: 'Choice Title 1',
+        value: 'Choice Value 1',
         active: false
       },
       {
@@ -86,7 +81,7 @@ export const informational = () => ({
           infoLine1: 'Information about this choice',
           infoLine2: 'More Information'
         },
-        value: 'Choice Title 2',
+        value: 'Choice Value 2',
         active: true
       }
     ]"
@@ -105,7 +100,7 @@ export const informational = () => ({
         </a>
       </div>
     </sprk-dropdown>
-  `
+  `,
 });
 
 informational.story = {


### PR DESCRIPTION
## What does this PR do?
Spark dropdown in angular used to use the "value" to update the trigger text after a choice was clicked. This updates it to the text "title" of the choice as the text for the trigger text.

🛑BREAKING CHANGE: This is a breaking change because it changes the Trigger text from using the value on the choice object to the title text. This means that if someone has "Choice Value" set to the value and the "My Favorite Choice" set to the title. That now, the trigger text will show "My Favorite Choice" instead of "Choice Value"..

### Associated Issue
Fixes #3234 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing), should be noted that there is a masthead branch in the dropdown that is not covered and was historically chosen to not be covered.


### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)
