### PR TITLE
Add stroke width to menu icon and new vars

### DIFF
--- a/html/components/_menu.scss
+++ b/html/components/_menu.scss
@@ -1,8 +1,6 @@
 // ==================================================================
 // Menu
 // ==================================================================
-
-// Reset styles for menu buttons
 .sprk-c-Menu {
   border: 0;
   background-color: $sprk-menu-icon-bg-color;

--- a/html/components/_menu.scss
+++ b/html/components/_menu.scss
@@ -1,9 +1,11 @@
 // ==================================================================
 // Menu
 // ==================================================================
+
+// Reset styles for menu buttons
 .sprk-c-Menu {
   border: 0;
-  background-color: $sprk-white;
+  background-color: $sprk-menu-icon-bg-color;
   display: inline-block;
   padding-top: 0;
   padding-bottom: 0;
@@ -12,22 +14,27 @@
 }
 
 .sprk-c-Menu__icon {
-  stroke: $sprk-black;
+  stroke: $sprk-menu-icon-stroke;
+  stroke-width: $sprk-menu-icon-stroke-width;
 }
 
 .sprk-c-Menu__line {
   opacity: 1;
-  transition: transform 0.3s ease-in-out, opacity 0.2s ease-in-out;
+  transition: $sprk-menu-icon-transition;
 }
 
 .sprk-c-Menu__line--one {
-  transform-origin: 1rem 1.5rem;
+  transform-origin: $sprk-menu-icon-line-one-transform-origin;
 }
 
 .sprk-c-Menu__line--three {
-  transform-origin: 1rem 2.5rem;
+  transform-origin: $sprk-menu-icon-line-three-transform-origin;
 }
 
+// Styles to turn the menu into
+// an "X" when open.
+// Not configurable because the "X" needs to be
+// exact.
 .sprk-c-Menu__icon--open .sprk-c-Menu__line--one {
   transform: rotate(45deg);
 }

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -618,7 +618,8 @@ $sprk-btn-border-color: $sprk-btn-background-color !default;
 /// The border width of the Button component.
 $sprk-btn-border-width: 2px !default;
 /// The border of the Button component.
-$sprk-btn-border: $sprk-btn-border-width $sprk-btn-border-style $sprk-btn-border-color !default;
+$sprk-btn-border: $sprk-btn-border-width $sprk-btn-border-style
+  $sprk-btn-border-color !default;
 /// The font weight of the Button component.
 $sprk-btn-font-weight: 500 !default;
 /// The font size of the Button component.
@@ -663,8 +664,8 @@ $sprk-btn-disabled-text-color: $sprk-white !default;
 /// The border color of the Disabled Button component.
 $sprk-btn-disabled-border-color: transparent !default;
 /// The border of the Disabled Button component.
-$sprk-btn-disabled-border: $sprk-btn-disabled-border-width $sprk-btn-disabled-border-style
-  $sprk-btn-disabled-border-color !default;
+$sprk-btn-disabled-border: $sprk-btn-disabled-border-width
+  $sprk-btn-disabled-border-style $sprk-btn-disabled-border-color !default;
 /// The box shadow of the Disabled Button component.
 $sprk-btn-disabled-shadow: none !default;
 /// The background color of the Disabled Button component.
@@ -696,16 +697,19 @@ $sprk-btn-quaternary-disabled-border-style: $sprk-btn-disabled-border-style !def
 /// The border width of the Quaternary Button component when disabled.
 $sprk-btn-quaternary-disabled-border-width: $sprk-btn-disabled-border-width !default;
 /// The border of the Button component when disabled on hover.
-$sprk-btn-disabled-hover-border: $sprk-btn-disabled-border-width $sprk-btn-disabled-border-style
-  $sprk-btn-disabled-border-color !default;
+$sprk-btn-disabled-hover-border: $sprk-btn-disabled-border-width
+  $sprk-btn-disabled-border-style $sprk-btn-disabled-border-color !default;
 /// The border of the Secondary Button component when disabled on hover.
-$sprk-btn-secondary-disabled-hover-border: $sprk-btn-secondary-disabled-border-width $sprk-btn-secondary-disabled-border-style
+$sprk-btn-secondary-disabled-hover-border: $sprk-btn-secondary-disabled-border-width
+  $sprk-btn-secondary-disabled-border-style
   $sprk-btn-secondary-disabled-border-color !default;
 /// The border of the Tertiary Button component when disabled on hover.
-$sprk-btn-tertiary-disabled-hover-border: $sprk-btn-tertiary-disabled-border-width $sprk-btn-tertiary-disabled-border-style
+$sprk-btn-tertiary-disabled-hover-border: $sprk-btn-tertiary-disabled-border-width
+  $sprk-btn-tertiary-disabled-border-style
   $sprk-btn-tertiary-disabled-border-color !default;
 /// The border of the Quaternary Button component when disabled on hover.
-$sprk-btn-quaternary-disabled-hover-border: $sprk-btn-quaternary-disabled-border-width $sprk-btn-quaternary-disabled-border-style
+$sprk-btn-quaternary-disabled-hover-border: $sprk-btn-quaternary-disabled-border-width
+  $sprk-btn-quaternary-disabled-border-style
   $sprk-btn-quaternary-disabled-border-color !default;
 
 // Secondary
@@ -2001,6 +2005,25 @@ $sprk-masthead-transition: all 0.3s ease-in !default;
 /// The transform length that gets applied
 /// when the Masthead scrolls out of view on narrow screens.
 $sprk-masthead-translateY: translateY(-100%) !default;
+
+// Menu
+/// The background color of the menu icon.
+$sprk-menu-icon-bg-color: $sprk-white !default;
+/// The stroke width of the menu icon.
+$sprk-menu-icon-stroke-width: 2px !default;
+/// The stroke of the menu icon.
+$sprk-menu-icon-stroke: $sprk-black !default;
+/// The transition on the menu icon that turns the
+/// menu icon into an "X".
+$sprk-menu-icon-transition: transform 0.3s ease-in-out, opacity 0.2s ease-in-out !default;
+/// The transform origin of the "X" state of the menu for the
+/// first menu line. Only
+/// needs to be changed if using a custom width and height.
+$sprk-menu-icon-line-one-transform-origin: 1rem 1.5rem !default;
+/// The transform origin of the "X" state of the menu for the
+/// third menu line. Only
+/// needs to be changed if using a custom width and height.
+$sprk-menu-icon-line-three-transform-origin: 1rem 2.5rem !default;
 
 // Big Nav
 /// The maximum width of the


### PR DESCRIPTION
## What does this PR do?
The icon for the masthead on mobile wasn't showing up. This is because we were removing the stroke and this is a custom icon. I added in that stroke and added new vars for the _menu.scss file. It's an older file and didn't have those settings.

### Associated Issue
Fixes #3380 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.
### Code
 - [x] Build Component in HTML
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
