### PR TITLE
Add  proptypes and fix eslint errors for InstallingSparkLayout.js

### DIFF
--- a/src/components/layouts/InstallingSparkLayout.js
+++ b/src/components/layouts/InstallingSparkLayout.js
@@ -1,10 +1,18 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import Layout from './Layout';
 
 function InstallingSparkLayout({ children, location }) {
   return (
-    <Layout initialContext={'installing-spark'} location={location}>{children}</Layout>
+    <Layout initialContext="installing-spark" location={location}>
+      {children}
+    </Layout>
   );
 }
+
+InstallingSparkLayout.propTypes = {
+  children: PropTypes.node,
+  location: PropTypes.string,
+};
 
 export default InstallingSparkLayout;


### PR DESCRIPTION
## What does this PR do?
Adds proptypes and fixes eslint errors for `spark-design-system/src/components/layouts/InstallingSparkLayout.js`

### Associated Issue
https://github.com/sparkdesignsystem/spark-design-system/issues/3474

## Please check off completed items as you work.
Removed checklist as it does not really apply. 


