### PR TITLE
fix: Fix non-unique id on toggle and AccordionItem

### DIFF
--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -38,11 +38,12 @@ class SprkMastheadAccordionItem extends Component {
       leadingIcon,
       subNavLinks,
       text,
+      itemId,
       ...rest
     } = this.props;
     const { isOpen, height, subNavLinks: stateLinks } = this.state;
     const TagName = element;
-    const itemId = rest.itemId ? rest.itemId : uniqueId('sprk_accordion_item_');
+    const uniqueIdentifier = itemId || uniqueId('sprk_accordion_item_');
     return (
       <li
         className={classNames(
@@ -61,7 +62,7 @@ class SprkMastheadAccordionItem extends Component {
               className="sprk-c-MastheadAccordion__summary"
               onClick={this.toggleAccordionOpen}
               aria-expanded={isOpen ? 'true' : 'false'}
-              aria-controls={itemId}
+              aria-controls={uniqueIdentifier}
               type="button"
             >
               <span className="sprk-b-TypeBodyOne sprk-c-MastheadAccordion__heading">
@@ -78,7 +79,7 @@ class SprkMastheadAccordionItem extends Component {
             <AnimateHeight duration={300} height={height}>
               <ul
                 className="sprk-b-List sprk-b-List--bare sprk-c-MastheadAccordion__details"
-                id={itemId}
+                id={uniqueIdentifier}
               >
                 {stateLinks.map((subnavlink) => {
                   const {

--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -38,11 +38,11 @@ class SprkMastheadAccordionItem extends Component {
       leadingIcon,
       subNavLinks,
       text,
-      itemId,
       ...rest
     } = this.props;
     const { isOpen, height, subNavLinks: stateLinks } = this.state;
     const TagName = element;
+    const itemId = rest.itemId ? rest.itemId : uniqueId('sprk_accordion_item_');
     return (
       <li
         className={classNames(
@@ -195,6 +195,8 @@ SprkMastheadAccordionItem.propTypes = {
   isActive: PropTypes.bool,
   /** Will render the element as a button with correct style. */
   isButton: PropTypes.bool,
+  /* The unique item `id` */
+  itemId: PropTypes.string,
   /**
    * The name of the icon to the left of the link text.
    * Will render in compatible components like narrowNav.
@@ -236,7 +238,6 @@ SprkMastheadAccordionItem.defaultProps = {
   isButton: false,
   subNavLinks: [],
   href: '#nogo',
-  itemId: uniqueId('sprk_accordion_item_'),
 };
 
 export default SprkMastheadAccordionItem;

--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
@@ -165,7 +165,7 @@ describe('SprkMastheadAccordionItem:', () => {
 
     expect(menuItemContentId).toMatch(/sprk_accordion_item_\d/);
     expect(menuItemToggleAriaControls).toEqual(menuItemContentId);
-    expect(wrapper.find(`div#${menuItemContentId}`).length).toBe(1);
+    expect(wrapper.find(`#${menuItemContentId}`).length).toBe(1);
   });
 
   it('should add correct aria-controls and id to narrowNav if narrowNavId is passed', () => {

--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
@@ -165,6 +165,7 @@ describe('SprkMastheadAccordionItem:', () => {
 
     expect(menuItemContentId).toMatch(/sprk_accordion_item_\d/);
     expect(menuItemToggleAriaControls).toEqual(menuItemContentId);
+    expect(wrapper.find(`div#${menuItemContentId}`).length).toBe(1);
   });
 
   it('should add correct aria-controls and id to narrowNav if narrowNavId is passed', () => {

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -2,8 +2,8 @@ import React, { Component } from 'react';
 import AnimateHeight from 'react-animate-height';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import SprkIcon from '../icons/SprkIcon';
 import uniqueId from 'lodash/uniqueId';
+import SprkIcon from '../icons/SprkIcon';
 import 'focus-visible';
 
 class SprkToggle extends Component {
@@ -14,12 +14,13 @@ class SprkToggle extends Component {
       isOpen: isDefaultOpen || false,
       height: isDefaultOpen ? 'auto' : 0,
     };
+
     this.toggleOpen = this.toggleOpen.bind(this);
   }
 
   toggleOpen(e) {
     e.preventDefault();
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
       height: !prevState.isOpen ? 'auto' : 0,
     }));
@@ -35,15 +36,15 @@ class SprkToggle extends Component {
       titleAddClasses,
       iconAddClasses,
       toggleIconName,
-      contentId,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
 
-    const containerClasses = classnames(
-      'sprk-c-Toggle',
-      additionalClasses
-    );
+    const contentId = other.contentId
+      ? other.contentId
+      : uniqueId('sprk_toggle_content_');
+
+    const containerClasses = classnames('sprk-c-Toggle', additionalClasses);
 
     const titleClasses = classnames(
       'sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-u-TextCrop--none',
@@ -64,6 +65,7 @@ class SprkToggle extends Component {
           onClick={this.toggleOpen}
           aria-expanded={isOpen ? 'true' : 'false'}
           aria-controls={contentId}
+          type="button"
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
           {title}
@@ -71,7 +73,7 @@ class SprkToggle extends Component {
         <AnimateHeight
           duration={300}
           height={height}
-          className='sprk-c-Toggle__content'
+          className="sprk-c-Toggle__content"
           id={contentId}
         >
           <div>{children}</div>
@@ -83,7 +85,6 @@ class SprkToggle extends Component {
 
 SprkToggle.defaultProps = {
   toggleIconName: 'chevron-down-circle',
-  contentId: uniqueId('sprk_toggle_content_'),
 };
 
 SprkToggle.propTypes = {
@@ -105,7 +106,9 @@ SprkToggle.propTypes = {
    * Assigned to the `data-analytics` attribute serving as a unique selector for outside libraries to capture data.
   */
   analyticsString: PropTypes.string,
-  /**
+  /** Whether if the toggle is open or not */
+  isDefaultOpen: PropTypes.bool,
+   /**
    * A space-separated string of classes to add to the outermost container of the component.
    */
   additionalClasses: PropTypes.string,

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -36,13 +36,12 @@ class SprkToggle extends Component {
       titleAddClasses,
       iconAddClasses,
       toggleIconName,
+      contentId,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
 
-    const contentId = other.contentId
-      ? other.contentId
-      : uniqueId('sprk_toggle_content_');
+    const uniqueIdentifier = contentId || uniqueId('sprk_toggle_content_');
 
     const containerClasses = classnames('sprk-c-Toggle', additionalClasses);
 
@@ -64,7 +63,7 @@ class SprkToggle extends Component {
           data-analytics={analyticsString}
           onClick={this.toggleOpen}
           aria-expanded={isOpen ? 'true' : 'false'}
-          aria-controls={contentId}
+          aria-controls={uniqueIdentifier}
           type="button"
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
@@ -74,7 +73,7 @@ class SprkToggle extends Component {
           duration={300}
           height={height}
           className="sprk-c-Toggle__content"
-          id={contentId}
+          id={uniqueIdentifier}
         >
           <div>{children}</div>
         </AnimateHeight>
@@ -106,7 +105,7 @@ SprkToggle.propTypes = {
    * Assigned to the `data-analytics` attribute serving as a unique selector for outside libraries to capture data.
   */
   analyticsString: PropTypes.string,
-  /** Whether if the toggle is open or not */
+  /** Determines if the toggle is open upon loading on the page. */
   isDefaultOpen: PropTypes.bool,
    /**
    * A space-separated string of classes to add to the outermost container of the component.

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -64,7 +64,11 @@ describe('SprkToggle:', () => {
     const wrapper = mount(
       <SprkToggle title="Toggle title">Body text</SprkToggle>,
     );
-    expect(wrapper.find('button').prop('aria-controls')).toMatch(/sprk_toggle_content_\d/);
-    expect(wrapper.find('div').at(1).prop('id')).toMatch(/sprk_toggle_content_\d/);
+    const ButtonAriaControls = wrapper.find('button').prop('aria-controls');
+    const toggleContentId = wrapper.find('.sprk-c-Toggle__content').at(1).prop('id');
+
+    expect(toggleContentId).toMatch(/sprk_toggle_content_\d/);
+    expect(toggleContentId).toEqual(ButtonAriaControls);
+    expect(wrapper.find(`div#${toggleContentId}`).length).toBe(1);
   });
 });

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -64,7 +64,7 @@ describe('SprkToggle:', () => {
     const wrapper = mount(
       <SprkToggle title="Toggle title">Body text</SprkToggle>,
     );
-    expect(wrapper.find('[aria-controls="sprk_toggle_content_1"]').length).toBe(1);
-    expect(wrapper.find('div#sprk_toggle_content_1').length).toBe(1);
+    expect(wrapper.find('button').prop('aria-controls')).toMatch(/sprk_toggle_content_\d/);
+    expect(wrapper.find('div').at(1).prop('id')).toMatch(/sprk_toggle_content_\d/);
   });
 });


### PR DESCRIPTION
## What does this PR do?
The default proptype uniqueID use at
- SprkToggle
- SprkMastheadAccordionItem

did not create unique IDs. Therefore now there's a check whether if prop with unique id is passed, and if not, a unique id is generated.

Relative tests were also updated.

### Associated Issue
Fixes #3472 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.


### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
![image](https://user-images.githubusercontent.com/45261205/95047824-708a6300-06ef-11eb-80f7-35e0df8d428f.png)

