### PR TITLE
Add propTypes for children prop in the ContentWrapper.js

### DIFF
--- a/src/components/ContentWrapper.js
+++ b/src/components/ContentWrapper.js
@@ -1,9 +1,17 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function ContentWrapper({children}) {
   return (
     <div>{children}</div>
   );
 }
+
+ContentWrapper.propTypes = {
+  /**
+  * Content to render inside of the component.
+  */
+  children: PropTypes.node
+};
 
 export default ContentWrapper;

--- a/src/components/ContentWrapper.js
+++ b/src/components/ContentWrapper.js
@@ -1,17 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-function ContentWrapper({children}) {
-  return (
-    <div>{children}</div>
-  );
+function ContentWrapper({ children }) {
+  return <div>{children}</div>;
 }
 
 ContentWrapper.propTypes = {
   /**
-  * Content to render inside of the component.
-  */
-  children: PropTypes.node
+   *  Content to render inside of the component.
+   */
+  children: PropTypes.node,
 };
 
 export default ContentWrapper;


### PR DESCRIPTION
## What does this PR do?
Added `propTypes` for `ContentWrapper`. Fixed eslint errors.

### Associated Issue
Fixes #3468 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

Not sure if any of the checklist applies here.
