### PR TITLE
Dictionary Upgrades

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -8,7 +8,7 @@ describe('SprkAngularDictionaryComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SprkDictionaryComponent]
+      declarations: [SprkDictionaryComponent],
     }).compileComponents();
   }));
 
@@ -34,5 +34,45 @@ describe('SprkAngularDictionaryComponent', () => {
     component.idString = null;
     fixture.detectChanges();
     expect(element.getAttribute('data-id')).toBeNull();
+  });
+
+  it('should add additionalClasses', () => {
+    component.additionalClasses = 'spark design';
+    fixture.detectChanges();
+    expect(element.classList.toString()).toContain('spark');
+    expect(element.classList.toString()).toContain('design');
+  });
+
+  it('should add additionalKeysClasses', () => {
+    component.additionalKeysClasses = 'keysClass';
+    component.keyValuePairs = { key: 'value', key2: 'value2' };
+    fixture.detectChanges();
+
+    let keys = element.getElementsByClassName('sprk-c-Dictionary__key');
+
+    Array.prototype.forEach.call(keys, (key) => {
+      expect(key.classList.toString()).toContain('keysClass');
+    });
+  });
+
+  it('should add additionalValuesClasses', () => {
+    component.additionalValuesClasses = 'valuesClass';
+    component.keyValuePairs = { key: 'value', key2: 'value2' };
+    fixture.detectChanges();
+
+    let values = element.getElementsByClassName('sprk-c-Dictionary__value');
+
+    Array.prototype.forEach.call(values, (value) => {
+      expect(value.classList.toString()).toContain('valuesClass');
+    });
+  });
+
+  it('should correctly add striped class with deprecated Input', () => {
+    component.dictionaryType = 'striped';
+    fixture.detectChanges();
+
+    expect(element.classList.toString()).toContain(
+      'sprk-c-Dictionary--striped',
+    );
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -67,12 +67,48 @@ describe('SprkAngularDictionaryComponent', () => {
     });
   });
 
-  it('should correctly add striped class with deprecated Input', () => {
-    component.dictionaryType = 'striped';
+  it('should correctly add striped class', () => {
+    component.variant = 'striped';
+
     fixture.detectChanges();
 
     expect(element.classList.toString()).toContain(
       'sprk-c-Dictionary--striped',
     );
+  });
+
+  it('should correctly add striped class with deprecated Input', () => {
+    component.dictionaryType = 'striped';
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(element.classList.toString()).toContain(
+      'sprk-c-Dictionary--striped',
+    );
+  });
+
+  it('should add data correctly', () => {
+    component.keyValuePairs = { key1: 'value1', key2: 'value2' };
+    fixture.detectChanges();
+
+    expect(
+      element.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(2);
+    expect(
+      element.getElementsByClassName('sprk-c-Dictionary__value').length,
+    ).toBe(2);
+  });
+
+  it('should add data correctly with deprecated Input', () => {
+    component.data = { key1: 'value1', key2: 'value2' };
+    component.ngOnInit();
+    fixture.detectChanges();
+
+    expect(
+      element.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(2);
+    expect(
+      element.getElementsByClassName('sprk-c-Dictionary__value').length,
+    ).toBe(2);
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -48,7 +48,7 @@ describe('SprkAngularDictionaryComponent', () => {
     component.keyValuePairs = { key: 'value', key2: 'value2' };
     fixture.detectChanges();
 
-    let keys = element.getElementsByClassName('sprk-c-Dictionary__key');
+    const keys = element.getElementsByClassName('sprk-c-Dictionary__key');
 
     Array.prototype.forEach.call(keys, (key) => {
       expect(key.classList.toString()).toContain('keysClass');
@@ -60,7 +60,7 @@ describe('SprkAngularDictionaryComponent', () => {
     component.keyValuePairs = { key: 'value', key2: 'value2' };
     fixture.detectChanges();
 
-    let values = element.getElementsByClassName('sprk-c-Dictionary__value');
+    const values = element.getElementsByClassName('sprk-c-Dictionary__value');
 
     Array.prototype.forEach.call(values, (value) => {
       expect(value.classList.toString()).toContain('valuesClass');

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -43,8 +43,8 @@ describe('SprkAngularDictionaryComponent', () => {
     expect(element.classList.toString()).toContain('design');
   });
 
-  it('should add additionalKeysClasses', () => {
-    component.additionalKeysClasses = 'keysClass';
+  it('should add keysAdditionalClasses', () => {
+    component.keysAdditionalClasses = 'keysClass';
     component.keyValuePairs = { key: 'value', key2: 'value2' };
     fixture.detectChanges();
 
@@ -55,8 +55,8 @@ describe('SprkAngularDictionaryComponent', () => {
     });
   });
 
-  it('should add additionalValuesClasses', () => {
-    component.additionalValuesClasses = 'valuesClass';
+  it('should add valuesAdditionalClasses', () => {
+    component.valuesAdditionalClasses = 'valuesClass';
     component.keyValuePairs = { key: 'value', key2: 'value2' };
     fixture.detectChanges();
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
@@ -18,7 +18,8 @@ import { Component, Input, OnInit } from '@angular/core';
 })
 export class SprkDictionaryComponent implements OnInit {
   /**
-   * The collection of key-value pairs to be rendered into the component.
+   * Deprecated - Use `keyValuePairs` instead. The collection of key-value
+   * pairs to be rendered into the component.
    */
   @Input()
   data: object = {};
@@ -28,9 +29,9 @@ export class SprkDictionaryComponent implements OnInit {
   @Input()
   keyValuePairs: object = {};
   /**
-   * Determines the variant of the dictionary component to render. The only
-   * available option is `striped`. Supplying no value will cause the base
-   * variant to be used.
+   * Deprecated - Use `variant` instead.  Determines the variant of the
+   * dictionary component to render. The only available option is `striped`.
+   * Supplying no value will cause the base variant to be used.
    */
   @Input()
   dictionaryType: string;
@@ -47,12 +48,14 @@ export class SprkDictionaryComponent implements OnInit {
   @Input()
   additionalClasses: string;
   /**
-   * Expects a space separated string of classes to be added to the TODO.
+   * Expects a space separated string of classes to be added to each key
+   * element.
    */
   @Input()
   additionalKeysClasses: string;
   /**
-   * Expects a space separated string of classes to be added to the TODO.
+   * Expects a space separated string of classes to be added to each value
+   * element.
    */
   @Input()
   additionalValuesClasses: string;
@@ -122,6 +125,9 @@ export class SprkDictionaryComponent implements OnInit {
     return classArray.join(' ');
   }
 
+  /**
+   * @ignore
+   */
   isEmpty = (obj) => {
     return Object.keys(obj).length === 0;
   };

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 
 @Component({
   selector: 'sprk-dictionary',
@@ -6,55 +6,66 @@ import { Component, Input } from '@angular/core';
     <div [ngClass]="getClasses()" [attr.data-id]="idString">
       <dl class="sprk-c-Dictionary__keyvaluepairs">
         <div
-          *ngFor="let key of objectKeys(data)"
+          *ngFor="let key of objectKeys(keyValuePairs)"
           class="sprk-c-Dictionary__keyvaluepair"
         >
-          <dt
-            class="sprk-c-Dictionary__key sprk-b-Label sprk-b-Label--no-input"
-          >
-            {{ key }}
-          </dt>
-          <dd class="sprk-c-Dictionary__value">{{ data[key] }}</dd>
+          <dt [ngClass]="getKeysClasses()">{{ key }}</dt>
+          <dd [ngClass]="getValuesClasses()">{{ keyValuePairs[key] }}</dd>
         </div>
       </dl>
     </div>
   `,
 })
-export class SprkDictionaryComponent {
+export class SprkDictionaryComponent implements OnInit {
   /**
-   * The collection of key-value pairs to be rendered
-   * into the component.
+   * The collection of key-value pairs to be rendered into the component.
    */
   @Input()
   data: object = {};
   /**
-   * Determines the variant of the dictionary component to render.
-   * The only available option is `striped`.
-   * Supplying no value will cause the base variant to be used.
+   * The collection of key-value pairs to be rendered into the component.
+   */
+  @Input()
+  keyValuePairs: object = {};
+  /**
+   * Determines the variant of the dictionary component to render. The only
+   * available option is `striped`. Supplying no value will cause the base
+   * variant to be used.
    */
   @Input()
   dictionaryType: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * component.
+   * Determines the variant of the dictionary component to render. The only
+   * available option is `striped`. Supplying no value will cause the base
+   * variant to be used.
+   */
+  @Input()
+  variant: string;
+  /**
+   * Expects a space separated string of classes to be added to the component.
    */
   @Input()
   additionalClasses: string;
   /**
-   * The value supplied will be assigned
-   * to the `data-id` attribute on the
-   * component. This is intended to be
-   * used as a selector for automated
-   * tools. This value should be unique
-   * per page.
+   * Expects a space separated string of classes to be added to the TODO.
+   */
+  @Input()
+  additionalKeysClasses: string;
+  /**
+   * Expects a space separated string of classes to be added to the TODO.
+   */
+  @Input()
+  additionalValuesClasses: string;
+  /**
+   * The value supplied will be assigned to the `data-id` attribute on the
+   * component. This is intended to be used as a selector for automated tools.
+   * This value should be unique per page.
    */
   @Input()
   idString: string;
   /**
    * @ignore
-   * Used to grab all the keys from
-   * objects.
+   * Used to grab all the keys from objects.
    */
   objectKeys = Object.keys;
 
@@ -64,7 +75,7 @@ export class SprkDictionaryComponent {
   getClasses(): string {
     const classArray: string[] = ['sprk-c-Dictionary'];
 
-    if (this.dictionaryType === 'striped') {
+    if (this.variant === 'striped') {
       classArray.push('sprk-c-Dictionary--striped');
     }
 
@@ -75,5 +86,53 @@ export class SprkDictionaryComponent {
     }
 
     return classArray.join(' ');
+  }
+
+  /**
+   * @ignore
+   */
+  getKeysClasses(): string {
+    const classArray: string[] = [
+      'sprk-c-Dictionary__key',
+      'sprk-b-Label',
+      'sprk-b-Label--no-input',
+    ];
+
+    if (this.additionalKeysClasses) {
+      this.additionalKeysClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    }
+
+    return classArray.join(' ');
+  }
+
+  /**
+   * @ignore
+   */
+  getValuesClasses(): string {
+    const classArray: string[] = ['sprk-c-Dictionary__value'];
+
+    if (this.additionalValuesClasses) {
+      this.additionalValuesClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    }
+
+    return classArray.join(' ');
+  }
+
+  isEmpty = (obj) => {
+    return Object.keys(obj).length === 0;
+  };
+
+  ngOnInit(): void {
+    if (!this.isEmpty(this.data) && this.isEmpty(this.keyValuePairs)) {
+      this.keyValuePairs = this.data;
+    }
+
+    if (this.dictionaryType && !this.variant) {
+      this.variant = this.dictionaryType;
+    }
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
@@ -52,13 +52,13 @@ export class SprkDictionaryComponent implements OnInit {
    * element.
    */
   @Input()
-  additionalKeysClasses: string;
+  keysAdditionalClasses: string;
   /**
    * Expects a space separated string of classes to be added to each value
    * element.
    */
   @Input()
-  additionalValuesClasses: string;
+  valuesAdditionalClasses: string;
   /**
    * The value supplied will be assigned to the `data-id` attribute on the
    * component. This is intended to be used as a selector for automated tools.
@@ -101,8 +101,8 @@ export class SprkDictionaryComponent implements OnInit {
       'sprk-b-Label--no-input',
     ];
 
-    if (this.additionalKeysClasses) {
-      this.additionalKeysClasses.split(' ').forEach((className) => {
+    if (this.keysAdditionalClasses) {
+      this.keysAdditionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }
@@ -116,8 +116,8 @@ export class SprkDictionaryComponent implements OnInit {
   getValuesClasses(): string {
     const classArray: string[] = ['sprk-c-Dictionary__value'];
 
-    if (this.additionalValuesClasses) {
-      this.additionalValuesClasses.split(' ').forEach((className) => {
+    if (this.valuesAdditionalClasses) {
+      this.valuesAdditionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
@@ -18,7 +18,7 @@ import { Component, Input } from '@angular/core';
         </div>
       </dl>
     </div>
-  `
+  `,
 })
 export class SprkDictionaryComponent {
   /**
@@ -33,7 +33,7 @@ export class SprkDictionaryComponent {
    * Supplying no value will cause the base variant to be used.
    */
   @Input()
-  dictionaryType = 'base';
+  dictionaryType: string;
   /**
    * Expects a space separated string
    * of classes to be added to the
@@ -69,7 +69,7 @@ export class SprkDictionaryComponent {
     }
 
     if (this.additionalClasses) {
-      this.additionalClasses.split(' ').forEach(className => {
+      this.additionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.stories.ts
@@ -27,13 +27,13 @@ export const defaultStory = () => ({
     <sprk-dictionary
      idString="dictionary-default"
      [keyValuePairs]="{
-       'Email Address':'sparkdesignsystem@quickenloans.com',
-       'Mailing Address': '123 Main Street, Detroit, MI, 48216',
-       'Home Phone': '(123) 456-7890',
-       'Cell Phone': '(098) 765-4321',
-       'Work Phone': '(555) 555-5555',
-       'Work Extension': '55555'
-     }"
+      'Email Address':'sparkdesignsystem@quickenloans.com',
+      'Mailing Address': '123 Main Street, Detroit, MI, 48216',
+      'Home Phone': '(123) 456-7890',
+      'Cell Phone': '(098) 765-4321',
+      'Work Phone': '(555) 555-5555',
+      'Work Extension': '55555'
+    }"
     ></sprk-dictionary>
   `,
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.stories.ts
@@ -8,10 +8,8 @@ export default {
   component: SprkDictionaryComponent,
   decorators: [
     storyWrapper(
-      storyContent => (
-        `<div class="sprk-o-Box">${ storyContent }<div>`
-      )
-    )
+      (storyContent) => `<div class="sprk-o-Box">${storyContent}<div>`,
+    ),
   ],
   parameters: {
     info: `${markdownDocumentationLinkBuilder('dictionary')}`,
@@ -28,7 +26,7 @@ export const defaultStory = () => ({
   template: `
     <sprk-dictionary
      idString="dictionary-default"
-     [data]="{
+     [keyValuePairs]="{
        'Email Address':'sparkdesignsystem@quickenloans.com',
        'Mailing Address': '123 Main Street, Detroit, MI, 48216',
        'Home Phone': '(123) 456-7890',
@@ -36,9 +34,8 @@ export const defaultStory = () => ({
        'Work Phone': '(555) 555-5555',
        'Work Extension': '55555'
      }"
-     idString="dictionary-1"
     ></sprk-dictionary>
-  `
+  `,
 });
 
 defaultStory.story = {
@@ -52,9 +49,9 @@ export const striped = () => ({
   moduleMetadata: modules,
   template: `
     <sprk-dictionary
-     dictionaryType="striped"
+     variant="striped"
      idString="dictionary-striped"
-     [data]="{
+     [keyValuePairs]="{
        'Email Address':'sparkdesignsystem@quickenloans.com',
        'Mailing Address': '123 Main Street, Detroit, MI, 48216',
        'Home Phone': '(123) 456-7890',
@@ -62,14 +59,13 @@ export const striped = () => ({
        'Work Phone': '(555) 555-5555',
        'Work Extension': '55555'
      }"
-     idString="dictionary-2"
     ></sprk-dictionary>
-  `
+  `,
 });
 
 striped.story = {
   name: 'Striped',
   parameters: {
     jest: ['sprk-dictionary.component'],
-  }
+  },
 };

--- a/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-link/sprk-link.component.ts
@@ -24,7 +24,7 @@ import { Router } from '@angular/router';
     >
       <ng-content></ng-content>
     </a>
-  `
+  `,
 })
 /**
  * @deprecate This component will be removed in
@@ -166,16 +166,16 @@ export class SprkLinkComponent implements OnInit {
   isExternal = false;
 
   ngOnInit() {
-
     // This message is split up like this so that we can keep the line
     // length down in the editor while also logging a single unformatted
     // line of text in the console.
-    const message = 'Spark Design System Warning: Spark Link has been ' +
-    'refactored to be an Angular Directive. The old Angular Component ' +
-    'version has been deprecated. This version will be permanently removed ' +
-    'from Spark in our Summer 2020 release. To update to the new version, ' +
-    'replace any instance of the <sprk-link> component in your codebase with ' +
-    'the new Directive syntax.';
+    const message =
+      'Spark Design System Warning: Spark Link has been ' +
+      'refactored to be an Angular Directive. The old Angular Component ' +
+      'version has been deprecated. This version will be permanently removed ' +
+      'from Spark in an upcoming release. To update to the new version, ' +
+      'replace any instance of the <sprk-link> component in your codebase with ' +
+      'the new Directive syntax.';
 
     console.warn(message);
 
@@ -274,7 +274,7 @@ export class SprkLinkComponent implements OnInit {
         break;
       case 'icon':
         classArray.push(
-          'sprk-b-Link sprk-b-Link--simple sprk-b-Link--has-icon'
+          'sprk-b-Link sprk-b-Link--simple sprk-b-Link--has-icon',
         );
         break;
       default:
@@ -287,7 +287,7 @@ export class SprkLinkComponent implements OnInit {
     }
 
     if (this.additionalClasses) {
-      this.additionalClasses.split(' ').forEach(className => {
+      this.additionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
@@ -12,7 +12,12 @@ import { markdownDocumentationLinkBuilder } from '../../../../../../../storybook
 export default {
   title: 'Components/Link',
   component: SprkLinkDirective,
-  decorators: [storyWrapper(storyContent => `<div class="sprk-o-Box sb-decorate">${storyContent}<div>`)],
+  decorators: [
+    storyWrapper(
+      (storyContent) =>
+        `<div class="sprk-o-Box sb-decorate">${storyContent}<div>`,
+    ),
+  ],
   parameters: {
     info: `
 ${markdownDocumentationLinkBuilder('link')}
@@ -20,7 +25,7 @@ ${markdownDocumentationLinkBuilder('link')}
 use Spark classes.
 - Spark Link has been refactored to be an Angular Directive. The old Angular
 Component version has been deprecated. This version will be permanently
-removed from Spark in our Summer 2020 release. To update to the new version,
+removed from Spark in an upcoming release. To update to the new version,
 replace any instance of the <code><sprk-link></code> component in your codebase
 with the new Directive syntax.
 `,
@@ -33,12 +38,14 @@ const modules = {
     SprkLinkDirectiveModule,
     SprkIconModule,
     SprkLinkModule,
-    RouterModule.forRoot([{
-      path: 'iframe.html',
-      component: SprkLinkComponent,
-    }]),
+    RouterModule.forRoot([
+      {
+        path: 'iframe.html',
+        component: SprkLinkComponent,
+      },
+    ]),
   ],
-  providers: [{ provide: APP_BASE_HREF, useValue: '/' }]
+  providers: [{ provide: APP_BASE_HREF, useValue: '/' }],
 };
 
 export const defaultStory = () => ({
@@ -58,9 +65,7 @@ export const defaultStory = () => ({
 defaultStory.story = {
   name: 'Default',
   parameters: {
-    jest: [
-      'sprk-link.directive',
-    ],
+    jest: ['sprk-link.directive'],
   },
 };
 
@@ -81,9 +86,7 @@ export const simple = () => ({
 
 simple.story = {
   parameters: {
-    jest: [
-      'sprk-link.directive',
-    ],
+    jest: ['sprk-link.directive'],
   },
 };
 
@@ -109,9 +112,7 @@ export const iconWithTextLink = () => ({
 
 iconWithTextLink.story = {
   parameters: {
-    jest: [
-      'sprk-link.directive',
-    ],
+    jest: ['sprk-link.directive'],
   },
 };
 
@@ -133,7 +134,7 @@ export const disabled = () => ({
 disabled.story = {
   parameters: {
     jest: ['sprk-link.directive'],
-  }
+  },
 };
 
 export const deprecated = () => ({
@@ -153,6 +154,5 @@ deprecated.story = {
   name: 'Component (Deprecated)',
   parameters: {
     jest: ['sprk-link.component'],
-  }
+  },
 };
-

--- a/react/src/components/dictionary/SprkDictionary.js
+++ b/react/src/components/dictionary/SprkDictionary.js
@@ -19,26 +19,22 @@ const SprkDictionary = (props) => {
     'sprk-c-Dictionary--striped': variant === 'striped',
   });
 
-  // const keysClassNames = classnames(
-  //   'sprk-c-Dictionary__key',
-  //   'sprk-b-Label',
-  //   'sprk-b-Label--no-input',
-  //   additionalKeysClasses,
-  // );
+  const keysClassNames = classnames(
+    'sprk-c-Dictionary__key',
+    'sprk-b-Label',
+    'sprk-b-Label--no-input',
+    additionalKeysClasses,
+  );
 
-  // const valuesClassNames = classnames(
-  //   'sprk-c-Dictionary__key',
-  //   'sprk-b-Label',
-  //   'sprk-b-Label--no-input',
-  //   additionalValuesClasses,
-  // );
+  const valuesClassNames = classnames(
+    'sprk-c-Dictionary__value',
+    additionalValuesClasses,
+  );
 
   const keyValuePairsMap = Object.keys(keyValuePairs).map((term) => (
     <div className="sprk-c-Dictionary__keyvaluepair" key={uniqueId('key-')}>
-      <dt className="sprk-c-Dictionary__key sprk-b-Label sprk-b-Label--no-input">
-        {term}
-      </dt>
-      <dd className="sprk-c-Dictionary__value">{keyValuePairs[term]}</dd>
+      <dt className={keysClassNames}>{term}</dt>
+      <dd className={valuesClassNames}>{keyValuePairs[term]}</dd>
     </div>
   ));
 

--- a/react/src/components/dictionary/SprkDictionary.js
+++ b/react/src/components/dictionary/SprkDictionary.js
@@ -10,8 +10,8 @@ const SprkDictionary = (props) => {
     variant,
     idString,
     additionalClasses,
-    additionalKeysClasses,
-    additionalValuesClasses,
+    keysAdditionalClasses,
+    valuesAdditionalClasses,
     ...other
   } = props;
 
@@ -23,12 +23,12 @@ const SprkDictionary = (props) => {
     'sprk-c-Dictionary__key',
     'sprk-b-Label',
     'sprk-b-Label--no-input',
-    additionalKeysClasses,
+    keysAdditionalClasses,
   );
 
   const valuesClassNames = classnames(
     'sprk-c-Dictionary__value',
-    additionalValuesClasses,
+    valuesAdditionalClasses,
   );
 
   const keyValuePairsMap = Object.keys(keyValuePairs).map((term) => (
@@ -66,12 +66,12 @@ SprkDictionary.propTypes = {
    * Expects a space separated string of classes to be added to each key
    * element.
    */
-  additionalKeysClasses: PropTypes.string,
+  keysAdditionalClasses: PropTypes.string,
   /**
    * Expects a space separated string of classes to be added to each value
    * element.
    */
-  additionalValuesClasses: PropTypes.string,
+  valuesAdditionalClasses: PropTypes.string,
   /**
    * Expects a space separated string of classes to be added to the component.
    */

--- a/react/src/components/dictionary/SprkDictionary.js
+++ b/react/src/components/dictionary/SprkDictionary.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-len */
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
@@ -9,51 +10,74 @@ const SprkDictionary = (props) => {
     variant,
     idString,
     additionalClasses,
+    additionalKeysClasses,
+    additionalValuesClasses,
     ...other
   } = props;
 
-  const classNames = classnames(
-    'sprk-c-Dictionary',
-    additionalClasses, {
-      'sprk-c-Dictionary--striped': variant === 'striped',
-    },
-  );
+  const classNames = classnames('sprk-c-Dictionary', additionalClasses, {
+    'sprk-c-Dictionary--striped': variant === 'striped',
+  });
 
-  const keyValuePairsMap = Object.keys(keyValuePairs).map(term => (
+  // const keysClassNames = classnames(
+  //   'sprk-c-Dictionary__key',
+  //   'sprk-b-Label',
+  //   'sprk-b-Label--no-input',
+  //   additionalKeysClasses,
+  // );
+
+  // const valuesClassNames = classnames(
+  //   'sprk-c-Dictionary__key',
+  //   'sprk-b-Label',
+  //   'sprk-b-Label--no-input',
+  //   additionalValuesClasses,
+  // );
+
+  const keyValuePairsMap = Object.keys(keyValuePairs).map((term) => (
     <div className="sprk-c-Dictionary__keyvaluepair" key={uniqueId('key-')}>
-      <dt className="sprk-c-Dictionary__key sprk-b-Label sprk-b-Label--no-input">{term}</dt>
+      <dt className="sprk-c-Dictionary__key sprk-b-Label sprk-b-Label--no-input">
+        {term}
+      </dt>
       <dd className="sprk-c-Dictionary__value">{keyValuePairs[term]}</dd>
     </div>
   ));
 
   return (
     <div className={classNames} data-id={idString} {...other}>
-      <dl className="sprk-c-Dictionary__keyvaluepairs">
-        {keyValuePairsMap}
-      </dl>
+      <dl className="sprk-c-Dictionary__keyvaluepairs">{keyValuePairsMap}</dl>
     </div>
   );
 };
 
 SprkDictionary.propTypes = {
   /**
-   * The collection of key-value pairs
-   * to render.
+   * The collection of key-value pairs to render.
    */
   keyValuePairs: PropTypes.PropTypes.shape({
     '': '',
   }).isRequired,
   /**
-   * Determines the style of dictionary component.
-   * Supplying no value will cause the base styles to be used.
+   * Determines the style of dictionary component. Supplying no value will
+   * cause the base styles to be used.
    */
   variant: PropTypes.oneOf(['striped']),
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as a unique selector for
+   * automated tools.
    */
   idString: PropTypes.string,
   /**
-   * A space-separated string of classes to add to the outermost container of the component.
+   * Expects a space separated string of classes to be added to each key
+   * element.
+   */
+  additionalKeysClasses: PropTypes.string,
+  /**
+   * Expects a space separated string of classes to be added to each value
+   * element.
+   */
+  additionalValuesClasses: PropTypes.string,
+  /**
+   * Expects a space separated string of classes to be added to the component.
    */
   additionalClasses: PropTypes.string,
 };

--- a/react/src/components/dictionary/SprkDictionary.test.js
+++ b/react/src/components/dictionary/SprkDictionary.test.js
@@ -48,4 +48,81 @@ describe('SprkDictionary:', () => {
       ).toBe(true);
     },
   );
+
+  it('should add data-id', () => {
+    const testKeyValuePairs = {
+      'Email Address': 'sparkdesignsystem@quickenloans.com',
+      'Mailing Address': '123 Main Street, Detroit, MI, 48216',
+      'Home Phone': '(123) 456-7890',
+      'Cell Phone': '(098) 765-4321',
+      'Work Phone': '(555) 555-5555',
+      'Work Extension': '55555',
+    };
+    const wrapper = shallow(
+      <SprkDictionary keyValuePairs={testKeyValuePairs} idString="asdf" />,
+    );
+    expect(wrapper.find('div.sprk-c-Dictionary[data-id="asdf"]').length).toBe(
+      1,
+    );
+  });
+
+  it('should add additionalClasses', () => {
+    const testKeyValuePairs = {
+      'Email Address': 'sparkdesignsystem@quickenloans.com',
+      'Mailing Address': '123 Main Street, Detroit, MI, 48216',
+      'Home Phone': '(123) 456-7890',
+      'Cell Phone': '(098) 765-4321',
+      'Work Phone': '(555) 555-5555',
+      'Work Extension': '55555',
+    };
+    const wrapper = shallow(
+      <SprkDictionary
+        keyValuePairs={testKeyValuePairs}
+        additionalClasses="asdf"
+      />,
+    );
+    expect(wrapper.find('div.sprk-c-Dictionary').hasClass('asdf')).toBe(true);
+  });
+
+  it('should add additionalKeysClasses', () => {
+    const testKeyValuePairs = {
+      'Email Address': 'sparkdesignsystem@quickenloans.com',
+      'Mailing Address': '123 Main Street, Detroit, MI, 48216',
+      'Home Phone': '(123) 456-7890',
+      'Cell Phone': '(098) 765-4321',
+      'Work Phone': '(555) 555-5555',
+      'Work Extension': '55555',
+    };
+    const wrapper = shallow(
+      <SprkDictionary
+        keyValuePairs={testKeyValuePairs}
+        additionalKeysClasses="asdf"
+      />,
+    );
+
+    wrapper.find('.sprk-c-Dictionary__key').forEach((key) => {
+      expect(key.hasClass('asdf')).toBe(true);
+    });
+  });
+
+  it('should add additionalValuesClasses', () => {
+    const testKeyValuePairs = {
+      'Email Address': 'sparkdesignsystem@quickenloans.com',
+      'Mailing Address': '123 Main Street, Detroit, MI, 48216',
+      'Home Phone': '(123) 456-7890',
+      'Cell Phone': '(098) 765-4321',
+      'Work Phone': '(555) 555-5555',
+      'Work Extension': '55555',
+    };
+    const wrapper = shallow(
+      <SprkDictionary
+        keyValuePairs={testKeyValuePairs}
+        additionalValuesClasses="asdf"
+      />,
+    );
+
+    wrapper.find('sprk-c-Dictionary__value').forEach((value) => {
+      expect(value.hasClass('asdf')).toBe(true);
+    });
+  });
 });

--- a/react/src/components/dictionary/SprkDictionary.test.js
+++ b/react/src/components/dictionary/SprkDictionary.test.js
@@ -84,7 +84,7 @@ describe('SprkDictionary:', () => {
     expect(wrapper.find('div.sprk-c-Dictionary').hasClass('asdf')).toBe(true);
   });
 
-  it('should add additionalKeysClasses', () => {
+  it('should add keysAdditionalClasses', () => {
     const testKeyValuePairs = {
       'Email Address': 'sparkdesignsystem@quickenloans.com',
       'Mailing Address': '123 Main Street, Detroit, MI, 48216',
@@ -96,7 +96,7 @@ describe('SprkDictionary:', () => {
     const wrapper = shallow(
       <SprkDictionary
         keyValuePairs={testKeyValuePairs}
-        additionalKeysClasses="asdf"
+        keysAdditionalClasses="asdf"
       />,
     );
 
@@ -105,7 +105,7 @@ describe('SprkDictionary:', () => {
     });
   });
 
-  it('should add additionalValuesClasses', () => {
+  it('should add valuesAdditionalClasses', () => {
     const testKeyValuePairs = {
       'Email Address': 'sparkdesignsystem@quickenloans.com',
       'Mailing Address': '123 Main Street, Detroit, MI, 48216',
@@ -117,7 +117,7 @@ describe('SprkDictionary:', () => {
     const wrapper = shallow(
       <SprkDictionary
         keyValuePairs={testKeyValuePairs}
-        additionalValuesClasses="asdf"
+        valuesAdditionalClasses="asdf"
       />,
     );
 

--- a/react/src/components/dictionary/SprkDictionary.test.js
+++ b/react/src/components/dictionary/SprkDictionary.test.js
@@ -15,21 +15,37 @@ describe('SprkDictionary:', () => {
       'Work Phone': '(555) 555-5555',
       'Work Extension': '55555',
     };
-    const wrapper = shallow(<SprkDictionary keyValuePairs={testKeyValuePairs} />);
-    expect(wrapper.find('div.sprk-c-Dictionary').hasClass('sprk-c-Dictionary')).toBe(true);
+    const wrapper = shallow(
+      <SprkDictionary keyValuePairs={testKeyValuePairs} />,
+    );
+    expect(
+      wrapper.find('div.sprk-c-Dictionary').hasClass('sprk-c-Dictionary'),
+    ).toBe(true);
   });
 
-  it('should display a striped dictionary with correct classes when variant is striped', () => {
-    const testKeyValuePairs = {
-      'Email Address': 'sparkdesignsystem@quickenloans.com',
-      'Mailing Address': '123 Main Street, Detroit, MI, 48216',
-      'Home Phone': '(123) 456-7890',
-      'Cell Phone': '(098) 765-4321',
-      'Work Phone': '(555) 555-5555',
-      'Work Extension': '55555',
-    };
-    const wrapper = shallow(<SprkDictionary variant="striped" keyValuePairs={testKeyValuePairs} />);
-    expect(wrapper.find('div.sprk-c-Dictionary').hasClass('sprk-c-Dictionary')).toBe(true);
-    expect(wrapper.find('div.sprk-c-Dictionary').hasClass('sprk-c-Dictionary--striped')).toBe(true);
-  });
+  it(
+    'should display a striped dictionary with correct classes when variant' +
+      ' is striped',
+    () => {
+      const testKeyValuePairs = {
+        'Email Address': 'sparkdesignsystem@quickenloans.com',
+        'Mailing Address': '123 Main Street, Detroit, MI, 48216',
+        'Home Phone': '(123) 456-7890',
+        'Cell Phone': '(098) 765-4321',
+        'Work Phone': '(555) 555-5555',
+        'Work Extension': '55555',
+      };
+      const wrapper = shallow(
+        <SprkDictionary variant="striped" keyValuePairs={testKeyValuePairs} />,
+      );
+      expect(
+        wrapper.find('div.sprk-c-Dictionary').hasClass('sprk-c-Dictionary'),
+      ).toBe(true);
+      expect(
+        wrapper
+          .find('div.sprk-c-Dictionary')
+          .hasClass('sprk-c-Dictionary--striped'),
+      ).toBe(true);
+    },
+  );
 });


### PR DESCRIPTION
## What does this PR do?

**Angular Changes**
- Change `dictionaryType` to variant and add typings that show it can only be set to `striped`. Remove its default setting of `base`. It's not used for anything.
- Add new unit test for new variant Input.
- Add ability to add classes to the keys and values via Input
- Add new unit tests for additional classes for keys and values
- Add in `keyValuePairs` Input following deprecation strategy for `data` Input
- Make sure code comments for props say deprecation info

**React Changes**
- Add ability to add classes to the keys and values via prop
- Add tests for the new additional classes props for the keys and values

### Associated Issue
Fixes #3277 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)
