### PR TITLE
Text Component Upgrades

### DIFF
--- a/angular/projects/spark-angular/src/lib/directives/sprk-text/sprk-text.directive.spec.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-text/sprk-text.directive.spec.ts
@@ -5,13 +5,13 @@ import { SprkTextDirective } from './sprk-text.directive';
 @Component({
   selector: 'sprk-test',
   template: `
-    <p sprkText variant="bodyOne">Text One</p>
+    <p sprkText variant="bodyOne" idString="foo">Text One</p>
     <h1 sprkText variant="bodyTwo">Text Two</h1>
     <cite sprkText variant="bodyThree">Text Three</cite>
     <small sprkText variant="bodyFour">Text Four</small>
-  `
+  `,
 })
-class TestComponent { }
+class TestComponent {}
 
 describe('Spark Text Directive', () => {
   let component: TestComponent;
@@ -23,7 +23,7 @@ describe('Spark Text Directive', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SprkTextDirective, TestComponent]
+      declarations: [SprkTextDirective, TestComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TestComponent);
@@ -53,5 +53,9 @@ describe('Spark Text Directive', () => {
 
   it('should add the display four class if variant is bodyFour', () => {
     expect(el4.classList.contains('sprk-b-TypeBodyFour')).toBe(true);
+  });
+
+  it('should apply correct idString value to data-id', () => {
+    expect(el1.getAttribute('data-id')).toBe('foo');
   });
 });

--- a/angular/projects/spark-angular/src/lib/directives/sprk-text/sprk-text.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-text/sprk-text.directive.ts
@@ -1,23 +1,25 @@
-import {
-  Directive,
-  Input,
-  HostBinding
-} from '@angular/core';
+import { Directive, Input, HostBinding } from '@angular/core';
 
 @Directive({
-  selector: '[sprkText]'
+  selector: '[sprkText]',
 })
-
 export class SprkTextDirective {
   /**
    * @ignore
    */
-  constructor() { }
+  constructor() {}
+
+  /**
+   * The value supplied will be assigned to the `data-id` attribute on the
+   * component. This is intended to be used as a selector for automated
+   * tools. This value should be unique per page.
+   */
+  @HostBinding('attr.data-id')
+  @Input()
+  idString: string;
 
   @Input()
-  variant: 'bodyOne' |
-    'bodyTwo' | 'bodyThree' |
-    'bodyFour';
+  variant: 'bodyOne' | 'bodyTwo' | 'bodyThree' | 'bodyFour';
 
   @HostBinding('class.sprk-b-TypeBodyOne')
   get textOne() {
@@ -36,5 +38,3 @@ export class SprkTextDirective {
     return this.variant === 'bodyFour';
   }
 }
-
-

--- a/react/src/base/typography/SprkText/SprkText.js
+++ b/react/src/base/typography/SprkText/SprkText.js
@@ -7,11 +7,9 @@ const SprkText = ({
   element,
   variant,
   idString,
-  isPageTitle,
   additionalClasses,
   ...other
 }) => {
-
   const classNames = classnames(additionalClasses, {
     'sprk-b-TypeBodyOne': variant === 'bodyOne',
     'sprk-b-TypeBodyTwo': variant === 'bodyTwo',
@@ -22,14 +20,10 @@ const SprkText = ({
   const TagName = element;
 
   return (
-    <TagName
-      className={classNames}
-      data-id={idString}
-      {...other}
-    >
+    <TagName className={classNames} data-id={idString} {...other}>
       {children}
     </TagName>
-  )
+  );
 };
 
 SprkText.defaultProps = {
@@ -47,28 +41,22 @@ SprkText.propTypes = {
   element: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.func,
-    PropTypes.elementType
+    PropTypes.elementType,
   ]),
   /**
    * The text style to render.
    * See [Typography](https://www.sparkdesignsystem.com/using-spark/foundations/typography)
    * for more information on the design styles.
    */
-  variant: PropTypes.oneOf([
-    'bodyOne',
-    'bodyTwo',
-    'bodyThree',
-    'bodyFour',
-  ]),
+  variant: PropTypes.oneOf(['bodyOne', 'bodyTwo', 'bodyThree', 'bodyFour']),
   /**
-   * Assigned to the `data-id` attribute
-   * serving as a unique selector for
+   * Assigned to the `data-id` attribute serving as a unique selector for
    * automated tools.
    */
   idString: PropTypes.string,
   /**
-   * A space-separated string of classes to add to the
-   * outermost container of the component.
+   * A space-separated string of classes to add to the outermost container
+   * of the component.
    */
   additionalClasses: PropTypes.string,
 };


### PR DESCRIPTION
## What does this PR do?
# React
- Fix eslint errors
- Remove `isPageTitle` from line 10. This is not used in this component. Must have been something someone copied over from the SprkHeading component.

# Angular
- Add `idString`

### Associated Issue
Fixes #3312

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [X] Build Component in Angular
 - [X] Build Component in React
 - [X] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [X] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)
