### PR TITLE
feat: #3530 Add support for default choice in react dropdown

### DIFF
--- a/react/src/components/dropdown/SprkDropdown.js
+++ b/react/src/components/dropdown/SprkDropdown.js
@@ -10,12 +10,21 @@ class SprkDropdown extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      triggerText: props.defaultTriggerText,
+      triggerText: this.getDefaultOptionText(),
       isOpen: false,
-      choiceItems: props.choices.items.map(item => ({
-        id: uniqueId(),
-        ...item,
-      })),
+      choiceItems: props.choices.items.map((item) =>
+        item.default
+          ? {
+              id: uniqueId(),
+              ...item,
+              isActive: true,
+            }
+          : {
+              id: uniqueId(),
+              ...item,
+              isActive: false,
+            },
+      ),
     };
     this.toggleDropdownOpen = this.toggleDropdownOpen.bind(this);
     this.closeOnEsc = this.closeOnEsc.bind(this);
@@ -48,6 +57,20 @@ class SprkDropdown extends Component {
     });
   }
 
+  getDefaultOptionText() {
+    const { props } = this;
+    const { choices, defaultTriggerText } = props;
+    const { items } = choices;
+
+    if (props.variant !== 'informational' || items.length === 0) {
+      return defaultTriggerText;
+    }
+
+    const defaultOption = items.find((item) => item.default);
+
+    return defaultOption ? defaultOption.content.title : defaultTriggerText;
+  }
+
   selectChoice(id, text) {
     this.setState({
       triggerText: text,
@@ -57,7 +80,7 @@ class SprkDropdown extends Component {
 
   toggleDropdownOpen(e) {
     e.preventDefault();
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
     }));
   }
@@ -165,7 +188,6 @@ class SprkDropdown extends Component {
                   isActive,
                   text,
                   value,
-                  idString,
                   ...rest
                 } = choice;
                 const TagName = element || 'a';
@@ -282,8 +304,14 @@ SprkDropdown.propTypes = {
         href: PropTypes.string,
         /** The text inside the choice item. */
         text: PropTypes.string,
+        /**
+         * If set to true, current option will be set as default selected option
+         *  */
+        default: PropTypes.bool,
       }),
     ),
+    footer: PropTypes.node,
+    choiceFunction: PropTypes.func,
   }),
   /** The text set as the default of the trigger link. */
   defaultTriggerText: PropTypes.string,

--- a/react/src/components/dropdown/SprkDropdown.js
+++ b/react/src/components/dropdown/SprkDropdown.js
@@ -13,7 +13,7 @@ class SprkDropdown extends Component {
       triggerText: this.getDefaultOptionText(),
       isOpen: false,
       choiceItems: props.choices.items.map((item) =>
-        item.default
+        item.isDefault
           ? {
               id: uniqueId(),
               ...item,
@@ -66,7 +66,7 @@ class SprkDropdown extends Component {
       return defaultTriggerText;
     }
 
-    const defaultOption = items.find((item) => item.default);
+    const defaultOption = items.find((item) => item.isDefault);
 
     return defaultOption ? defaultOption.content.title : defaultTriggerText;
   }
@@ -307,7 +307,7 @@ SprkDropdown.propTypes = {
         /**
          * If set to true, current option will be set as default selected option
          *  */
-        default: PropTypes.bool,
+        isDefault: PropTypes.bool,
       }),
     ),
     footer: PropTypes.node,

--- a/react/src/components/dropdown/SprkDropdown.test.js
+++ b/react/src/components/dropdown/SprkDropdown.test.js
@@ -192,10 +192,10 @@ describe('SprkDropdown:', () => {
 
   it(
     'should set state with default choice option' +
-      ' having isActive as true, when default true attribute is provided',
+      ' having isActive as true, when isDefault true attribute is provided',
     () => {
       const choices = {
-        items: [{ text: 'Item 1', value: 'item-1', default: true }],
+        items: [{ text: 'Item 1', value: 'item-1', isDefault: true }],
       };
 
       const wrapper = mount(<SprkDropdown choices={choices} />);
@@ -205,10 +205,10 @@ describe('SprkDropdown:', () => {
 
   it(
     'should set state with default choice option' +
-      ' having isActive as true, when default true attribute is provided',
+      ' having isActive as true, when isDefault true attribute is provided',
     () => {
       const choices = {
-        items: [{ text: 'Item 1', value: 'item-1', default: true }],
+        items: [{ text: 'Item 1', value: 'item-1', isDefault: true }],
       };
 
       const wrapper = mount(<SprkDropdown choices={choices} />);
@@ -218,10 +218,10 @@ describe('SprkDropdown:', () => {
 
   it(
     'should set state with default choice option' +
-      ' having isActive as true, when default true attribute is provided',
+      ' having isActive as true, when isDefault true attribute is provided',
     () => {
       const choices = {
-        items: [{ text: 'Item 1', value: 'item-1', default: true }],
+        items: [{ text: 'Item 1', value: 'item-1', isDefault: true }],
       };
 
       const wrapper = mount(<SprkDropdown choices={choices} />);
@@ -258,7 +258,7 @@ describe('SprkDropdown:', () => {
     () => {
       const choices = {
         items: [
-          { content: { title: 'Item 1' }, value: 'item-1', default: true },
+          { content: { title: 'Item 1' }, value: 'item-1', isDefault: true },
         ],
       };
 
@@ -361,7 +361,7 @@ describe('SprkDropdown:', () => {
 
   it(
     'should choose aria-label text as default choice item title' +
-      ' if defaultTriggerText is provided and default is true for a choice' +
+      ' if defaultTriggerText is provided and isDefault is true for a choice' +
       ' and variant is informational',
     () => {
       const wrapper = mount(
@@ -369,7 +369,7 @@ describe('SprkDropdown:', () => {
           defaultTriggerText="test"
           variant="informational"
           choices={{
-            items: [{ content: { title: 'Item 1' }, default: true }],
+            items: [{ content: { title: 'Item 1' }, isDefault: true }],
           }}
         />,
       );

--- a/react/src/components/dropdown/SprkDropdown.test.js
+++ b/react/src/components/dropdown/SprkDropdown.test.js
@@ -25,30 +25,48 @@ describe('SprkDropdown:', () => {
     expect(wrapper.find('.sprk-c-Dropdown__footer').length).toBe(1);
   });
 
-  it('should add classes to the dropdown when additionalClasses has a value', () => {
-    const wrapper = mount(<SprkDropdown additionalClasses="sprk-u-man" />);
-    wrapper.find('.sprk-b-Link').simulate('click');
-    expect(wrapper.find('.sprk-c-Dropdown.sprk-u-man').length).toBe(1);
-  });
+  it(
+    'should add classes to the dropdown,' +
+      ' when additionalClasses has a value',
+    () => {
+      const wrapper = mount(<SprkDropdown additionalClasses="sprk-u-man" />);
+      wrapper.find('.sprk-b-Link').simulate('click');
+      expect(wrapper.find('.sprk-c-Dropdown.sprk-u-man').length).toBe(1);
+    },
+  );
 
-  it('should add classes to the icon when additionalIconClasses has a value', () => {
-    const wrapper = mount(
-      <SprkDropdown additionalIconClasses="test-class" />,
-    );
-    expect(wrapper.find('.sprk-c-Icon.test-class').length).toBe(1);
-  });
+  it(
+    'should add classes to the icon,' +
+      ' when additionalIconClasses has a value',
+    () => {
+      const wrapper = mount(
+        <SprkDropdown additionalIconClasses="test-class" />,
+      );
+      expect(wrapper.find('.sprk-c-Icon.test-class').length).toBe(1);
+    },
+  );
 
-  it('should add classes to the trigger when additionalTriggerClasses has a value', () => {
-    const wrapper = mount(<SprkDropdown additionalTriggerClasses="sprk-u-man" />);
-    expect(wrapper.find('.sprk-b-Link.sprk-u-man').length).toBe(1);
-  });
+  it(
+    'should add classes to the trigger,' +
+      ' when additionalTriggerClasses has a value',
+    () => {
+      const wrapper = mount(
+        <SprkDropdown additionalTriggerClasses="sprk-u-man" />,
+      );
+      expect(wrapper.find('.sprk-b-Link.sprk-u-man').length).toBe(1);
+    },
+  );
 
-  it('should add classes to the trigger text when additionalTriggerTextClasses has a value', () => {
-    const wrapper = mount(
-      <SprkDropdown additionalTriggerTextClasses="sprk-u-man" />,
-    );
-    expect(wrapper.find('span.sprk-u-man').length).toBe(1);
-  });
+  it(
+    'should add classes to the trigger text when,' +
+      'additionalTriggerTextClasses has a value',
+    () => {
+      const wrapper = mount(
+        <SprkDropdown additionalTriggerTextClasses="sprk-u-man" />,
+      );
+      expect(wrapper.find('span.sprk-u-man').length).toBe(1);
+    },
+  );
 
   it('should assign data-analytics when analyticsString has a value', () => {
     const wrapper = mount(<SprkDropdown analyticsString="321" />);
@@ -60,7 +78,8 @@ describe('SprkDropdown:', () => {
     expect(wrapper.find('[data-id="321"]').length).toBe(2);
   });
 
-  it('should assign screen reader text to the trigger for base dropdowns', () => {
+  it(`should assign screen reader text
+      to the trigger for base dropdowns`, () => {
     const wrapper = mount(<SprkDropdown screenReaderText="test" />);
     expect(wrapper.find('.sprk-u-ScreenReaderText').text()).toBe('test');
   });
@@ -83,71 +102,79 @@ describe('SprkDropdown:', () => {
     expect(wrapper.find('.sprk-c-Dropdown__link').length).toBe(2);
   });
 
-  it('should run the choiceFunction supplied with the list of choices (base)', () => {
-    const spyFunc = jest.fn();
-    const choices = {
-      choiceFunction: spyFunc,
-      items: [
-        { text: 'Item 1', value: 'item-1' },
-        { text: 'Item 2', value: 'item-2' },
-      ],
-    };
-    const wrapper = mount(<SprkDropdown choices={choices} />);
-    wrapper.find('.sprk-b-Link').simulate('click');
-    wrapper
-      .find('.sprk-c-Dropdown__link')
-      .first()
-      .simulate('click');
-    expect(spyFunc.mock.calls.length).toBe(1);
-  });
+  it(
+    'should run the choiceFunction supplied' +
+      ' with the list of choices (base)',
+    () => {
+      const spyFunc = jest.fn();
+      const choices = {
+        choiceFunction: spyFunc,
+        items: [
+          { text: 'Item 1', value: 'item-1' },
+          { text: 'Item 2', value: 'item-2' },
+        ],
+      };
+      const wrapper = mount(<SprkDropdown choices={choices} />);
+      wrapper.find('.sprk-b-Link').simulate('click');
+      wrapper.find('.sprk-c-Dropdown__link').first().simulate('click');
+      expect(spyFunc.mock.calls.length).toBe(1);
+    },
+  );
 
-  it('should not error if choiceFunction is supplied but undefined (base)', () => {
-    const choices = {
-      choiceFunction: undefined,
-      items: [
-        { text: 'Item 1', value: 'item-1' },
-        { text: 'Item 2', value: 'item-2' },
-      ],
-    };
-    const wrapper = mount(<SprkDropdown choices={choices} />);
-    wrapper.find('.sprk-b-Link').simulate('click');
-    wrapper
-      .find('.sprk-c-Dropdown__link')
-      .first()
-      .simulate('click');
-  });
+  it(
+    'should not error, ' +
+      ' if choiceFunction is supplied but undefined (base)',
+    () => {
+      const choices = {
+        choiceFunction: undefined,
+        items: [
+          { text: 'Item 1', value: 'item-1' },
+          { text: 'Item 2', value: 'item-2' },
+        ],
+      };
+      const wrapper = mount(<SprkDropdown choices={choices} />);
+      wrapper.find('.sprk-b-Link').simulate('click');
+      wrapper.find('.sprk-c-Dropdown__link').first().simulate('click');
+    },
+  );
 
-  it('should run the choiceFunction supplied with the list of choices (informational)', () => {
-    const spyFunc = jest.fn();
-    const choices = {
-      choiceFunction: spyFunc,
-      items: [{ text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } }],
-    };
-    const wrapper = mount(
-      <SprkDropdown choices={choices} variant="informational" />,
-    );
-    wrapper.find('.sprk-b-Link').simulate('click');
-    wrapper
-      .find('.sprk-c-Dropdown__link')
-      .first()
-      .simulate('click');
-    expect(spyFunc.mock.calls.length).toBe(1);
-  });
+  it(
+    'should run the choiceFunction supplied' +
+      'with the list of choices (informational)',
+    () => {
+      const spyFunc = jest.fn();
+      const choices = {
+        choiceFunction: spyFunc,
+        items: [
+          { text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } },
+        ],
+      };
+      const wrapper = mount(
+        <SprkDropdown choices={choices} variant="informational" />,
+      );
+      wrapper.find('.sprk-b-Link').simulate('click');
+      wrapper.find('.sprk-c-Dropdown__link').first().simulate('click');
+      expect(spyFunc.mock.calls.length).toBe(1);
+    },
+  );
 
-  it('should not error if choiceFunction is supplied but undefined (informational)', () => {
-    const choices = {
-      choiceFunction: undefined,
-      items: [{ text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } }],
-    };
-    const wrapper = mount(
-      <SprkDropdown choices={choices} variant="informational" />,
-    );
-    wrapper.find('.sprk-b-Link').simulate('click');
-    wrapper
-      .find('.sprk-c-Dropdown__link')
-      .first()
-      .simulate('click');
-  });
+  it(
+    'should not error' +
+      ' if choiceFunction is supplied but undefined (informational)',
+    () => {
+      const choices = {
+        choiceFunction: undefined,
+        items: [
+          { text: 'Item 1', value: 'item-1', content: { title: 'Item 1' } },
+        ],
+      };
+      const wrapper = mount(
+        <SprkDropdown choices={choices} variant="informational" />,
+      );
+      wrapper.find('.sprk-b-Link').simulate('click');
+      wrapper.find('.sprk-c-Dropdown__link').first().simulate('click');
+    },
+  );
 
   it('should close the dropdown on click outside', () => {
     const choices = {
@@ -162,6 +189,89 @@ describe('SprkDropdown:', () => {
     wrapper.instance().closeOnClickOutside({});
     expect(wrapper.state().isOpen).toBe(false);
   });
+
+  it(
+    'should set state with default choice option' +
+      ' having isActive as true, when default true attribute is provided',
+    () => {
+      const choices = {
+        items: [{ text: 'Item 1', value: 'item-1', default: true }],
+      };
+
+      const wrapper = mount(<SprkDropdown choices={choices} />);
+      expect(wrapper.state().choiceItems[0].isActive).toBe(true);
+    },
+  );
+
+  it(
+    'should set state with default choice option' +
+      ' having isActive as true, when default true attribute is provided',
+    () => {
+      const choices = {
+        items: [{ text: 'Item 1', value: 'item-1', default: true }],
+      };
+
+      const wrapper = mount(<SprkDropdown choices={choices} />);
+      expect(wrapper.state().choiceItems[0].isActive).toBe(true);
+    },
+  );
+
+  it(
+    'should set state with default choice option' +
+      ' having isActive as true, when default true attribute is provided',
+    () => {
+      const choices = {
+        items: [{ text: 'Item 1', value: 'item-1', default: true }],
+      };
+
+      const wrapper = mount(<SprkDropdown choices={choices} />);
+      expect(wrapper.state().choiceItems[0].isActive).toBe(true);
+    },
+  );
+
+  it(
+    'should set state with triggerText as Choose One...' +
+      ' when choice items are empty and defaultTriggerText is not provided',
+    () => {
+      const wrapper = mount(<SprkDropdown />);
+      expect(wrapper.state().triggerText).toBe('Choose One...');
+    },
+  );
+
+  it(
+    'should set state with triggerText as defaultTriggerText' +
+      ' when choice items are empty and defaultTriggerText is provided',
+    () => {
+      const choices = { items: [] };
+
+      const wrapper = mount(
+        <SprkDropdown choices={choices} defaultTriggerText="Default" />,
+      );
+      expect(wrapper.state().triggerText).toBe('Default');
+    },
+  );
+
+  it(
+    'should set state with triggerText as title of default choice' +
+      ' when choice items are not empty, defaultTriggerText is provided' +
+      ' and variant is informational',
+    () => {
+      const choices = {
+        items: [
+          { content: { title: 'Item 1' }, value: 'item-1', default: true },
+        ],
+      };
+
+      const wrapper = mount(
+        <SprkDropdown
+          choices={choices}
+          defaultTriggerText="Default"
+          variant="informational"
+        />,
+      );
+      expect(wrapper.state().triggerText).toBe('Item 1');
+    },
+  );
 
   it('should close the dropdown on keydown (Escape)', () => {
     const choices = {
@@ -230,110 +340,127 @@ describe('SprkDropdown:', () => {
     ).toBe(null);
   });
 
-  it('should choose correct aria-label text if defaultTriggerText is provided.', () => {
-    const wrapper = mount(
-      <SprkDropdown
-        defaultTriggerText="test"
-        variant="informational"
-        choices={{
-          items: [
-            { content: { title: 'Item 1' } },
-          ],
-        }}
-      />,
-    );
-    expect(
-      wrapper
-        .find('.sprk-b-Link')
-        .instance()
-        .getAttribute('aria-label'),
-    ).toBe('test');
-  });
+  it(
+    'should choose correct aria-label text' +
+      ' if defaultTriggerText is provided.',
+    () => {
+      const wrapper = mount(
+        <SprkDropdown
+          defaultTriggerText="test"
+          variant="informational"
+          choices={{
+            items: [{ content: { title: 'Item 1' } }],
+          }}
+        />,
+      );
+      expect(
+        wrapper.find('.sprk-b-Link').instance().getAttribute('aria-label'),
+      ).toBe('test');
+    },
+  );
 
-  it('should apply default aria-label if defaultTriggerText is not provided.', () => {
-    const wrapper = mount(
-      <SprkDropdown
-        variant="informational"
-        choices={{
-          items: [
-            { content: { title: 'Item 1' } },
-          ],
-        }}
-      />,
-    );
-    wrapper.find('.sprk-b-Link').simulate('click');
-    expect(
-      wrapper
-        .find('.sprk-b-Link')
-        .instance()
-        .getAttribute('aria-label'),
-    ).toBe('Choose One...');
-  });
+  it(
+    'should choose aria-label text as default choice item title' +
+      ' if defaultTriggerText is provided and default is true for a choice' +
+      ' and variant is informational',
+    () => {
+      const wrapper = mount(
+        <SprkDropdown
+          defaultTriggerText="test"
+          variant="informational"
+          choices={{
+            items: [{ content: { title: 'Item 1' }, default: true }],
+          }}
+        />,
+      );
+      expect(
+        wrapper.find('.sprk-b-Link').instance().getAttribute('aria-label'),
+      ).toBe('Item 1');
+    },
+  );
 
-  it('should default to correct aria-label if screenReaderText is provided.', () => {
+  it(
+    'should apply default aria-label' +
+      ' if defaultTriggerText is not provided.',
+    () => {
+      const wrapper = mount(
+        <SprkDropdown
+          variant="informational"
+          choices={{
+            items: [{ content: { title: 'Item 1' } }],
+          }}
+        />,
+      );
+      wrapper.find('.sprk-b-Link').simulate('click');
+      expect(
+        wrapper.find('.sprk-b-Link').instance().getAttribute('aria-label'),
+      ).toBe('Choose One...');
+    },
+  );
+
+  it(
+    'should default to correct aria-label' +
+      ' if screenReaderText is provided.',
+    () => {
+      const choices = {
+        items: [{ text: 'Item 1', value: 'item-1' }],
+      };
+
+      const wrapper = mount(
+        <SprkDropdown
+          choices={choices}
+          screenReaderText="Dropdown description"
+        />,
+      );
+
+      expect(
+        wrapper.find('.sprk-b-Link').instance().getAttribute('aria-label'),
+      ).toBe('Dropdown description');
+    },
+  );
+
+  it(`should default to correct aria-label,
+      if screenReaderText is not provided.`, () => {
     const choices = {
-      items: [
-        { text: 'Item 1', value: 'item-1' },
-      ],
-    };
-
-    const wrapper = mount(<SprkDropdown choices={choices} screenReaderText="Dropdown description"/>);
-
-    expect(
-      wrapper
-        .find('.sprk-b-Link')
-        .instance()
-        .getAttribute('aria-label'),
-    ).toBe('Dropdown description');
-  });
-
-  it('should default to correct aria-label if screenReaderText is not provided.', () => {
-    const choices = {
-      items: [
-        { text: 'Item 1', value: 'item-1' },
-      ],
+      items: [{ text: 'Item 1', value: 'item-1' }],
     };
 
     const wrapper = mount(<SprkDropdown choices={choices} />);
 
     expect(
-      wrapper
-        .find('.sprk-b-Link')
-        .instance()
-        .getAttribute('aria-label'),
+      wrapper.find('.sprk-b-Link').instance().getAttribute('aria-label'),
     ).toBe('Choose One...');
   });
 
   it('should apply aria-label to listbox when title is provided', () => {
-    const wrapper = mount(<SprkDropdown title="test"/>);
+    const wrapper = mount(<SprkDropdown title="test" />);
     wrapper.find('.sprk-b-Link').simulate('click');
-    expect(
-      wrapper
-        .find('ul')
-        .instance()
-        .getAttribute('aria-label'),
-    ).toBe('test');
+    expect(wrapper.find('ul').instance().getAttribute('aria-label')).toBe(
+      'test',
+    );
   });
 
-  it('should apply aria-label to listbox when there is no title but screenReaderText is provided', () => {
-    const wrapper = mount(<SprkDropdown screenReaderText="test"/>);
-    wrapper.find('.sprk-b-Link').simulate('click');
-    expect(
-      wrapper
-        .find('ul')
-        .instance()
-        .getAttribute('aria-label'),
-    ).toBe('test');
-  });
+  it(
+    'should apply aria-label to listbox,' +
+      'when there is no title but screenReaderText is provided',
+    () => {
+      const wrapper = mount(<SprkDropdown screenReaderText="test" />);
+      wrapper.find('.sprk-b-Link').simulate('click');
+      expect(wrapper.find('ul').instance().getAttribute('aria-label')).toBe(
+        'test',
+      );
+    },
+  );
 
-  it('should apply default aria-label to listbox when neither title nor screenReaderText is provided', () => {
-    const wrapper = mount(<SprkDropdown />);
-    wrapper.find('.sprk-b-Link').simulate('click');
-    expect(
-      wrapper
-        .find('ul')
-        .instance()
-        .getAttribute('aria-label'),
-    ).toBe('My Choices');
-  });
+  it(
+    'should apply default aria-label to listbox,' +
+      ' when neither title nor screenReaderText is provided',
+    () => {
+      const wrapper = mount(<SprkDropdown />);
+      wrapper.find('.sprk-b-Link').simulate('click');
+      expect(wrapper.find('ul').instance().getAttribute('aria-label')).toBe(
+        'My Choices',
+      );
+    },
+  );
 });


### PR DESCRIPTION
## What does this PR do?
Adds handling to select default choice in react dropdown, if isDefault: true is provided in option config.

### Associated Issue
Fixes #3530

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Documentation
 - [ ] Update Spark Docs

### Code
 - [ ] Build Component in HTML
 - [ ] Build Component in Angular
 - [x] Build Component in React
 - [ ] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [ ] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [ ] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.

<img width="1280" alt="Screenshot 2020-10-03 at 1 27 37 AM" src="https://user-images.githubusercontent.com/11902742/94964641-b391de00-0517-11eb-9f8b-150bda17024a.png">
<img width="1280" alt="Screenshot 2020-10-03 at 1 27 44 AM" src="https://user-images.githubusercontent.com/11902742/94964654-b7256500-0517-11eb-9fd9-02382f889a11.png">

