### PR TITLE
Convert ComponentPreview.js into a functional component

### DIFF
--- a/src/components/ComponentPreview.js
+++ b/src/components/ComponentPreview.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import IframeResizer from 'iframe-resizer-react';
 import DevDocLinks from './DevDocLinks';
 
-function ComponentPreview(props) {
+const ComponentPreview = (props) => {
   const {
     componentName,
     hasReact,
@@ -45,7 +45,7 @@ function ComponentPreview(props) {
       )}
     </div>
   );
-}
+};
 
 ComponentPreview.propTypes = {
   componentName: PropTypes.string,

--- a/src/components/ComponentPreview.js
+++ b/src/components/ComponentPreview.js
@@ -3,54 +3,48 @@ import PropTypes from 'prop-types';
 import IframeResizer from 'iframe-resizer-react';
 import DevDocLinks from './DevDocLinks';
 
-class ComponentPreview extends React.Component {
-  constructor(props) {
-    super(props);
-  }
+function ComponentPreview(props) {
+  const {
+    componentName,
+    hasReact,
+    hasAngular,
+    hasHTML,
+    componentType,
+    minHeight,
+    maxHeight,
+    maxWidth,
+    allowScrolling,
+  } = props;
+  const iframeURL = `https://html.sparkdesignsystem.com/iframe.html?id=${componentType}-${componentName}`;
 
-  render() {
-    const {
-      componentName,
-      hasReact,
-      hasAngular,
-      hasHTML,
-      componentType,
-      minHeight,
-      maxHeight,
-      maxWidth,
-      allowScrolling,
-    } = this.props;
-    const iframeURL = `https://html.sparkdesignsystem.com/iframe.html?id=${componentType}-${componentName}`;
-
-    return (
-      <div className="sprk-u-mbm sprk-u-ptl">
-        <div className="sprk-u-mbl">
-          <IframeResizer
-            style={{
-              minHeight,
-              maxHeight,
-              maxWidth,
-            }}
-            scrolling={allowScrolling}
-            title="Component Preview"
-            className="docs-c-ComponentPreview sprk-o-Box"
-            src={iframeURL}
-            loading="lazy"
-          />
-        </div>
-
-        {(hasHTML || hasAngular || hasReact) && (
-          <DevDocLinks
-            hasAngular={hasAngular}
-            hasHTML={hasHTML}
-            hasReact={hasReact}
-            componentType={componentType}
-            componentName={componentName}
-          />
-        )}
+  return (
+    <div className="sprk-u-mbm sprk-u-ptl">
+      <div className="sprk-u-mbl">
+        <IframeResizer
+          style={{
+            minHeight,
+            maxHeight,
+            maxWidth,
+          }}
+          scrolling={allowScrolling}
+          title="Component Preview"
+          className="docs-c-ComponentPreview sprk-o-Box"
+          src={iframeURL}
+          loading="lazy"
+        />
       </div>
-    );
-  }
+
+      {(hasHTML || hasAngular || hasReact) && (
+        <DevDocLinks
+          hasAngular={hasAngular}
+          hasHTML={hasHTML}
+          hasReact={hasReact}
+          componentType={componentType}
+          componentName={componentName}
+        />
+      )}
+    </div>
+  );
 }
 
 ComponentPreview.propTypes = {

--- a/src/components/ComponentPreview.js
+++ b/src/components/ComponentPreview.js
@@ -3,18 +3,17 @@ import PropTypes from 'prop-types';
 import IframeResizer from 'iframe-resizer-react';
 import DevDocLinks from './DevDocLinks';
 
-const ComponentPreview = (props) => {
-  const {
-    componentName,
-    hasReact,
-    hasAngular,
-    hasHTML,
-    componentType,
-    minHeight,
-    maxHeight,
-    maxWidth,
-    allowScrolling,
-  } = props;
+const ComponentPreview = ({
+  componentName,
+  hasReact,
+  hasAngular,
+  hasHTML,
+  componentType,
+  minHeight,
+  maxHeight,
+  maxWidth,
+  allowScrolling,
+}) => {
   const iframeURL = `https://html.sparkdesignsystem.com/iframe.html?id=${componentType}-${componentName}`;
 
   return (


### PR DESCRIPTION
## What does this PR do?
Converted ComponentPreview into a functional component and removed constructor at `src/components/ComponentPreview.js`

### Associated Issue
Fixes #3502 

### Documentation
 - [ ] Update Spark Docs

### Code
 - [ ] Build Component in HTML
 - [ ] Build Component in Angular
 - [ ] Build Component in React
 - [ ] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [ ] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [ ] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [ ] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team
