### PR TITLE
Tooltip Upgrades

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -31,10 +31,13 @@ describe('SprkAngularDictionaryComponent', () => {
   let wrappedFixture: ComponentFixture<WrappedDictionaryComponent>;
   let wrappedElement: HTMLElement;
 
+  let spy;
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [SprkDictionaryComponent, WrappedDictionaryComponent],
     }).compileComponents();
+
+    spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
   }));
 
   beforeEach(() => {
@@ -47,6 +50,10 @@ describe('SprkAngularDictionaryComponent', () => {
     wrappedComponent = wrappedFixture.componentInstance;
     wrappedElement = wrappedFixture.nativeElement.querySelector('div');
     wrappedFixture.detectChanges();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
   });
 
   it('should create', () => {
@@ -143,6 +150,8 @@ describe('SprkAngularDictionaryComponent', () => {
     expect(
       wrappedElement.getElementsByClassName('sprk-c-Dictionary__value').length,
     ).toBe(2);
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
   });
 
   it('should correctly respond to changes to data Input', () => {
@@ -159,6 +168,8 @@ describe('SprkAngularDictionaryComponent', () => {
     expect(
       wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
     ).toBe(3);
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
   });
 
   it('should correctly respond to changes to keyValuePairs Input', () => {
@@ -179,6 +190,8 @@ describe('SprkAngularDictionaryComponent', () => {
     expect(
       wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
     ).toBe(3);
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
   });
 
   it('should correctly respond to changes to dictionaryType Input', () => {
@@ -193,12 +206,16 @@ describe('SprkAngularDictionaryComponent', () => {
     expect(wrappedElement.classList.toString()).toContain(
       'sprk-c-Dictionary--striped',
     );
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
   });
 
   it('should prefer keyValuePairs over data', () => {
     wrappedComponent.keyValuePairs = { key1: 'value1', key2: 'value2' };
     wrappedComponent.data = { key1: 'value1', key2: 'value2', key3: 'value3' };
     wrappedFixture.detectChanges();
+
+    expect(console.warn).toHaveBeenCalledTimes(3);
 
     expect(
       wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
@@ -211,5 +228,19 @@ describe('SprkAngularDictionaryComponent', () => {
     expect(
       wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
     ).toBe(1);
+
+    expect(console.warn).toHaveBeenCalledTimes(4);
+  });
+
+  it('should prefer variant over dictionaryType', () => {
+    wrappedComponent.variant = 'striped';
+    wrappedComponent.dictionaryType = '';
+    wrappedFixture.detectChanges();
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
+
+    expect(wrappedElement.classList.toString()).toContain(
+      'sprk-c-Dictionary--striped',
+    );
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -111,4 +111,20 @@ describe('SprkAngularDictionaryComponent', () => {
       element.getElementsByClassName('sprk-c-Dictionary__value').length,
     ).toBe(2);
   });
+
+  it('should correctly respond to changes to data Input', () => {
+    component.data = { key1: 'value1', key2: 'value2' };
+    fixture.detectChanges();
+
+    expect(
+      element.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(2);
+
+    component.data = { key1: 'value1', key2: 'value2', key3: 'value3' };
+    fixture.detectChanges();
+
+    expect(
+      element.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(3);
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -101,7 +101,6 @@ describe('SprkAngularDictionaryComponent', () => {
   it('should correctly add striped class with deprecated Input', () => {
     wrappedComponent.dictionaryType = 'striped';
     wrappedFixture.detectChanges();
-    console.log(wrappedFixture.nativeElement.innerHTML);
 
     expect(wrappedElement.classList.toString()).toContain(
       'sprk-c-Dictionary--striped',

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -4,14 +4,22 @@ import { Component } from '@angular/core';
 
 @Component({
   selector: `sprk-test`,
-  template: `<sprk-dictionary
-    [dictionaryType]="dictionaryType"
+  template: ` <sprk-dictionary
+    [keyValuePairs]="keyValuePairs"
     [data]="data"
+    [dictionaryType]="dictionaryType"
+    [variant]="variant"
+    [keysAdditionalClasses]="keysAdditionalClasses"
+    [valuesAdditionalClasses]="valuesAdditionalClasses"
   ></sprk-dictionary>`,
 })
-class TestComponent {
-  data = {};
-  dictionaryType = '';
+class WrappedDictionaryComponent {
+  data: object = {};
+  keyValuePairs: object = {};
+  dictionaryType: string = '';
+  variant: string = '';
+  keysAdditionalClasses: string = '';
+  valuesAdditionalClasses: string = '';
 }
 
 describe('SprkAngularDictionaryComponent', () => {
@@ -19,13 +27,13 @@ describe('SprkAngularDictionaryComponent', () => {
   let fixture: ComponentFixture<SprkDictionaryComponent>;
   let element: HTMLElement;
 
-  let wrappedComponent: TestComponent;
-  let wrappedFixture: ComponentFixture<TestComponent>;
+  let wrappedComponent: WrappedDictionaryComponent;
+  let wrappedFixture: ComponentFixture<WrappedDictionaryComponent>;
   let wrappedElement: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SprkDictionaryComponent, TestComponent],
+      declarations: [SprkDictionaryComponent, WrappedDictionaryComponent],
     }).compileComponents();
   }));
 
@@ -35,7 +43,7 @@ describe('SprkAngularDictionaryComponent', () => {
     element = fixture.nativeElement.querySelector('div');
     fixture.detectChanges();
 
-    wrappedFixture = TestBed.createComponent(TestComponent);
+    wrappedFixture = TestBed.createComponent(WrappedDictionaryComponent);
     wrappedComponent = wrappedFixture.componentInstance;
     wrappedElement = wrappedFixture.nativeElement.querySelector('div');
     wrappedFixture.detectChanges();
@@ -66,36 +74,54 @@ describe('SprkAngularDictionaryComponent', () => {
   });
 
   it('should add keysAdditionalClasses', () => {
-    component.keysAdditionalClasses = 'keysClass';
-    component.keyValuePairs = { key: 'value', key2: 'value2' };
-    fixture.detectChanges();
+    wrappedComponent.keysAdditionalClasses = 'spark keysClass';
+    wrappedComponent.keyValuePairs = { key: 'value', key2: 'value2' };
+    wrappedFixture.detectChanges();
 
-    const keys = element.getElementsByClassName('sprk-c-Dictionary__key');
+    const keys = wrappedElement.getElementsByClassName(
+      'sprk-c-Dictionary__key',
+    );
 
     Array.prototype.forEach.call(keys, (key) => {
+      expect(key.classList.toString()).toContain('spark');
       expect(key.classList.toString()).toContain('keysClass');
     });
   });
 
   it('should add valuesAdditionalClasses', () => {
-    component.valuesAdditionalClasses = 'valuesClass';
-    component.keyValuePairs = { key: 'value', key2: 'value2' };
-    fixture.detectChanges();
+    wrappedComponent.valuesAdditionalClasses = 'spark valuesClass';
+    wrappedComponent.keyValuePairs = { key: 'value', key2: 'value2' };
+    wrappedFixture.detectChanges();
 
-    const values = element.getElementsByClassName('sprk-c-Dictionary__value');
+    const values = wrappedElement.getElementsByClassName(
+      'sprk-c-Dictionary__value',
+    );
 
     Array.prototype.forEach.call(values, (value) => {
+      expect(value.classList.toString()).toContain('spark');
       expect(value.classList.toString()).toContain('valuesClass');
     });
   });
 
   it('should correctly add striped class', () => {
-    component.variant = 'striped';
+    wrappedComponent.variant = 'striped';
 
-    fixture.detectChanges();
-    expect(element.classList.toString()).toContain(
+    wrappedFixture.detectChanges();
+    expect(wrappedElement.classList.toString()).toContain(
       'sprk-c-Dictionary--striped',
     );
+  });
+
+  it('should add keyValuePairs correctly', () => {
+    wrappedComponent.keyValuePairs = { key1: 'value1', key2: 'value2' };
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(2);
+    expect(
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__value').length,
+    ).toBe(2);
   });
 
   it('should correctly add striped class with deprecated Input', () => {
@@ -105,18 +131,6 @@ describe('SprkAngularDictionaryComponent', () => {
     expect(wrappedElement.classList.toString()).toContain(
       'sprk-c-Dictionary--striped',
     );
-  });
-
-  it('should add keyValuePairs correctly', () => {
-    component.keyValuePairs = { key1: 'value1', key2: 'value2' };
-    fixture.detectChanges();
-
-    expect(
-      element.getElementsByClassName('sprk-c-Dictionary__key').length,
-    ).toBe(2);
-    expect(
-      element.getElementsByClassName('sprk-c-Dictionary__value').length,
-    ).toBe(2);
   });
 
   it('should add data correctly with deprecated Input', () => {
@@ -147,6 +161,26 @@ describe('SprkAngularDictionaryComponent', () => {
     ).toBe(3);
   });
 
+  it('should correctly respond to changes to keyValuePairs Input', () => {
+    wrappedComponent.keyValuePairs = { key1: 'value1', key2: 'value2' };
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(2);
+
+    wrappedComponent.keyValuePairs = {
+      key1: 'value1',
+      key2: 'value2',
+      key3: 'value3',
+    };
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(3);
+  });
+
   it('should correctly respond to changes to dictionaryType Input', () => {
     wrappedComponent.dictionaryType = '';
     wrappedFixture.detectChanges();
@@ -159,5 +193,23 @@ describe('SprkAngularDictionaryComponent', () => {
     expect(wrappedElement.classList.toString()).toContain(
       'sprk-c-Dictionary--striped',
     );
+  });
+
+  it('should prefer keyValuePairs over data', () => {
+    wrappedComponent.keyValuePairs = { key1: 'value1', key2: 'value2' };
+    wrappedComponent.data = { key1: 'value1', key2: 'value2', key3: 'value3' };
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(2);
+
+    wrappedComponent.keyValuePairs = { key1: 'value1' };
+    wrappedComponent.data = { key1: 'value1', key2: 'value2' };
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
+    ).toBe(1);
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -1,14 +1,31 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SprkDictionaryComponent } from './sprk-dictionary.component';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: `sprk-test`,
+  template: `<sprk-dictionary
+    [dictionaryType]="dictionaryType"
+    [data]="data"
+  ></sprk-dictionary>`,
+})
+class TestComponent {
+  data = {};
+  dictionaryType = '';
+}
 
 describe('SprkAngularDictionaryComponent', () => {
   let component: SprkDictionaryComponent;
   let fixture: ComponentFixture<SprkDictionaryComponent>;
   let element: HTMLElement;
 
+  let wrappedComponent: TestComponent;
+  let wrappedFixture: ComponentFixture<TestComponent>;
+  let wrappedElement: HTMLElement;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SprkDictionaryComponent],
+      declarations: [SprkDictionaryComponent, TestComponent],
     }).compileComponents();
   }));
 
@@ -17,6 +34,11 @@ describe('SprkAngularDictionaryComponent', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement.querySelector('div');
     fixture.detectChanges();
+
+    wrappedFixture = TestBed.createComponent(TestComponent);
+    wrappedComponent = wrappedFixture.componentInstance;
+    wrappedElement = wrappedFixture.nativeElement.querySelector('div');
+    wrappedFixture.detectChanges();
   });
 
   it('should create', () => {
@@ -71,18 +93,17 @@ describe('SprkAngularDictionaryComponent', () => {
     component.variant = 'striped';
 
     fixture.detectChanges();
-
     expect(element.classList.toString()).toContain(
       'sprk-c-Dictionary--striped',
     );
   });
 
   it('should correctly add striped class with deprecated Input', () => {
-    component.dictionaryType = 'striped';
-    component.ngOnInit();
-    fixture.detectChanges();
+    wrappedComponent.dictionaryType = 'striped';
+    wrappedFixture.detectChanges();
+    console.log(wrappedFixture.nativeElement.innerHTML);
 
-    expect(element.classList.toString()).toContain(
+    expect(wrappedElement.classList.toString()).toContain(
       'sprk-c-Dictionary--striped',
     );
   });
@@ -100,31 +121,44 @@ describe('SprkAngularDictionaryComponent', () => {
   });
 
   it('should add data correctly with deprecated Input', () => {
-    component.data = { key1: 'value1', key2: 'value2' };
-    component.ngOnInit();
-    fixture.detectChanges();
+    wrappedComponent.data = { key1: 'value1', key2: 'value2' };
+    wrappedFixture.detectChanges();
 
     expect(
-      element.getElementsByClassName('sprk-c-Dictionary__key').length,
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
     ).toBe(2);
     expect(
-      element.getElementsByClassName('sprk-c-Dictionary__value').length,
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__value').length,
     ).toBe(2);
   });
 
   it('should correctly respond to changes to data Input', () => {
-    component.data = { key1: 'value1', key2: 'value2' };
-    fixture.detectChanges();
+    wrappedComponent.data = { key1: 'value1', key2: 'value2' };
+    wrappedFixture.detectChanges();
 
     expect(
-      element.getElementsByClassName('sprk-c-Dictionary__key').length,
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
     ).toBe(2);
 
-    component.data = { key1: 'value1', key2: 'value2', key3: 'value3' };
-    fixture.detectChanges();
+    wrappedComponent.data = { key1: 'value1', key2: 'value2', key3: 'value3' };
+    wrappedFixture.detectChanges();
 
     expect(
-      element.getElementsByClassName('sprk-c-Dictionary__key').length,
+      wrappedElement.getElementsByClassName('sprk-c-Dictionary__key').length,
     ).toBe(3);
+  });
+
+  it('should correctly respond to changes to dictionaryType Input', () => {
+    wrappedComponent.dictionaryType = '';
+    wrappedFixture.detectChanges();
+
+    expect(wrappedElement.classList.toString()).toBe('sprk-c-Dictionary');
+
+    wrappedComponent.dictionaryType = 'striped';
+    wrappedFixture.detectChanges();
+
+    expect(wrappedElement.classList.toString()).toContain(
+      'sprk-c-Dictionary--striped',
+    );
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.spec.ts
@@ -108,7 +108,7 @@ describe('SprkAngularDictionaryComponent', () => {
     );
   });
 
-  it('should add data correctly', () => {
+  it('should add keyValuePairs correctly', () => {
     component.keyValuePairs = { key1: 'value1', key2: 'value2' };
     fixture.detectChanges();
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
@@ -134,6 +134,24 @@ export class SprkDictionaryComponent implements OnChanges {
   }
 
   ngOnChanges(changes: SimpleChanges) {
+    if (changes['keyValuePairs'] && changes['data']) {
+      const deprecatedInputValue = changes['data'].currentValue;
+      console.warn(
+        `Spark Design System - conflicting Inputs found in sprk-dictionary. data has been deprecated; please use keyValuePairs instead. Deprecated Input with value "` +
+          JSON.stringify(deprecatedInputValue) +
+          `" will be ignored.`,
+      );
+    }
+
+    if (changes['variant'] && changes['dictionaryType']) {
+      const deprecatedInputValue = changes['dictionaryType'].currentValue;
+      console.warn(
+        `Spark Design System - conflicting Inputs found in sprk-dictionary. dictionaryType has been deprecated; please use variant instead. Deprecated Input with value "` +
+          deprecatedInputValue +
+          `" will be ignored.`,
+      );
+    }
+
     if (changes['keyValuePairs']) {
       this.dataToUse = changes['keyValuePairs'].currentValue;
     } else if (changes['data']) {

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Input,
-  OnInit,
-  OnChanges,
-  SimpleChanges,
-} from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 
 @Component({
   selector: 'sprk-dictionary',
@@ -12,17 +6,17 @@ import {
     <div [ngClass]="getClasses()" [attr.data-id]="idString">
       <dl class="sprk-c-Dictionary__keyvaluepairs">
         <div
-          *ngFor="let key of objectKeys(keyValuePairs)"
+          *ngFor="let key of objectKeys(dataToUse)"
           class="sprk-c-Dictionary__keyvaluepair"
         >
           <dt [ngClass]="getKeysClasses()">{{ key }}</dt>
-          <dd [ngClass]="getValuesClasses()">{{ keyValuePairs[key] }}</dd>
+          <dd [ngClass]="getValuesClasses()">{{ dataToUse[key] }}</dd>
         </div>
       </dl>
     </div>
   `,
 })
-export class SprkDictionaryComponent implements OnInit, OnChanges {
+export class SprkDictionaryComponent implements OnChanges {
   /**
    * Deprecated - Use `keyValuePairs` instead. The collection of key-value
    * pairs to be rendered into the component.
@@ -77,6 +71,14 @@ export class SprkDictionaryComponent implements OnInit, OnChanges {
    * Used to grab all the keys from objects.
    */
   objectKeys = Object.keys;
+  /**
+   * @ignore
+   */
+  dataToUse: object = {};
+  /**
+   * @ignore
+   */
+  variantToUse: string;
 
   /**
    * @ignore
@@ -84,7 +86,7 @@ export class SprkDictionaryComponent implements OnInit, OnChanges {
   getClasses(): string {
     const classArray: string[] = ['sprk-c-Dictionary'];
 
-    if (this.variant === 'striped') {
+    if (this.variantToUse === 'striped') {
       classArray.push('sprk-c-Dictionary--striped');
     }
 
@@ -131,31 +133,17 @@ export class SprkDictionaryComponent implements OnInit, OnChanges {
     return classArray.join(' ');
   }
 
-  /**
-   * @ignore
-   */
-  isEmpty = (obj) => {
-    return Object.keys(obj).length === 0;
-  };
-
-  ngOnInit(): void {
-    // TODO - remove data and dictionaryType as part of Issue 1167
-    if (!this.isEmpty(this.data) && this.isEmpty(this.keyValuePairs)) {
-      this.keyValuePairs = this.data;
-    }
-
-    if (this.dictionaryType && !this.variant) {
-      this.variant = this.dictionaryType;
-    }
-  }
-
   ngOnChanges(changes: SimpleChanges) {
-    if (changes['data']) {
-      this.keyValuePairs = changes['data'].currentValue;
+    if (changes['keyValuePairs']) {
+      this.dataToUse = changes['keyValuePairs'].currentValue;
+    } else if (changes['data']) {
+      this.dataToUse = changes['data'].currentValue;
     }
 
-    if (changes['dictionaryType']) {
-      this.variant = changes['dictionaryType'].currentValue;
+    if (changes['variant']) {
+      this.variantToUse = changes['variant'].currentValue;
+    } else if (changes['dictionaryType']) {
+      this.variantToUse = changes['dictionaryType'].currentValue;
     }
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
@@ -133,6 +133,7 @@ export class SprkDictionaryComponent implements OnInit {
   };
 
   ngOnInit(): void {
+    // TODO - remove data and dictionaryType as part of Issue 1167
     if (!this.isEmpty(this.data) && this.isEmpty(this.keyValuePairs)) {
       this.keyValuePairs = this.data;
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dictionary/sprk-dictionary.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, OnInit } from '@angular/core';
+import {
+  Component,
+  Input,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+} from '@angular/core';
 
 @Component({
   selector: 'sprk-dictionary',
@@ -16,7 +22,7 @@ import { Component, Input, OnInit } from '@angular/core';
     </div>
   `,
 })
-export class SprkDictionaryComponent implements OnInit {
+export class SprkDictionaryComponent implements OnInit, OnChanges {
   /**
    * Deprecated - Use `keyValuePairs` instead. The collection of key-value
    * pairs to be rendered into the component.
@@ -140,6 +146,16 @@ export class SprkDictionaryComponent implements OnInit {
 
     if (this.dictionaryType && !this.variant) {
       this.variant = this.dictionaryType;
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['data']) {
+      this.keyValuePairs = changes['data'].currentValue;
+    }
+
+    if (changes['dictionaryType']) {
+      this.variant = changes['dictionaryType'].currentValue;
     }
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.spec.ts
@@ -30,6 +30,7 @@ describe('SprkTooltipComponent', () => {
   let wrappedContainerElement: HTMLElement;
   let wrappedTriggerElement;
 
+  let spy;
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       declarations: [
@@ -38,6 +39,8 @@ describe('SprkTooltipComponent', () => {
         WrappedTooltipComponent,
       ],
     }).compileComponents();
+
+    spy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
   }));
 
   beforeEach(() => {
@@ -55,6 +58,10 @@ describe('SprkTooltipComponent', () => {
     );
     wrappedTriggerElement = wrappedContainerElement.querySelector('button');
     wrappedFixture.detectChanges();
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
   });
 
   it('should create itself', () => {
@@ -313,6 +320,8 @@ describe('SprkTooltipComponent', () => {
     expect(
       wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
     ).toEqual('#access');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
   it('should correctly use the new icon property', () => {
@@ -322,6 +331,8 @@ describe('SprkTooltipComponent', () => {
     expect(
       wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
     ).toEqual('#email');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 
   it('should prefer the new property over the deprecated property', () => {
@@ -332,6 +343,8 @@ describe('SprkTooltipComponent', () => {
     expect(
       wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
     ).toEqual('#email');
+
+    expect(console.warn).toHaveBeenCalledTimes(2);
   });
 
   it('should use the correct default icon', () => {
@@ -356,5 +369,7 @@ describe('SprkTooltipComponent', () => {
     expect(
       wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
     ).toEqual('#email');
+
+    expect(console.warn).toHaveBeenCalledTimes(1);
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.spec.ts
@@ -2,6 +2,21 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { SprkIconComponent } from '../sprk-icon/sprk-icon.component';
 import { SprkTooltipComponent } from './sprk-tooltip.component';
+import { Component } from '@angular/core';
+
+@Component({
+  selector: `sprk-test`,
+  template: ` <sprk-tooltip
+    [triggerIconName]="triggerIconName"
+    [triggerIconType]="triggerIconType"
+    >"tooltipText"</sprk-tooltip
+  >`,
+})
+class WrappedTooltipComponent {
+  triggerIconName: string;
+  triggerIconType: string;
+  tooltipText: string = 'tooltip content';
+}
 
 describe('SprkTooltipComponent', () => {
   let component: SprkTooltipComponent;
@@ -10,9 +25,18 @@ describe('SprkTooltipComponent', () => {
   let triggerElement;
   let tooltipElement;
 
+  let wrappedComponent: WrappedTooltipComponent;
+  let wrappedFixture: ComponentFixture<WrappedTooltipComponent>;
+  let wrappedContainerElement: HTMLElement;
+  let wrappedTriggerElement;
+
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SprkTooltipComponent, SprkIconComponent],
+      declarations: [
+        SprkTooltipComponent,
+        SprkIconComponent,
+        WrappedTooltipComponent,
+      ],
     }).compileComponents();
   }));
 
@@ -23,6 +47,14 @@ describe('SprkTooltipComponent', () => {
     triggerElement = containerElement.querySelector('button');
     tooltipElement = containerElement.querySelector('span');
     fixture.detectChanges();
+
+    wrappedFixture = TestBed.createComponent(WrappedTooltipComponent);
+    wrappedComponent = wrappedFixture.componentInstance;
+    wrappedContainerElement = wrappedFixture.nativeElement.querySelector(
+      'span',
+    );
+    wrappedTriggerElement = wrappedContainerElement.querySelector('button');
+    wrappedFixture.detectChanges();
   });
 
   it('should create itself', () => {
@@ -274,24 +306,55 @@ describe('SprkTooltipComponent', () => {
     ).toBe(true);
   });
 
-  it('should use the deprecated icon property if it has a value', () => {
-    component.triggerIconType = 'access';
-    component.ngAfterViewInit();
-    fixture.detectChanges();
+  it('should correctly use the deprecated icon property', () => {
+    wrappedComponent.triggerIconType = 'access';
+    wrappedFixture.detectChanges();
 
     expect(
-      triggerElement.querySelector('use').getAttribute('xlink:href'),
+      wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
     ).toEqual('#access');
   });
 
+  it('should correctly use the new icon property', () => {
+    wrappedComponent.triggerIconName = 'email';
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#email');
+  });
+
   it('should prefer the new property over the deprecated property', () => {
-    component.triggerIconType = 'access';
-    component.triggerIconName = 'email';
-    component.ngAfterViewInit();
+    wrappedComponent.triggerIconName = 'email';
+    wrappedComponent.triggerIconType = 'access';
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#email');
+  });
+
+  it('should use the correct default icon', () => {
     fixture.detectChanges();
 
     expect(
       triggerElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#question-filled');
+  });
+
+  it('should not change the icon if the input has not changed', () => {
+    wrappedComponent.triggerIconName = 'email';
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#email');
+
+    wrappedComponent.tooltipText = 'asdf';
+    wrappedFixture.detectChanges();
+
+    expect(
+      wrappedTriggerElement.querySelector('use').getAttribute('xlink:href'),
     ).toEqual('#email');
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.spec.ts
@@ -273,4 +273,25 @@ describe('SprkTooltipComponent', () => {
       tooltipElement.classList.contains('sprk-c-Tooltip--bottom-right'),
     ).toBe(true);
   });
+
+  it('should use the deprecated icon property if it has a value', () => {
+    component.triggerIconType = 'access';
+    component.ngAfterViewInit();
+    fixture.detectChanges();
+
+    expect(
+      triggerElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#access');
+  });
+
+  it('should prefer the new property over the deprecated property', () => {
+    component.triggerIconType = 'access';
+    component.triggerIconName = 'email';
+    component.ngAfterViewInit();
+    fixture.detectChanges();
+
+    expect(
+      triggerElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#email');
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
@@ -288,6 +288,15 @@ export class SprkTooltipComponent implements AfterViewInit, OnChanges {
   ngOnChanges(changes: SimpleChanges) {
     // triggerIconName should always be preferred over triggerIconType
     // TODO - remove triggerIconType as part of Issue 1166
+    if (changes['triggerIconName'] && changes['triggerIconType']) {
+      const deprecatedInputValue = changes['triggerIconType'].currentValue;
+      console.warn(
+        `Spark Design System - conflicting Inputs found in sprk-tooltip. triggerIconType has been deprecated; please use triggerIconName instead. Deprecated Input with value "` +
+          deprecatedInputValue +
+          `" will be ignored.`,
+      );
+    }
+
     if (changes['triggerIconName']) {
       this.iconNameToUse = changes['triggerIconName'].currentValue;
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
@@ -29,7 +29,7 @@ import { uniqueId } from 'lodash';
         #triggerElement
       >
         <sprk-icon
-          [iconType]="triggerIconType"
+          [iconType]="triggerIconName"
           [additionalClasses]="iconAdditionalClasses"
           aria-hidden="true"
         ></sprk-icon>
@@ -54,46 +54,43 @@ export class SprkTooltipComponent implements AfterViewInit {
   @Input()
   isToggled = false;
   /**
-   * The icon to use for the trigger element.
+   * Deprecated - use `triggerIconName` instead. The icon to use for the
+   * trigger element.
    */
   @Input()
   triggerIconType = 'question-filled';
   /**
-   * The value supplied will be assigned to the
-   * `data-analytics` attribute on the trigger element.
-   * Intended for an outside
-   * library to capture data.
+   * The icon to use for the trigger element.
+   */
+  @Input()
+  triggerIconName = 'question-filled';
+  /**
+   * The value supplied will be assigned to the `data-analytics` attribute on
+   * the trigger element. Intended for an outside library to capture data.
    */
   @Input()
   analyticsString: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * tooltip element.
+   * Expects a space separated string of classes to be added to the tooltip
+   * element.
    */
   @Input()
   additionalClasses: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * svg icon.
+   * Expects a space separated string of classes to be added to the svg icon.
    */
   @Input()
   iconAdditionalClasses: string;
   /**
-   * The value supplied will be assigned
-   * to the `data-id` attribute on the
-   * container element. This is intended to be
-   * used as a selector for automated
-   * tools. This value should be unique
-   * per page.
+   * The value supplied will be assigned to the `data-id` attribute on the
+   * container element. This is intended to be used as a selector for
+   * automated tools. This value should be unique per page.
    */
   @Input()
   idString: string;
   /**
-   * Optional: the unique ID to use for the tooltip element.
-   * If an ID is not provided, a unique ID will be created
-   * automatically.
+   * Optional: the unique ID to use for the tooltip element. If an ID is not
+   * provided, a unique ID will be created automatically.
    */
   @Input()
   id = uniqueId(`sprk_tooltip_`);
@@ -280,5 +277,12 @@ export class SprkTooltipComponent implements AfterViewInit {
 
   ngAfterViewInit(): void {
     this.setPositioningClass();
+
+    if (
+      this.triggerIconType !== 'question-filled' &&
+      this.triggerIconName === 'question-filled'
+    ) {
+      this.triggerIconName = this.triggerIconType;
+    }
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
@@ -278,6 +278,7 @@ export class SprkTooltipComponent implements AfterViewInit {
   ngAfterViewInit(): void {
     this.setPositioningClass();
 
+    // TODO - remove triggerIconType as part of Issue 1166
     if (
       this.triggerIconType !== 'question-filled' &&
       this.triggerIconName === 'question-filled'

--- a/react/src/components/tooltip/SprkTooltip.js
+++ b/react/src/components/tooltip/SprkTooltip.js
@@ -79,11 +79,11 @@ class SprkTooltip extends Component {
 
   handleWindowKeydown(e) {
     if (e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27) {
-      const { onToggle } = this.props;
+      const { closedEvent } = this.props;
       const { isToggled } = this.state;
 
-      if (onToggle && isToggled) {
-        onToggle();
+      if (closedEvent && isToggled) {
+        closedEvent();
       }
       this.setState({
         isToggled: false,
@@ -93,15 +93,15 @@ class SprkTooltip extends Component {
 
   handleWindowClick(e) {
     const { isToggled } = this.state;
-    const { onToggle } = this.props;
+    const { closedEvent } = this.props;
 
     if (isToggled) {
       if (
         !this.tooltipRef.current.contains(e.target) &&
         !this.triggerRef.current.contains(e.target)
       ) {
-        if (onToggle) {
-          onToggle();
+        if (closedEvent) {
+          closedEvent();
         }
         this.setState({
           isToggled: false,
@@ -111,14 +111,24 @@ class SprkTooltip extends Component {
   }
 
   toggle() {
-    const { onToggle } = this.props;
+    const { openedEvent, closedEvent } = this.props;
+    const { isToggled } = this.state;
 
-    if (onToggle) {
-      onToggle();
+    if (isToggled) {
+      if (closedEvent) {
+        closedEvent();
+      }
+      this.setState({
+        isToggled: false,
+      });
+    } else {
+      if (openedEvent) {
+        openedEvent();
+      }
+      this.setState({
+        isToggled: true,
+      });
     }
-    this.setState((prevState) => ({
-      isToggled: !prevState.isToggled,
-    }));
   }
 
   render() {
@@ -132,6 +142,8 @@ class SprkTooltip extends Component {
       analyticsString,
       isDefaultOpen,
       id,
+      openedEvent,
+      closedEvent,
       ...other
     } = this.props;
 
@@ -233,9 +245,13 @@ SprkTooltip.propTypes = {
    */
   triggerIconName: PropTypes.string,
   /**
-   * A function to be called when the tooltip is toggled.
+   * A function to be called when the tooltip is toggled open.
    */
-  onToggle: PropTypes.func,
+  openedEvent: PropTypes.func,
+  /**
+   * A function to be called when the tooltip is toggled closed.
+   */
+  closedEvent: PropTypes.func,
 };
 
 export default SprkTooltip;

--- a/react/src/components/tooltip/SprkTooltip.js
+++ b/react/src/components/tooltip/SprkTooltip.js
@@ -51,14 +51,16 @@ class SprkTooltip extends Component {
     let calculatedWidth;
 
     if (elemX > viewportWidth / 2) {
-      calculatedWidth = elemX + triggerWidth + tooltipBorderWidth - tooltipSpacing;
+      calculatedWidth =
+        elemX + triggerWidth + tooltipBorderWidth - tooltipSpacing;
       if (elemY > viewportHeight / 2) {
         this.setState({ position: 'topleft' });
       } else {
         this.setState({ position: 'bottomleft' });
       }
     } else {
-      calculatedWidth = viewportWidth - elemX + tooltipBorderWidth - tooltipSpacing;
+      calculatedWidth =
+        viewportWidth - elemX + tooltipBorderWidth - tooltipSpacing;
       if (elemY > viewportHeight / 2) {
         this.setState({ position: 'topright' });
       } else {
@@ -77,6 +79,12 @@ class SprkTooltip extends Component {
 
   handleWindowKeydown(e) {
     if (e.key === 'Escape' || e.key === 'Esc' || e.keyCode === 27) {
+      const { onToggle } = this.props;
+      const { isToggled } = this.state;
+
+      if (onToggle && isToggled) {
+        onToggle();
+      }
       this.setState({
         isToggled: false,
       });
@@ -85,12 +93,16 @@ class SprkTooltip extends Component {
 
   handleWindowClick(e) {
     const { isToggled } = this.state;
+    const { onToggle } = this.props;
 
     if (isToggled) {
       if (
         !this.tooltipRef.current.contains(e.target) &&
         !this.triggerRef.current.contains(e.target)
       ) {
+        if (onToggle) {
+          onToggle();
+        }
         this.setState({
           isToggled: false,
         });
@@ -99,6 +111,11 @@ class SprkTooltip extends Component {
   }
 
   toggle() {
+    const { onToggle } = this.props;
+
+    if (onToggle) {
+      onToggle();
+    }
     this.setState((prevState) => ({
       isToggled: !prevState.isToggled,
     }));
@@ -165,32 +182,27 @@ SprkTooltip.propTypes = {
   /** Content to render inside of the component. */
   children: PropTypes.node,
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * tooltip element.
+   * Expects a space separated string of classes to be added to the tooltip
+   * element.
    */
   additionalClasses: PropTypes.string,
   /**
-   * The value supplied will be assigned to the
-   * `data-analytics` attribute on the trigger element.
-   * Intended for an outside
-   * library to capture data.
+   * The value supplied will be assigned to the `data-analytics` attribute on
+   * the trigger element. Intended for an outside library to capture data.
    */
   analyticsString: PropTypes.string,
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * svg icon.
+   * Expects a space separated string of classes to be added to the svg icon.
    */
   iconAdditionalClasses: PropTypes.string,
   /**
-   * ID will be placed on the tooltip element and used for
-   * aria-labelledby on the trigger element.
+   * ID will be placed on the tooltip element and used for aria-labelledby on
+   * the trigger element.
    */
   id: PropTypes.string,
   /**
-   * Assigned to the `data-id` attribute serving as a
-   * unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as a unique selector for
+   * automated tools.
    */
   idString: PropTypes.string,
   /**
@@ -201,6 +213,10 @@ SprkTooltip.propTypes = {
    * The icon to use for the trigger element.
    */
   triggerIconType: PropTypes.string,
+  /**
+   * A function to be called when the tooltip is toggled.
+   */
+  onToggle: PropTypes.func,
 };
 
 export default SprkTooltip;

--- a/react/src/components/tooltip/SprkTooltip.js
+++ b/react/src/components/tooltip/SprkTooltip.js
@@ -138,7 +138,10 @@ class SprkTooltip extends Component {
     const { isToggled, position } = this.state;
 
     let iconName = '';
-    if (triggerIconType !== 'question-filled') {
+    if (
+      triggerIconType !== 'question-filled' &&
+      triggerIconName === 'question-filled'
+    ) {
       // Use the deprecated prop if it has a non-default value
       iconName = triggerIconType;
     } else {

--- a/react/src/components/tooltip/SprkTooltip.js
+++ b/react/src/components/tooltip/SprkTooltip.js
@@ -126,6 +126,7 @@ class SprkTooltip extends Component {
       children,
       idString,
       triggerIconType,
+      triggerIconName,
       iconAdditionalClasses,
       additionalClasses,
       analyticsString,
@@ -135,6 +136,15 @@ class SprkTooltip extends Component {
     } = this.props;
 
     const { isToggled, position } = this.state;
+
+    let iconName = '';
+    if (triggerIconType !== 'question-filled') {
+      // Use the deprecated prop if it has a non-default value
+      iconName = triggerIconType;
+    } else {
+      // otherwise use the new prop, whether or not it has a non-default value
+      iconName = triggerIconName;
+    }
 
     return (
       <span {...other} className="sprk-c-Tooltip__container" data-id={idString}>
@@ -152,7 +162,7 @@ class SprkTooltip extends Component {
           data-analytics={analyticsString}
         >
           <SprkIcon
-            iconName={triggerIconType}
+            iconName={iconName}
             additionalClasses={iconAdditionalClasses}
           />
         </button>
@@ -175,6 +185,7 @@ class SprkTooltip extends Component {
 
 SprkTooltip.defaultProps = {
   triggerIconType: 'question-filled',
+  triggerIconName: 'question-filled',
   id: uniqueId('sprk_tooltip_'),
 };
 
@@ -210,9 +221,14 @@ SprkTooltip.propTypes = {
    */
   isDefaultOpen: PropTypes.bool,
   /**
-   * The icon to use for the trigger element.
+   * Deprecated - Use `triggerIconName` instead. The icon to use for the
+   * trigger element.
    */
   triggerIconType: PropTypes.string,
+  /**
+   * The icon to use for the trigger element.
+   */
+  triggerIconName: PropTypes.string,
   /**
    * A function to be called when the tooltip is toggled.
    */

--- a/react/src/components/tooltip/SprkTooltip.js
+++ b/react/src/components/tooltip/SprkTooltip.js
@@ -149,6 +149,7 @@ class SprkTooltip extends Component {
 
     const { isToggled, position } = this.state;
 
+    // TODO - remove triggerIconType as part of Issue 1166
     let iconName = '';
     if (
       triggerIconType !== 'question-filled' &&

--- a/react/src/components/tooltip/SprkTooltip.stories.js
+++ b/react/src/components/tooltip/SprkTooltip.stories.js
@@ -14,8 +14,8 @@ export default {
 
 export const defaultStory = () => (
   <SprkTooltip iconAdditionalClasses="sprk-c-Icon--filled">
-    Use Tooltips to provide info that’s not vital to completing the task.
-    Keep the text short and stick to what’s helpful and relevant.
+    Use Tooltips to provide info that’s not vital to completing the task. Keep
+    the text short and stick to what’s helpful and relevant.
   </SprkTooltip>
 );
 

--- a/react/src/components/tooltip/SprkTooltip.test.js
+++ b/react/src/components/tooltip/SprkTooltip.test.js
@@ -272,13 +272,28 @@ describe('SprkTooltip:', () => {
     },
   );
 
-  it('should use the deprecated icon property if it has a value', () => {
+  it('should prefer the new property over the deprecated property', () => {
     const wrapper = mount(
       <SprkTooltip
         // deprecated prop
         triggerIconType="access"
         // new prop
         triggerIconName="message"
+      />,
+    );
+
+    expect(
+      wrapper.find('use').filterWhere((item) => {
+        return item.prop('xlinkHref') === '#message';
+      }).length,
+    ).toBe(1);
+  });
+
+  it('should use the deprecated property if new prop is not used', () => {
+    const wrapper = mount(
+      <SprkTooltip
+        // deprecated prop
+        triggerIconType="access"
       />,
     );
 

--- a/react/src/components/tooltip/SprkTooltip.test.js
+++ b/react/src/components/tooltip/SprkTooltip.test.js
@@ -29,8 +29,9 @@ describe('SprkTooltip:', () => {
     expect(wrapper.find('button').prop('aria-expanded')).toEqual(false);
 
     wrapper.find('button').simulate('click');
-
     expect(wrapper.find('button').prop('aria-expanded')).toEqual(true);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.find('button').prop('aria-expanded')).toEqual(false);
   });
 
   it('should add additionalClasses', () => {
@@ -206,23 +207,34 @@ describe('SprkTooltip:', () => {
     expect(wrapper.state().position).toBe('topleft');
   });
 
-  it('should call onToggle when the button is clicked', () => {
+  it('should call openEvent the first time button is clicked', () => {
     const myMock = jest.fn();
 
-    const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+    const wrapper = mount(<SprkTooltip openedEvent={myMock} />);
 
     wrapper.find('button').simulate('click');
 
     expect(myMock.mock.calls.length).toBe(1);
   });
 
+  it('should call closedEvent the second time button is clicked', () => {
+    const myMock = jest.fn();
+
+    const wrapper = mount(<SprkTooltip closedEvent={myMock} />);
+
+    wrapper.find('button').simulate('click');
+    expect(myMock.mock.calls.length).toBe(0);
+    wrapper.find('button').simulate('click');
+    expect(myMock.mock.calls.length).toBe(1);
+  });
+
   it(
-    'should not call onToggle when Escape is pressed if the tooltip is not' +
-      ' already toggled',
+    'should not call closedEvent when Escape is pressed if the tooltip is' +
+      ' not already toggled',
     () => {
       const myMock = jest.fn();
 
-      const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+      const wrapper = mount(<SprkTooltip closedEvent={myMock} />);
 
       wrapper.instance().handleWindowKeydown({ key: 'Escape' });
 
@@ -231,26 +243,26 @@ describe('SprkTooltip:', () => {
   );
 
   it(
-    'should call onToggle when Escape is pressed if the tooltip is ' +
+    'should call closedEvent when Escape is pressed if the tooltip is ' +
       ' already toggled',
     () => {
       const myMock = jest.fn();
 
-      const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+      const wrapper = mount(<SprkTooltip closedEvent={myMock} />);
       wrapper.find('button').simulate('click');
-      expect(myMock.mock.calls.length).toBe(1);
+      expect(myMock.mock.calls.length).toBe(0);
       wrapper.instance().handleWindowKeydown({ key: 'Escape' });
-      expect(myMock.mock.calls.length).toBe(2);
+      expect(myMock.mock.calls.length).toBe(1);
     },
   );
 
   it(
-    'should not call onToggle when the document is clicked if the tooltip' +
+    'should not call closedEvent when the document is clicked if the tooltip' +
       ' is not already toggled',
     () => {
       const myMock = jest.fn();
 
-      const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+      const wrapper = mount(<SprkTooltip closedEvent={myMock} />);
 
       wrapper.instance().handleWindowClick({});
 
@@ -259,16 +271,16 @@ describe('SprkTooltip:', () => {
   );
 
   it(
-    'should call onToggle when the document is clicked if the tooltip is ' +
+    'should call closedEvent when the document is clicked if the tooltip is ' +
       ' already toggled',
     () => {
       const myMock = jest.fn();
 
-      const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+      const wrapper = mount(<SprkTooltip closedEvent={myMock} />);
       wrapper.find('button').simulate('click');
-      expect(myMock.mock.calls.length).toBe(1);
+      expect(myMock.mock.calls.length).toBe(0);
       wrapper.instance().handleWindowClick({});
-      expect(myMock.mock.calls.length).toBe(2);
+      expect(myMock.mock.calls.length).toBe(1);
     },
   );
 

--- a/react/src/components/tooltip/SprkTooltip.test.js
+++ b/react/src/components/tooltip/SprkTooltip.test.js
@@ -271,4 +271,21 @@ describe('SprkTooltip:', () => {
       expect(myMock.mock.calls.length).toBe(2);
     },
   );
+
+  it('should use the deprecated icon property if it has a value', () => {
+    const wrapper = mount(
+      <SprkTooltip
+        // deprecated prop
+        triggerIconType="access"
+        // new prop
+        triggerIconName="message"
+      />,
+    );
+
+    expect(
+      wrapper.find('use').filterWhere((item) => {
+        return item.prop('xlinkHref') === '#access';
+      }).length,
+    ).toBe(1);
+  });
 });

--- a/react/src/components/tooltip/SprkTooltip.test.js
+++ b/react/src/components/tooltip/SprkTooltip.test.js
@@ -205,4 +205,70 @@ describe('SprkTooltip:', () => {
 
     expect(wrapper.state().position).toBe('topleft');
   });
+
+  it('should call onToggle when the button is clicked', () => {
+    const myMock = jest.fn();
+
+    const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+
+    wrapper.find('button').simulate('click');
+
+    expect(myMock.mock.calls.length).toBe(1);
+  });
+
+  it(
+    'should not call onToggle when Escape is pressed if the tooltip is not' +
+      ' already toggled',
+    () => {
+      const myMock = jest.fn();
+
+      const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+
+      wrapper.instance().handleWindowKeydown({ key: 'Escape' });
+
+      expect(myMock.mock.calls.length).toBe(0);
+    },
+  );
+
+  it(
+    'should call onToggle when Escape is pressed if the tooltip is ' +
+      ' already toggled',
+    () => {
+      const myMock = jest.fn();
+
+      const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+      wrapper.find('button').simulate('click');
+      expect(myMock.mock.calls.length).toBe(1);
+      wrapper.instance().handleWindowKeydown({ key: 'Escape' });
+      expect(myMock.mock.calls.length).toBe(2);
+    },
+  );
+
+  it(
+    'should not call onToggle when the document is clicked if the tooltip' +
+      ' is not already toggled',
+    () => {
+      const myMock = jest.fn();
+
+      const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+
+      wrapper.instance().handleWindowClick({});
+
+      expect(myMock.mock.calls.length).toBe(0);
+    },
+  );
+
+  it(
+    'should call onToggle when the document is clicked if the tooltip is ' +
+      ' already toggled',
+    () => {
+      const myMock = jest.fn();
+
+      const wrapper = mount(<SprkTooltip onToggle={myMock} />);
+      wrapper.find('button').simulate('click');
+      expect(myMock.mock.calls.length).toBe(1);
+      wrapper.instance().handleWindowClick({});
+      expect(myMock.mock.calls.length).toBe(2);
+    },
+  );
 });


### PR DESCRIPTION
# React
- Fix eslint errors
- Provide a prop to accept a function that runs on toggle.
- Update `triggerIconType` to `triggerIconName`. The icon component will be updated to use name instead of type.

# Angular
- Update `triggerIconType` to `triggerIconName`. The icon component will be updated to use name instead of type.

# Angular Dictionary
- refactor to not use ngOnInit

### Associated Issue
Fixes #3310 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)