### PR TITLE
add proptypes to ContextSubMenu

### DIFF
--- a/src/components/ContextSubMenu.js
+++ b/src/components/ContextSubMenu.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { Link } from 'gatsby';
 import { SprkLink } from '@sparkdesignsystem/spark-react';
 
@@ -29,6 +30,12 @@ function ContextSubMenu({heading, collection, directory}) {
       </ul>
     </div>
   );
+}
+
+ContextSubMenu.propTypes = {
+  heading: PropTypes.string,
+  collection: PropTypes.array,
+  directory: PropTypes.string
 }
 
 export default ContextSubMenu;


### PR DESCRIPTION
## What does this PR do?
adds prop types to ContextSubMenu component

### Associated Issue
Fixes Issue Number #3469

### Documentation
 - [ ] Update Spark Docs

### Code
 - [ ] Build Component in HTML
 - [ ] Build Component in Angular
 - [ ] Build Component in React
 - [ ] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [ ] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [ ] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [ ] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
