### PR TITLE
adds loading attr to iframes, set to lazy

### DIFF
--- a/src/components/ComponentPreview.js
+++ b/src/components/ComponentPreview.js
@@ -35,6 +35,7 @@ class ComponentPreview extends React.Component {
             title="Component Preview"
             className="docs-c-ComponentPreview sprk-o-Box"
             src={iframeURL}
+            loading="lazy"
           />
         </div>
 
@@ -50,7 +51,7 @@ class ComponentPreview extends React.Component {
       </div>
     );
   }
-};
+}
 
 ComponentPreview.propTypes = {
   componentName: PropTypes.string,


### PR DESCRIPTION
## What does this PR do?
Adds loading="lazy" to iframes in the gatsby mdx pages.
https://web.dev/iframe-lazy-loading

### Before Lazy loading
<img width="895" alt="before" src="https://user-images.githubusercontent.com/412903/90641478-49d7a200-e1ff-11ea-919e-acdc2594c4c3.png">

### After
<img width="1101" alt="after" src="https://user-images.githubusercontent.com/412903/90641497-4e9c5600-e1ff-11ea-878d-37bf0f53992f.png">
