### PR TITLE
Change HTML and Ng tooltip button types

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
@@ -19,6 +19,7 @@ import { uniqueId } from 'lodash';
       #containerElement
     >
       <button
+        type="button"
         [ngClass]="{
           'sprk-c-Tooltip__trigger': true,
           'sprk-c-Tooltip--toggled': isToggled

--- a/html/components/tooltip.stories.js
+++ b/html/components/tooltip.stories.js
@@ -25,6 +25,7 @@ export const defaultStory = () => {
       class="sprk-c-Tooltip__container"
       >
       <button
+        type="button"
         data-sprk-tooltip="trigger"
         class="sprk-c-Tooltip__trigger"
         aria-labelledby="tooltip_1"


### PR DESCRIPTION
# Spark Tooltip `type="button"` fix

_Credit to Greeshma Mula of Rocket Technology for finding the bug that led to this PR. I am submitting this PR myself with her permission._

## What does this PR do?
Updates the `button` element in the HTML tooltip example and Angular Spark tooltip implementation to include `type="button"`. This change will prevent a clicked tooltip from emitting the `submit` event. The most visible benefit of this fix is not causing unexpected things to happen if the clicked tooltip is within a form.

(The React component was not changed, as its button already includes the `type="button"` attribute and value.)

### Associated Issue
Fixes sparkdesignsystem/backlog#1178

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in HTML
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

[edit: Removed additional checklist items per Bob's suggestion]
