### PR TITLE
Fix focus for React modal component

### DIFF
--- a/react/src/components/modals/SprkModal.js
+++ b/react/src/components/modals/SprkModal.js
@@ -68,11 +68,11 @@ class SprkModal extends Component {
   }
 
   isTabPressed(e) {
-    e.key === 'Tab' || e.keyCode === 9;
+    return e.key === 'Tab' || e.keyCode === 9;
   }
   
   isEscPressed(e) {
-    e.key === 'Escape' || e.keyCode === 27;
+    return e.key === 'Escape' || e.keyCode === 27;
   }
 
   getFocusableEls(containerRef) {
@@ -87,7 +87,7 @@ class SprkModal extends Component {
   }
 
   isActiveElement(elementRef) {
-    document.activeElement === elementRef;
+    return document.activeElement === elementRef;
   }
 
   setExternalFocus() {
@@ -164,7 +164,7 @@ class SprkModal extends Component {
         this.cancel();
       }
     }
-
+    
     if (this.isTabPressed(e)) {
       if (variant === 'wait') {
         e.preventDefault();


### PR DESCRIPTION
## What does this PR do?
Fixes the issue of the React modal not trapping the focus to elements inside of it. The issue was that the value for boolean checks for seeing if tab/escape keys are pressed or if the element is active was not being returned. Therefore, the part of the `SprkModal.js` code that sets the focus to the modal elements was never being hit.

### Associated Issue
Fixes #3531 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [ x ] Build Component in React

### Browser Testing (current version and 1 prior)
  - [ x ] Google Chrome

### Screenshots
<img width="761" alt="Screen Shot 2020-10-02 at 9 43 53 PM" src="https://user-images.githubusercontent.com/22095244/94980502-67837100-04f8-11eb-8969-263990fa6051.png">

