### PR TITLE
remove rebase error

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "develop": "npm run prebuild && gatsby develop",
     "start": "npm run develop",
     "serve": "gatsby serve",
-    "clean": "gatsby clean",
     "prebuild": "npm run clean && npm run sassdoc && npm run sassdocmodifiers && npm run sassdocutilities",
     "sassdoc": "sassdoc './html/settings/**/*.scss' --parse > ./src/data/sass-vars.json",
     "clean": "gatsby clean",


### PR DESCRIPTION
fixes an issue where the gatsby clean cmd was in there twice due to a fetch/rebase/merge/update 