### PR TITLE
make dropdown trigger + icon black + use lightest purp for highlight

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -19,6 +19,7 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
       <div [ngClass]="{ 'sprk-o-Box': dropdownType === 'mastheadSelector' }">
         <a
           sprkLink
+          variant="plain"
           [ngClass]="getTriggerClasses()"
           (click)="toggle($event)"
           [idString]="idString"
@@ -31,7 +32,7 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
           <span class="sprk-u-ScreenReaderText">{{ screenReaderText }}</span>
           <sprk-icon
             [iconType]="triggerIconType"
-            additionalClasses="sprk-u-mls sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color {{
+            additionalClasses="sprk-u-mls {{
               additionalIconClasses
             }}"
           ></sprk-icon>
@@ -62,9 +63,14 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
             >
             <sprk-icon
               [iconType]="triggerIconType"
-              additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-u-mls sprk-c-Icon--toggle sprk-Stack__item {{
-                additionalIconClasses
-              }}"
+              additionalClasses="
+                sprk-c-Icon--filled-current-color
+                sprk-c-Icon--stroke-current-color
+                sprk-u-mls
+                sprk-c-Icon--toggle
+                sprk-Stack__item
+                {{ additionalIconClasses }}
+              "
             ></sprk-icon>
           </a>
         </div>
@@ -329,7 +335,7 @@ export class SprkDropdownComponent {
    * @ignore
    */
   getTriggerClasses(): string {
-    const classArray: string[] = [];
+    const classArray: string[] = ['sprk-c-Dropdown__trigger'];
 
     if (this.additionalTriggerClasses) {
       this.additionalTriggerClasses.split(' ').forEach(className => {

--- a/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.directive.ts
@@ -50,11 +50,11 @@ export class SprkLinkDirective implements OnInit {
 
   ngOnInit() {
     const variants = {
-      'simple' : 'sprk-b-Link--simple',
-      'icon' : 'sprk-b-Link--has-icon',
-      'plain' : 'sprk-b-Link--plain',
-      'light' : 'sprk-b-Link--light'
-    }
+      simple : 'sprk-b-Link--simple',
+      icon : 'sprk-b-Link--has-icon',
+      plain : 'sprk-b-Link--plain',
+      light : 'sprk-b-Link--light'
+    };
     if (this.variant !== 'unstyled') {
       this.renderer.addClass(this.el.nativeElement, 'sprk-b-Link');
     }

--- a/html/components/_dropdown.scss
+++ b/html/components/_dropdown.scss
@@ -58,7 +58,7 @@
 }
 
 .sprk-c-Dropdown__link {
-  color: $sprk-black;
+  color: $sprk-dropdown-link-color;
   display: block;
   padding: ($sprk-dropdown-padding / 2) $sprk-dropdown-padding;
   text-decoration: none;
@@ -69,8 +69,22 @@
   }
 }
 
+.sprk-c-Dropdown__trigger {
+  color: $sprk-dropdown-trigger-color;
+
+  &:visited {
+    color: $sprk-dropdown-trigger-color-visited;
+  }
+
+  &:hover,
+  &:active,
+  &:focus {
+    color: $sprk-dropdown-trigger-color-active;
+  }
+}
+
 /// Adds styles to indicate that the dropdown
-/// link is currently active. 
+/// link is currently active.
 .sprk-c-Dropdown__link--active {
   box-shadow: $sprk-dropdown-active-box-shadow;
   border-left: $sprk-dropdown-active-border;

--- a/html/components/dropdown.stories.js
+++ b/html/components/dropdown.stories.js
@@ -4,9 +4,7 @@ import { markdownDocumentationLinkBuilder } from '../../storybook-utilities/mark
 
 export default {
   title: 'Components/Dropdown',
-  decorators: [
-    story => `<div class="sprk-o-Box">${story()}</div>`,
-  ],
+  decorators: [(story) => `<div class="sprk-o-Box">${story()}</div>`],
   parameters: {
     info: `
 ${markdownDocumentationLinkBuilder('dropdown')}
@@ -25,7 +23,7 @@ export const defaultStory = () => {
 
   return `
     <a
-      class="sprk-b-Link sprk-b-Link--plain"
+      class="sprk-c-Dropdown__trigger sprk-b-Link sprk-b-Link--plain"
       href="#nogo"
       data-sprk-dropdown-trigger="dropdown01"
       aria-haspopup="listbox"
@@ -76,7 +74,7 @@ defaultStory.story = {
   name: 'Default',
   parameters: {
     jest: ['dropdown'],
-  }
+  },
 };
 
 export const informational = () => {
@@ -86,7 +84,7 @@ export const informational = () => {
 
   return `
     <a
-      class="sprk-b-Link sprk-b-Link--plain sprk-u-mrs"
+      class="sprk-c-Dropdown__trigger sprk-b-Link sprk-b-Link--plain sprk-u-mrs"
       href="#nogo"
       data-sprk-dropdown-trigger="dropdown02"
       aria-haspopup="listbox"
@@ -171,5 +169,5 @@ informational.story = {
   name: 'Informational',
   parameters: {
     jest: ['dropdown'],
-  }
+  },
 };

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -8,7 +8,7 @@
 
 /// Setting for the background
 /// color of any text when selected.
-$sprk-selection-bg-color: $sprk-purple-light !default;
+$sprk-selection-bg-color: $sprk-purple-lightest !default;
 /// Setting for the
 /// color of any text when selected.
 $sprk-selection-text-color: $sprk-black !default;

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -1865,6 +1865,14 @@ $sprk-dropdown-title-color: $sprk-black-tint-30 !default;
 $sprk-dropdown-title-font-size: $sprk-dropdown-font-size !default;
 /// The font weight of the Dropdown title.
 $sprk-dropdown-title-font-weight: 300 !default;
+/// The color of the Dropdown links.
+$sprk-dropdown-link-color: $sprk-black !default;
+/// The color of the Dropdown trigger.
+$sprk-dropdown-trigger-color: $sprk-black !default;
+/// The color of the Dropdown trigger on hover, active, focus.
+$sprk-dropdown-trigger-color-active: $sprk-black !default;
+/// The color of the Dropdown trigger for the visited state.
+$sprk-dropdown-trigger-color-visited: $sprk-black !default;
 
 //
 // Modals

--- a/react/src/components/dropdown/SprkDropdown.js
+++ b/react/src/components/dropdown/SprkDropdown.js
@@ -102,18 +102,19 @@ class SprkDropdown extends Component {
           element="a"
           variant="plain"
           additionalClasses={classNames(
+            'sprk-c-Dropdown__trigger',
             { 'sprk-u-mrs': variant === 'informational' },
             additionalTriggerClasses,
           )}
           aria-expanded={isOpen}
           aria-haspopup="listbox"
-          aria-label={screenReaderText ? screenReaderText : triggerText}
+          aria-label={screenReaderText || triggerText}
           data-analytics={analyticsString || 'undefined'}
           data-id={idString || 'undefined'}
           onClick={this.toggleDropdownOpen}
         >
           {variant === 'informational' && (
-            <React.Fragment>
+            <>
               <span className={classNames(additionalTriggerTextClasses)}>
                 {triggerText}
               </span>
@@ -121,13 +122,14 @@ class SprkDropdown extends Component {
                 additionalClasses="
                   sprk-c-Icon--filled-current-color
                   sprk-c-Icon--stroke-current-color
-                  sprk-u-mls"
+                  sprk-u-mls
+                "
                 iconName="chevron-down"
               />
-            </React.Fragment>
+            </>
           )}
           {variant === 'base' && (
-            <React.Fragment>
+            <>
               <span
                 className={classNames(
                   'sprk-u-ScreenReaderText',
@@ -140,7 +142,7 @@ class SprkDropdown extends Component {
                 iconName={iconName}
                 additionalClasses={additionalIconClasses}
               />
-            </React.Fragment>
+            </>
           )}
         </SprkLink>
         {isOpen && (
@@ -152,7 +154,7 @@ class SprkDropdown extends Component {
             )}
             <ul
               className="sprk-c-Dropdown__links"
-              aria-label={title ? title : (screenReaderText || "My Choices")}
+              aria-label={title || screenReaderText || 'My Choices'}
               role="listbox"
             >
               {choiceItems.map((choice) => {
@@ -193,7 +195,7 @@ class SprkDropdown extends Component {
                       </TagName>
                     )}
                     {variant === 'informational' && (
-                      <React.Fragment>
+                      <>
                         <TagName
                           className={classNames('sprk-c-Dropdown__link', {
                             'sprk-c-Dropdown__link--active': isActive,
@@ -217,7 +219,7 @@ class SprkDropdown extends Component {
                             {content.infoLine2}
                           </p>
                         </TagName>
-                      </React.Fragment>
+                      </>
                     )}
                   </li>
                 );
@@ -237,7 +239,9 @@ class SprkDropdown extends Component {
 
 SprkDropdown.propTypes = {
   /**
-   * A space-separated string of classes to add to the outermost container of the component.
+   * A space-separated string of
+   * classes to add to the outermost
+   * container of the component.
    */
   additionalClasses: PropTypes.string,
   /**
@@ -245,15 +249,19 @@ SprkDropdown.propTypes = {
    */
   additionalIconClasses: PropTypes.string,
   /**
-   * A space-separated string of classes to add to the trigger element.
+   * A space-separated string of classes
+   * to add to the trigger element.
    */
   additionalTriggerClasses: PropTypes.string,
   /**
-   * A space-separated string of classes to add to the trigger text.
+   * A space-separated string of classes
+   * to add to the trigger text.
    */
   additionalTriggerTextClasses: PropTypes.string,
   /**
-   * Assigned to the `data-analytics` attribute serving as a unique selector for outside libraries to capture data.
+   * Assigned to the `data-analytics`
+   * attribute serving as a unique
+   * selector for outside libraries to capture data.
    */
   analyticsString: PropTypes.string,
   /** Content to render inside of the SprkDropdown */
@@ -285,15 +293,17 @@ SprkDropdown.propTypes = {
    */
   iconName: PropTypes.string,
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id`
+   * attribute serving as a unique
+   * selector for automated tools.
    */
   idString: PropTypes.string,
   /**
-  * A value for screen readers when there isn't
-  * discernable text on the dropdown.
-  * Useful for when the `title` prop is empty
-  * and the Dropdown trigger is only an icon.
-  */
+   * A value for screen readers when there isn't
+   * discernable text on the dropdown.
+   * Useful for when the `title` prop is empty
+   * and the Dropdown trigger is only an icon.
+   */
   screenReaderText: PropTypes.string,
   /**
    * The text of the optional header above the

--- a/react/src/components/dropdown/SprkDropdown.stories.js
+++ b/react/src/components/dropdown/SprkDropdown.stories.js
@@ -6,9 +6,7 @@ import { markdownDocumentationLinkBuilder } from '../../../../storybook-utilitie
 export default {
   title: 'Components/Dropdown',
   component: SprkDropdown,
-  decorators: [
-    story => <div className="sprk-o-Box">{story()}</div>
-  ],
+  decorators: [(story) => <div className="sprk-o-Box">{story()}</div>],
   parameters: {
     jest: ['SprkDropdown'],
     info: `
@@ -24,7 +22,7 @@ export const defaultStory = () => (
   <SprkDropdown
     screenReaderText="Description of default dropdown."
     choices={{
-      choiceFunction: choiceText => {
+      choiceFunction: (choiceText) => {
         console.log(choiceText);
       },
       items: [
@@ -35,13 +33,6 @@ export const defaultStory = () => (
           href: '#nogo',
           idString: 'option-1',
         },
-        // TODO - when we build knobs, make sure this story demos multiple kinds of dropdown items
-        // {
-        //   text: 'Option 2',
-        //   value: 'option-2',
-        //   element: Link,
-        //   to: '/link',
-        // },
         {
           text: 'Option 2',
           value: 'option-2',
@@ -50,6 +41,7 @@ export const defaultStory = () => (
       ],
     }}
     iconName="settings"
+    title="My Choices"
     additionalIconClasses="sprk-c-Icon--l"
   />
 );
@@ -63,7 +55,7 @@ export const informational = () => (
     variant="informational"
     title="My Choices"
     choices={{
-      choiceFunction: choiceText => {
+      choiceFunction: (choiceText) => {
         console.log(choiceText);
       },
       footer: (
@@ -80,26 +72,24 @@ export const informational = () => (
       items: [
         {
           content: {
-            title: 'Choice Title',
+            title: 'Choice Title 1',
             infoLine1: 'Information about this choice',
             infoLine2: 'More Information',
           },
           value: 'choice-title-1',
           isActive: false,
-          href: '#nogo'
+          href: '#nogo',
         },
-        // TODO - when we build knobs, make sure this story demos multiple kinds of dropdown items
-        // {
-        //   element: Link,
-        //   content: {
-        //     title: 'Choice Title',
-        //     infoLine1: 'Information about this choice',
-        //     infoLine2: 'More Information',
-        //   },
-        //   to: '/button',
-        //   value: 'choice-title-2',
-        //   isActive: true,
-        // },
+        {
+          content: {
+            title: 'Choice Title 2',
+            infoLine1: 'Information about this choice',
+            infoLine2: 'More Information',
+          },
+          value: 'choice-title-2',
+          isActive: false,
+          href: '#nogo',
+        },
       ],
     }}
     defaultTriggerText="Make a selection..."


### PR DESCRIPTION
## What does this PR do?
add new dd trigger class and make it black for all states and lightens the text highlight color.

### Associated Issue
working off a list

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
