### PR TITLE
React Award API Updates

### DIFF
--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -78,15 +78,17 @@ const SprkAward = (props) => {
         })}
       </SprkStack>
 
-      <SprkToggle
-        title={disclaimerTitle}
-        analyticsString={disclaimerAnalytics}
-        additionalClasses="sprk-o-Stack__item"
-      >
-        <p className="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
-          {disclaimerText}
-        </p>
-      </SprkToggle>
+      {(disclaimerTitle || disclaimerText) && (
+        <SprkToggle
+          title={disclaimerTitle}
+          analyticsString={disclaimerAnalytics}
+          additionalClasses="sprk-o-Stack__item"
+        >
+          <p className="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
+            {disclaimerText}
+          </p>
+        </SprkToggle>
+      )}
     </SprkStack>
   );
 };

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -103,7 +103,11 @@ SprkAward.defaultProps = {
 };
 
 SprkAward.propTypes = {
-  /** Determines the spacing between the items. */
+  /**
+   * Determines the spacing between the items.
+   * `misc-a`, `misc-b`, etc are deprecated. Use `miscA`, `miscB`, etc
+   * instead.
+   */
   itemSpacing: PropTypes.oneOf([
     'tiny',
     'small',

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -94,12 +94,6 @@ const SprkAward = (props) => {
 SprkAward.defaultProps = {
   splitAt: 'small',
   itemSpacing: 'medium',
-  additionalClasses: '',
-  idString: '',
-  heading: '',
-  disclaimerText: '',
-  disclaimerAnalytics: '',
-  disclaimerTitle: '',
 };
 
 SprkAward.propTypes = {

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -82,7 +82,7 @@ const SprkAward = (props) => {
         })}
       </SprkStack>
 
-      {(disclaimerTitle || disclaimerText) && (
+      {disclaimerTitle && disclaimerText && (
         <SprkToggle
           title={disclaimerTitle}
           analyticsString={disclaimerAnalytics}

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -122,7 +122,6 @@ SprkAward.propTypes = {
     'miscB',
     'miscC',
     'miscD',
-    '',
   ]),
   /**
    * Determines when the flex-direction should
@@ -135,7 +134,6 @@ SprkAward.propTypes = {
     'medium',
     'large',
     'huge',
-    '',
   ]),
   /**
    * A space-separated string of classes to add

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -48,6 +48,8 @@ const SprkAward = (props) => {
             href,
             linkAddClasses,
             addClasses,
+            imageAdditionalClasses,
+            linkAdditionalClasses,
             alt,
             src,
             element,
@@ -58,7 +60,7 @@ const SprkAward = (props) => {
             <TagName
               className={classnames(
                 'sprk-o-Stack__item sprk-o-Stack__item--flex@s sprk-o-Stack',
-                linkAddClasses,
+                linkAdditionalClasses || linkAddClasses,
               )}
               href={TagName === 'a' ? href || '#nogo' : undefined}
               data-analytics={analyticsString}
@@ -68,7 +70,7 @@ const SprkAward = (props) => {
               <img
                 className={classnames(
                   'sprk-o-Stack__item sprk-o-Stack__item--center-column',
-                  addClasses,
+                  imageAdditionalClasses || addClasses,
                 )}
                 alt={alt}
                 src={src}
@@ -133,10 +135,17 @@ SprkAward.propTypes = {
       src: PropTypes.string.isRequired,
       /** The alt text for the image, icon, or SprkIcon. */
       alt: PropTypes.string.isRequired,
-      /** Additional classes for the image. */
+      /** Deprecated - Use `imageAdditionalClasses` instead.
+       * Additional classes for the image. */
       addClasses: PropTypes.string,
-      /** Additional classes for the link wrapping the image. */
+      /** Deprecated - Use `linkAdditionalClasses` instead.
+       * Additional classes for the link wrapping the image. */
       linkAddClasses: PropTypes.string,
+      /** Additional classes for the image. */
+      imageAdditionalClasses: PropTypes.string,
+      /** Additional classes for the link wrapping the image. */
+      linkAdditionalClasses: PropTypes.string,
+
       /**
        * Assigned to the `data-analytics` attribute
        * serving as a unique selector for outside libraries to capture data.

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -42,6 +42,8 @@ const SprkAward = (props) => {
         splitAt={splitAt}
         itemSpacing={itemSpacing}
       >
+        {/* TODO - Remove linkAddClasses and addClasses
+        as part of Issue 1279 */}
         {images.map((image) => {
           const {
             analyticsString,

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -163,14 +163,23 @@ SprkAward.propTypes = {
       /** The alt text for the image, icon, or SprkIcon. */
       alt: PropTypes.string.isRequired,
       /** Deprecated - Use `imageAdditionalClasses` instead.
-       * Additional classes for the image. */
+       * A space-separated string of classes to add to each of the images in
+       * the component. */
       addClasses: PropTypes.string,
       /** Deprecated - Use `linkAdditionalClasses` instead.
-       * Additional classes for the link wrapping the image. */
+       * A space-separated string of classes to add to the links wrapping each
+       * of the images in the component.
+       */
       linkAddClasses: PropTypes.string,
-      /** Additional classes for the image. */
+      /**
+       * A space-separated string of classes to add to each of the images in
+       * the component.
+       */
       imageAdditionalClasses: PropTypes.string,
-      /** Additional classes for the link wrapping the image. */
+      /**
+       * A space-separated string of classes to add to the links wrapping each
+       * of the images in the component.
+       */
       linkAdditionalClasses: PropTypes.string,
 
       /**

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -17,7 +17,7 @@ const SprkAward = (props) => {
     splitAt,
     itemSpacing,
   } = props;
-  const classNames = classnames('sprk-o-CenteredColumn', additionalClasses);
+  const classNames = classnames(additionalClasses);
 
   return (
     <SprkStack

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -102,12 +102,35 @@ SprkAward.defaultProps = {
 
 SprkAward.propTypes = {
   /** Determines the spacing between the items. */
-  itemSpacing: PropTypes.string,
+  itemSpacing: PropTypes.oneOf([
+    'tiny',
+    'small',
+    'medium',
+    'large',
+    'huge',
+    'misc-a',
+    'misc-b',
+    'misc-c',
+    'misc-d',
+    'miscA',
+    'miscB',
+    'miscC',
+    'miscD',
+    '',
+  ]),
   /**
    * Determines when the flex-direction should
    * change to row from column for the images.
    */
-  splitAt: PropTypes.string,
+  splitAt: PropTypes.oneOf([
+    'extraTiny',
+    'tiny',
+    'small',
+    'medium',
+    'large',
+    'huge',
+    '',
+  ]),
   /**
    * A space-separated string of classes to add
    * to the outermost container of the component.

--- a/react/src/components/awards/SprkAward.stories.js
+++ b/react/src/components/awards/SprkAward.stories.js
@@ -43,6 +43,7 @@ export const defaultStory = () => (
         element: 'a',
       },
     ]}
+    additionalClasses="sprk-o-CenteredColumn"
   />
 );
 

--- a/react/src/components/awards/SprkAward.stories.js
+++ b/react/src/components/awards/SprkAward.stories.js
@@ -5,11 +5,9 @@ import { markdownDocumentationLinkBuilder } from '../../../../storybook-utilitie
 export default {
   title: 'Components/Award',
   component: SprkAward,
-  decorators: [
-    story => <div className="sprk-o-Box">{story()}</div>
-  ],
+  decorators: [(story) => <div className="sprk-o-Box">{story()}</div>],
   parameters: {
-    jest: ['SprkAward'] ,
+    jest: ['SprkAward'],
     info: `${markdownDocumentationLinkBuilder('award')}`,
   },
 };

--- a/react/src/components/awards/SprkAward.stories.js
+++ b/react/src/components/awards/SprkAward.stories.js
@@ -8,7 +8,11 @@ export default {
   decorators: [(story) => <div className="sprk-o-Box">{story()}</div>],
   parameters: {
     jest: ['SprkAward'],
-    info: `${markdownDocumentationLinkBuilder('award')}`,
+    info: `
+${markdownDocumentationLinkBuilder('award')}
+- If you do not want the Award component centered, be sure to remove the
+sprk-o-CenteredColumn class from additionalClasses.
+`,
   },
 };
 

--- a/react/src/components/awards/SprkAward.test.js
+++ b/react/src/components/awards/SprkAward.test.js
@@ -124,4 +124,12 @@ describe('SprkAward:', () => {
       0,
     );
   });
+
+  it('should not render the Toggle if props are empty', () => {
+    let wrapper = mount(<SprkAward images={[]} />);
+    expect(wrapper.find('div.sprk-c-Toggle').length).toBe(0);
+
+    wrapper = mount(<SprkAward images={[]} disclaimerTitle="Title" />);
+    expect(wrapper.find('div.sprk-c-Toggle').length).toBe(1);
+  });
 });

--- a/react/src/components/awards/SprkAward.test.js
+++ b/react/src/components/awards/SprkAward.test.js
@@ -132,4 +132,42 @@ describe('SprkAward:', () => {
     wrapper = mount(<SprkAward images={[]} disclaimerTitle="Title" />);
     expect(wrapper.find('div.sprk-c-Toggle').length).toBe(1);
   });
+
+  it('should render with deprecated props', () => {
+    const images = [
+      {
+        href: '#nogo',
+        src: 'https://spark-assets.netlify.app/spark-placeholder.jpg',
+        alt: 'Spark Placeholder Logo',
+        analyticsString: 'award-1',
+        addClasses: 'oldImageClass',
+        linkAddClasses: 'oldLinkClass',
+      },
+    ];
+    const wrapper = mount(<SprkAward images={images} />);
+
+    expect(wrapper.find('.oldImageClass').length).toBe(1);
+    expect(wrapper.find('.oldLinkClass').length).toBe(1);
+  });
+
+  it('should prefer new props over deprecated props', () => {
+    const images = [
+      {
+        href: '#nogo',
+        src: 'https://spark-assets.netlify.app/spark-placeholder.jpg',
+        alt: 'Spark Placeholder Logo',
+        analyticsString: 'award-1',
+        addClasses: 'oldImageClass',
+        imageAdditionalClasses: 'newImageClass',
+        linkAddClasses: 'oldLinkClass',
+        linkAdditionalClasses: 'newLinkClass',
+      },
+    ];
+    const wrapper = mount(<SprkAward images={images} />);
+
+    expect(wrapper.find('.newImageClass').length).toBe(1);
+    expect(wrapper.find('.oldImageClass').length).toBe(0);
+    expect(wrapper.find('.newLinkClass').length).toBe(1);
+    expect(wrapper.find('.oldLinkClass').length).toBe(0);
+  });
 });

--- a/react/src/components/awards/SprkAward.test.js
+++ b/react/src/components/awards/SprkAward.test.js
@@ -133,6 +133,7 @@ describe('SprkAward:', () => {
     expect(wrapper.find('div.sprk-c-Toggle').length).toBe(1);
   });
 
+  // TODO - Remove linkAddClasses and addClasses as part of Issue 1279
   it('should render with deprecated props', () => {
     const images = [
       {
@@ -150,6 +151,7 @@ describe('SprkAward:', () => {
     expect(wrapper.find('.oldLinkClass').length).toBe(1);
   });
 
+  // TODO - Remove linkAddClasses and addClasses as part of Issue 1279
   it('should prefer new props over deprecated props', () => {
     const images = [
       {

--- a/react/src/components/awards/SprkAward.test.js
+++ b/react/src/components/awards/SprkAward.test.js
@@ -8,7 +8,7 @@ import SprkAward from './SprkAward';
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('SprkAward:', () => {
-  it('should display a SprkAward with the correct base class', () => {
+  it('should display a SprkAward with the correct base classes', () => {
     const images = [
       {
         href: '#nogo',
@@ -24,11 +24,10 @@ describe('SprkAward:', () => {
       },
     ];
     const wrapper = mount(<SprkAward images={images} />);
-    expect(
-      wrapper.find(
-        'div.sprk-o-Stack.sprk-o-CenteredColumn.sprk-o-Stack--medium',
-      ).length,
-    ).toBe(1);
+    expect(wrapper.find('div').first().hasClass('sprk-o-Stack')).toBe(true);
+    expect(wrapper.find('div').first().hasClass('sprk-o-Stack--medium')).toBe(
+      true,
+    );
   });
 
   it('should display the award component with the images section', () => {
@@ -118,4 +117,11 @@ describe('SprkAward:', () => {
       expect(wrapper.find('a[href=""]').length).toBe(0);
     },
   );
+
+  it('should not add centered column class by default', () => {
+    const wrapper = mount(<SprkAward images={[]} />);
+    expect(wrapper.find('div.sprk-o-Stack.sprk-o-CenteredColumn').length).toBe(
+      0,
+    );
+  });
 });

--- a/react/src/components/awards/SprkAward.test.js
+++ b/react/src/components/awards/SprkAward.test.js
@@ -125,11 +125,16 @@ describe('SprkAward:', () => {
     );
   });
 
-  it('should not render the Toggle if props are empty', () => {
+  it('should not render the Toggle if both props are empty', () => {
     let wrapper = mount(<SprkAward images={[]} />);
     expect(wrapper.find('div.sprk-c-Toggle').length).toBe(0);
 
     wrapper = mount(<SprkAward images={[]} disclaimerTitle="Title" />);
+    expect(wrapper.find('div.sprk-c-Toggle').length).toBe(0);
+
+    wrapper = mount(
+      <SprkAward images={[]} disclaimerTitle="Title" disclaimerText="Body" />,
+    );
     expect(wrapper.find('div.sprk-c-Toggle').length).toBe(1);
   });
 

--- a/react/src/objects/stack/SprkStack.js
+++ b/react/src/objects/stack/SprkStack.js
@@ -19,6 +19,7 @@ const SprkStack = (props) => {
     'sprk-o-Stack--medium': itemSpacing === 'medium',
     'sprk-o-Stack--large': itemSpacing === 'large',
     'sprk-o-Stack--huge': itemSpacing === 'huge',
+    // TODO deprecate hyphenated in favor of camelCase, Issue 1294
     'sprk-o-Stack--misc-a': itemSpacing === 'miscA' || itemSpacing === 'misc-a',
     'sprk-o-Stack--misc-b': itemSpacing === 'miscB' || itemSpacing === 'misc-b',
     'sprk-o-Stack--misc-c': itemSpacing === 'miscC' || itemSpacing === 'misc-c',


### PR DESCRIPTION
## What does this PR do?
- Award will no longer render an empty Toggle
- Award will no longer render with `sprk-o-CenteredColumn` by default. This class can be added back with `additionalClasses` if it is desired.
- Property `addClasses` is deprecated. Use `imageAdditionalClasses` instead.
- Property `linkAddClasses` is deprecated. Use `linkAdditionalClasses` instead.
- Remove the empty string default props
- Fix the eslint errors
- Add in oneOf for splitAt prop to define expected strings.
- Add in oneOf for itemSpacing prop to define the expected strings.

### Associated Issue
Fixes #3315 

### Code
 - [X] Build Component in React
 - [X] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)

