### PR TITLE
Add proptypes for the PrinciplesLayout

### DIFF
--- a/src/components/layouts/PrinciplesLayout.js
+++ b/src/components/layouts/PrinciplesLayout.js
@@ -1,9 +1,12 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Layout from './Layout';
 
 function PrinciplesLayout({ children, location }) {
   return (
-    <Layout initialContext={'principles'} location={location}>{children}</Layout>
+    <Layout initialContext="principles" location={location}>
+      {children}
+    </Layout>
   );
 }
 

--- a/src/components/layouts/PrinciplesLayout.js
+++ b/src/components/layouts/PrinciplesLayout.js
@@ -7,4 +7,8 @@ function PrinciplesLayout({ children, location }) {
   );
 }
 
+PrinciplesLayout.propTypes = {
+  children: PropTypes.node,
+};
+
 export default PrinciplesLayout;

--- a/src/components/layouts/PrinciplesLayout.js
+++ b/src/components/layouts/PrinciplesLayout.js
@@ -9,6 +9,7 @@ function PrinciplesLayout({ children, location }) {
 
 PrinciplesLayout.propTypes = {
   children: PropTypes.node,
+  location: PropTypes.string,
 };
 
 export default PrinciplesLayout;


### PR DESCRIPTION
## What does this PR do?
This PR adds proptypes for the `PrinciplesLayout` to fix linter warnings.

### Associated Issue
Fixes #3477

