### PR TITLE
converts tooltip placement css to use percentages instead of variables

### DIFF
--- a/html/components/_tooltip.scss
+++ b/html/components/_tooltip.scss
@@ -2,10 +2,6 @@
 /// @group tooltip
 ////
 
-// TODO new vars
-$sprk-tooltip-caret-offset: 1rem;
-$sprk-tooltip-trigger-hover-offset: 1rem;
-
 .sprk-c-Tooltip__container {
   position: relative;
   display: inline-flex;

--- a/html/components/_tooltip.scss
+++ b/html/components/_tooltip.scss
@@ -2,9 +2,9 @@
 /// @group tooltip
 ////
 
-// TODO make these configurable
-$sprk-trigger-height: 1rem;
-$sprk-trigger-width: 1rem;
+// TODO new vars
+$sprk-tooltip-caret-offset: 1rem;
+$sprk-tooltip-trigger-hover-offset: 1rem;
 
 .sprk-c-Tooltip__container {
   position: relative;
@@ -22,10 +22,10 @@ $sprk-trigger-width: 1rem;
   /* Increase hoverable area of trigger */
   &:hover::after {
     position: absolute;
-    top: calc(-#{$sprk-trigger-height});
-    left: calc(-#{$sprk-trigger-width});
-    width: calc(3 * #{$sprk-trigger-height});
-    height: calc(3 * #{$sprk-trigger-width});
+    top: calc(-#{$sprk-tooltip-trigger-hover-offset});
+    left: calc(-#{$sprk-tooltip-trigger-hover-offset});
+    width: calc(3 * #{$sprk-tooltip-trigger-hover-offset});
+    height: calc(3 * #{$sprk-tooltip-trigger-hover-offset});
     content: ' ';
   }
 }
@@ -68,15 +68,13 @@ $sprk-trigger-width: 1rem;
 
   &.sprk-c-Tooltip--top-left {
     top: auto;
-    right: calc(-#{$sprk-trigger-width});
-    bottom: calc(
-      #{$sprk-trigger-height} + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset}
-    );
     left: auto;
+    bottom: calc(100% + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset});
+    right: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
 
     &::before {
       top: auto;
-      right: $sprk-trigger-width;
+      right: $sprk-tooltip-caret-offset;
       bottom: calc(-#{$sprk-tooltip-caret-width} / 2);
       left: auto;
     }
@@ -85,48 +83,42 @@ $sprk-trigger-width: 1rem;
   &.sprk-c-Tooltip--top-right {
     top: auto;
     right: auto;
-    bottom: calc(
-      #{$sprk-trigger-height} + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset}
-    );
-    left: calc(-#{$sprk-trigger-width});
+    bottom: calc(100% + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset});
+    left: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
 
     &::before {
       top: auto;
       right: auto;
       bottom: calc(-#{$sprk-tooltip-caret-width} / 2);
-      left: $sprk-trigger-width;
+      left: $sprk-tooltip-caret-offset;
     }
   }
 
   &.sprk-c-Tooltip--bottom-left {
-    top: calc(
-      #{$sprk-trigger-height} + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset}
-    );
-    right: calc(-#{$sprk-trigger-width});
+    top: calc(100% + #{$sprk-tooltip-caret-width} +  #{$sprk-tooltip-animation-offset});
+    right: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
     bottom: auto;
     left: auto;
 
     &::before {
       top: calc(-#{$sprk-tooltip-caret-width} / 2);
-      right: $sprk-trigger-width;
+      right: $sprk-tooltip-caret-offset;
       bottom: auto;
       left: auto;
     }
   }
 
   &.sprk-c-Tooltip--bottom-right {
-    top: calc(
-      #{$sprk-trigger-height} + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset}
-    );
+    top: calc(100% + #{$sprk-tooltip-caret-width} +  #{$sprk-tooltip-animation-offset});
     right: auto;
     bottom: auto;
-    left: calc(-#{$sprk-trigger-width});
+    left: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
 
     &::before {
       top: calc(-#{$sprk-tooltip-caret-width} / 2);
       right: auto;
       bottom: auto;
-      left: $sprk-trigger-width;
+      left: $sprk-tooltip-caret-offset;
     }
   }
 }
@@ -146,29 +138,29 @@ $sprk-trigger-width: 1rem;
 
   &.sprk-c-Tooltip--top-left {
     top: auto;
-    right: calc(-#{sprk-trigger-width});
-    bottom: calc(#{$sprk-trigger-height} + #{$sprk-tooltip-caret-width});
     left: auto;
+    bottom: calc(100% + #{$sprk-tooltip-caret-width});
+    right: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
   }
 
   &.sprk-c-Tooltip--top-right {
     top: auto;
     right: auto;
-    bottom: calc(#{$sprk-trigger-height} + #{$sprk-tooltip-caret-width});
-    left: calc(-#{sprk-trigger-width});
+    bottom: calc(100% + #{$sprk-tooltip-caret-width});
+    left: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
   }
 
   &.sprk-c-Tooltip--bottom-left {
-    top: calc(#{$sprk-trigger-height} + #{$sprk-tooltip-caret-width});
-    right: calc(-#{sprk-trigger-width});
+    top: calc(100% + #{$sprk-tooltip-caret-width});
+    right: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
     bottom: auto;
     left: auto;
   }
 
   &.sprk-c-Tooltip--bottom-right {
-    top: calc(#{$sprk-trigger-height} + #{$sprk-tooltip-caret-width});
+    top: calc(100% + #{$sprk-tooltip-caret-width});
     right: auto;
     bottom: auto;
-    left: calc(-#{sprk-trigger-width});
+    left: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
   }
 }

--- a/html/components/tooltip.stories.js
+++ b/html/components/tooltip.stories.js
@@ -20,6 +20,7 @@ export const defaultStory = () => {
   }, []);
 
   return `
+    <div>
     <span data-sprk-tooltip="container" class="sprk-c-Tooltip__container">
       <button
         data-sprk-tooltip="trigger"
@@ -45,6 +46,32 @@ export const defaultStory = () => {
         Keep the text short and stick to what’s helpful and relevant.
       </span>
     </span>
+    <span data-sprk-tooltip="container" class="sprk-c-Tooltip__container">
+      <button
+        data-sprk-tooltip="trigger"
+        class="sprk-c-Tooltip__trigger"
+        aria-labelledby="tooltip_1"
+        type="button"
+      >
+        <svg
+          class="sprk-c-Icon sprk-c-Icon--xxl sprk-c-Icon--filled"
+          aria-hidden="true"
+        >
+          <use xlink:href="#question-filled" />
+        </svg>
+      </button>
+      <span
+        data-sprk-tooltip="content"
+        class="sprk-c-Tooltip"
+        aria-hidden="true"
+        id="tooltip_1"
+        role="tooltip"
+      >
+        Use Tooltips to provide info that’s not vital to completing the task.
+        Keep the text short and stick to what’s helpful and relevant.
+      </span>
+    </span>
+    </div>
   `;
 };
 

--- a/html/components/tooltip.stories.js
+++ b/html/components/tooltip.stories.js
@@ -20,7 +20,6 @@ export const defaultStory = () => {
   }, []);
 
   return `
-    <div>
     <span data-sprk-tooltip="container" class="sprk-c-Tooltip__container">
       <button
         data-sprk-tooltip="trigger"
@@ -46,32 +45,6 @@ export const defaultStory = () => {
         Keep the text short and stick to what’s helpful and relevant.
       </span>
     </span>
-    <span data-sprk-tooltip="container" class="sprk-c-Tooltip__container">
-      <button
-        data-sprk-tooltip="trigger"
-        class="sprk-c-Tooltip__trigger"
-        aria-labelledby="tooltip_1"
-        type="button"
-      >
-        <svg
-          class="sprk-c-Icon sprk-c-Icon--xxl sprk-c-Icon--filled"
-          aria-hidden="true"
-        >
-          <use xlink:href="#question-filled" />
-        </svg>
-      </button>
-      <span
-        data-sprk-tooltip="content"
-        class="sprk-c-Tooltip"
-        aria-hidden="true"
-        id="tooltip_1"
-        role="tooltip"
-      >
-        Use Tooltips to provide info that’s not vital to completing the task.
-        Keep the text short and stick to what’s helpful and relevant.
-      </span>
-    </span>
-    </div>
   `;
 };
 

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -1653,7 +1653,7 @@ $sprk-toggle-transition-timing: 0.3s ease !default;
 // Tooltip
 ///
 
-/// The space that the tooltip's caret is offset from the edge
+/// The space that the Tooltip's caret is offset from the edge.
 $sprk-tooltip-caret-offset: 1rem;
 /// The surrounding hover area around the trigger when the tooltip is visible.
 $sprk-tooltip-trigger-hover-offset: 1rem;

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -1653,6 +1653,10 @@ $sprk-toggle-transition-timing: 0.3s ease !default;
 // Tooltip
 ///
 
+/// The space that the tooltip's caret is offset from the edge
+$sprk-tooltip-caret-offset: 1rem;
+/// The surrounding hover area around the trigger when the tooltip is visible.
+$sprk-tooltip-trigger-hover-offset: 1rem;
 /// The border for the tooltip trigger.
 $sprk-tooltip-trigger-border: none !default;
 /// The background color for the tooltip trigger.

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -1655,7 +1655,7 @@ $sprk-toggle-transition-timing: 0.3s ease !default;
 
 /// The space that the Tooltip's caret is offset from the edge.
 $sprk-tooltip-caret-offset: 1rem;
-/// The surrounding hover area around the trigger when the tooltip is visible.
+/// The surrounding hover area around the trigger when the Tooltip is visible.
 $sprk-tooltip-trigger-hover-offset: 1rem;
 /// The border for the tooltip trigger.
 $sprk-tooltip-trigger-border: none !default;


### PR DESCRIPTION
## What does this PR do?
Allows the tooltip component to be used with differently sized icons.

### Associated Issue
#3357 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in HTML

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)

### Screenshots
![Screen Shot 2020-08-28 at 4 02 41 PM](https://user-images.githubusercontent.com/412903/91610872-148e2b00-e948-11ea-8434-c1c298efdcaa.png)
(added a second tooltip icon for example, then removed)

