### PR TITLE
Angular Award API Updates

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -120,7 +120,7 @@ describe('SprkAwardComponent', () => {
     const testString = 'element-id';
     component.idString = testString;
     fixture.detectChanges();
-    element = fixture.nativeElement.querySelector('h2');
+    element = fixture.nativeElement.querySelector('div');
     expect(element.getAttribute('data-id')).toEqual(testString);
   });
 
@@ -128,7 +128,7 @@ describe('SprkAwardComponent', () => {
     const testString = null;
     component.idString = testString;
     fixture.detectChanges();
-    element = fixture.nativeElement.querySelector('h2');
+    element = fixture.nativeElement.querySelector('div');
     expect(element.getAttribute('data-id')).toBeNull();
   });
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -5,13 +5,27 @@ import { SprkAwardComponent } from './sprk-award.component';
 import { SprkToggleComponent } from '../sprk-toggle/sprk-toggle.component';
 import { SprkStackComponent } from '../sprk-stack/sprk-stack.component';
 import { SprkStackItemDirective } from '../../directives/sprk-stack-item/sprk-stack-item.directive';
+import { Component } from '@angular/core';
 
 import { SprkIconComponent } from '../sprk-icon/sprk-icon.component';
+
+@Component({
+  selector: `sprk-test`,
+  template: ` <sprk-award [title]="title" [heading]="heading"></sprk-award>`,
+})
+class WrappedAwardComponent {
+  title: string; // = '';
+  heading: string; // = '';
+}
 
 describe('SprkAwardComponent', () => {
   let component: SprkAwardComponent;
   let fixture: ComponentFixture<SprkAwardComponent>;
   let element: HTMLElement;
+
+  let wrappedComponent: WrappedAwardComponent;
+  let wrappedFixture: ComponentFixture<WrappedAwardComponent>;
+  let wrappedElement: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -23,6 +37,7 @@ describe('SprkAwardComponent', () => {
         SprkStackComponent,
         SprkStackItemDirective,
         SprkIconComponent,
+        WrappedAwardComponent,
       ],
     }).compileComponents();
   }));
@@ -31,6 +46,12 @@ describe('SprkAwardComponent', () => {
     fixture = TestBed.createComponent(SprkAwardComponent);
     component = fixture.componentInstance;
     element = fixture.nativeElement.querySelector('div');
+    fixture.detectChanges();
+
+    wrappedFixture = TestBed.createComponent(WrappedAwardComponent);
+    wrappedComponent = wrappedFixture.componentInstance;
+    wrappedElement = wrappedFixture.nativeElement.querySelector('div');
+    wrappedFixture.detectChanges();
   });
 
   it('should create itself', () => {
@@ -132,9 +153,25 @@ describe('SprkAwardComponent', () => {
     expect(element.getAttribute('data-id')).toBeNull();
   });
 
-  it('should respond to updates to title', () => {});
+  it('should respond to updates to title', () => {
+    let testString = 'initTitle';
+    wrappedComponent.title = testString;
+    wrappedFixture.detectChanges();
+    expect(wrappedElement.querySelector('h2').textContent).toEqual(testString);
 
-  it('should prefer heading over title', () => {});
+    testString = 'updatedTitle';
+
+    wrappedComponent.title = testString;
+    wrappedFixture.detectChanges();
+    expect(wrappedElement.querySelector('h2').textContent).toEqual(testString);
+  });
+
+  it('should prefer heading over title', () => {
+    wrappedComponent.title = 'title';
+    wrappedComponent.heading = 'heading';
+    wrappedFixture.detectChanges();
+    expect(wrappedElement.querySelector('h2').textContent).toEqual('heading');
+  });
 
   it('should respond to updates to analyticsStringImgOne', () => {});
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -131,4 +131,28 @@ describe('SprkAwardComponent', () => {
     element = fixture.nativeElement.querySelector('h2');
     expect(element.getAttribute('data-id')).toBeNull();
   });
+
+  it('should respond to updates to title', () => {});
+
+  it('should prefer heading over title', () => {});
+
+  it('should respond to updates to analyticsStringImgOne', () => {});
+
+  it('should prefer imgOneAnalyticsString over analyticsStringImgOne', () => {});
+
+  it('should respond to updates to analyticsStringImgTwo', () => {});
+
+  it('should prefer imgTwoAnalyticsString over analyticsStringImgTwo', () => {});
+
+  it('should respond to updates to analyticsStringDisclaimer', () => {});
+
+  it('should prefer disclaimerAnalyticsString over analyticsStringDisclaimer', () => {});
+
+  it('should respond to updates to additionalClassesImgOne', () => {});
+
+  it('should prefer imgOneAdditionalClasses over additionalClassesImgOne', () => {});
+
+  it('should respond to updates to additionalClassesImgTwo', () => {});
+
+  it('should prefer imgTwoAdditionalClasses over additionalClassesImgTwo', () => {});
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -153,25 +153,25 @@ describe('SprkAwardComponent', () => {
     expect(element.getAttribute('data-id')).toBeNull();
   });
 
-  it('should respond to updates to title', () => {
-    let testString = 'initTitle';
-    wrappedComponent.title = testString;
-    wrappedFixture.detectChanges();
-    expect(wrappedElement.querySelector('h2').textContent).toEqual(testString);
+  // it('should respond to updates to title', () => {
+  //   let testString = 'initTitle';
+  //   wrappedComponent.title = testString;
+  //   wrappedFixture.detectChanges();
+  //   expect(wrappedElement.querySelector('h2').textContent).toEqual(testString);
 
-    testString = 'updatedTitle';
+  //   testString = 'updatedTitle';
 
-    wrappedComponent.title = testString;
-    wrappedFixture.detectChanges();
-    expect(wrappedElement.querySelector('h2').textContent).toEqual(testString);
-  });
+  //   wrappedComponent.title = testString;
+  //   wrappedFixture.detectChanges();
+  //   expect(wrappedElement.querySelector('h2').textContent).toEqual(testString);
+  // });
 
-  it('should prefer heading over title', () => {
-    wrappedComponent.title = 'title';
-    wrappedComponent.heading = 'heading';
-    wrappedFixture.detectChanges();
-    expect(wrappedElement.querySelector('h2').textContent).toEqual('heading');
-  });
+  // it('should prefer heading over title', () => {
+  //   wrappedComponent.title = 'title';
+  //   wrappedComponent.heading = 'heading';
+  //   wrappedFixture.detectChanges();
+  //   expect(wrappedElement.querySelector('h2').textContent).toEqual('heading');
+  // });
 
   it('should respond to updates to analyticsStringImgOne', () => {});
 
@@ -192,4 +192,18 @@ describe('SprkAwardComponent', () => {
   it('should respond to updates to additionalClassesImgTwo', () => {});
 
   it('should prefer imgTwoAdditionalClasses over additionalClassesImgTwo', () => {});
+
+  it('should only display the toggle if both Inputs are provided', () => {
+    fixture.detectChanges();
+    expect(element.querySelectorAll('.sprk-c-Toggle').length).toEqual(0);
+
+    component.disclaimerCopy = 'copy';
+    fixture.detectChanges();
+    expect(element.querySelectorAll('.sprk-c-Toggle').length).toEqual(0);
+
+    component.disclaimerCopy = 'copy';
+    component.disclaimerTitle = 'title';
+    fixture.detectChanges();
+    expect(element.querySelectorAll('.sprk-c-Toggle').length).toEqual(1);
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -22,8 +22,8 @@ describe('SprkAwardComponent', () => {
         SprkToggleComponent,
         SprkStackComponent,
         SprkStackItemDirective,
-        SprkIconComponent
-      ]
+        SprkIconComponent,
+      ],
     }).compileComponents();
   }));
 
@@ -41,15 +41,7 @@ describe('SprkAwardComponent', () => {
     component.splitAt = 'huge';
     fixture.detectChanges();
     expect(element.querySelector('div').classList.toString()).toEqual(
-      component.getClasses()
-    );
-  });
-
-  it('should add the correct class if splitAt is not set', () => {
-    component.splitAt = '';
-    fixture.detectChanges();
-    expect(component.getClasses()).toEqual(
-      'sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack__item sprk-o-Stack__item--center-column'
+      component.getClasses(),
     );
   });
 
@@ -57,7 +49,7 @@ describe('SprkAwardComponent', () => {
     component.splitAt = 'tiny';
     fixture.detectChanges();
     expect(component.getClasses()).toEqual(
-      'sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack__item sprk-o-Stack__item--center-column sprk-o-Stack--split@xs'
+      'sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack__item sprk-o-Stack__item--center-column sprk-o-Stack--split@xs',
     );
   });
 
@@ -65,7 +57,7 @@ describe('SprkAwardComponent', () => {
     component.splitAt = 'small';
     fixture.detectChanges();
     expect(component.getClasses()).toEqual(
-      'sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack__item sprk-o-Stack__item--center-column sprk-o-Stack--split@s'
+      'sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack__item sprk-o-Stack__item--center-column sprk-o-Stack--split@s',
     );
   });
 
@@ -73,7 +65,7 @@ describe('SprkAwardComponent', () => {
     component.additionalClassesImgOne = 'test-img-one';
     fixture.detectChanges();
     expect(element.querySelector('img').classList.toString()).toEqual(
-      component.getClassesImgOne()
+      component.getClassesImgOne(),
     );
   });
 
@@ -81,7 +73,7 @@ describe('SprkAwardComponent', () => {
     component.additionalClassesImgTwo = 'test-img-two';
     fixture.detectChanges();
     expect(element.querySelectorAll('img')[1].classList.toString()).toEqual(
-      component.getClassesImgTwo()
+      component.getClassesImgTwo(),
     );
   });
 
@@ -89,7 +81,7 @@ describe('SprkAwardComponent', () => {
     component.splitAt = 'small';
     fixture.detectChanges();
     expect(component.getImgContainerClasses()).toEqual(
-      'sprk-o-Stack__item sprk-o-Stack__item--flex@s'
+      'sprk-o-Stack__item sprk-o-Stack__item--flex@s',
     );
   });
 
@@ -105,7 +97,7 @@ describe('SprkAwardComponent', () => {
     component.analyticsStringImgOne = str;
     fixture.detectChanges();
     expect(element.querySelector('a').getAttribute('data-analytics')).toEqual(
-      str
+      str,
     );
   });
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -9,23 +9,23 @@ import { Component } from '@angular/core';
 
 import { SprkIconComponent } from '../sprk-icon/sprk-icon.component';
 
-@Component({
-  selector: `sprk-test`,
-  template: ` <sprk-award [title]="title" [heading]="heading"></sprk-award>`,
-})
-class WrappedAwardComponent {
-  title: string; // = '';
-  heading: string; // = '';
-}
+// @Component({
+//   selector: `sprk-test`,
+//   template: ` <sprk-award [title]="title" [heading]="heading"></sprk-award>`,
+// })
+// class WrappedAwardComponent {
+//   title: string; // = '';
+//   heading: string; // = '';
+// }
 
 describe('SprkAwardComponent', () => {
   let component: SprkAwardComponent;
   let fixture: ComponentFixture<SprkAwardComponent>;
   let element: HTMLElement;
 
-  let wrappedComponent: WrappedAwardComponent;
-  let wrappedFixture: ComponentFixture<WrappedAwardComponent>;
-  let wrappedElement: HTMLElement;
+  // let wrappedComponent: WrappedAwardComponent;
+  // let wrappedFixture: ComponentFixture<WrappedAwardComponent>;
+  // let wrappedElement: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -37,7 +37,7 @@ describe('SprkAwardComponent', () => {
         SprkStackComponent,
         SprkStackItemDirective,
         SprkIconComponent,
-        WrappedAwardComponent,
+        // WrappedAwardComponent,
       ],
     }).compileComponents();
   }));
@@ -48,10 +48,10 @@ describe('SprkAwardComponent', () => {
     element = fixture.nativeElement.querySelector('div');
     fixture.detectChanges();
 
-    wrappedFixture = TestBed.createComponent(WrappedAwardComponent);
-    wrappedComponent = wrappedFixture.componentInstance;
-    wrappedElement = wrappedFixture.nativeElement.querySelector('div');
-    wrappedFixture.detectChanges();
+    // wrappedFixture = TestBed.createComponent(WrappedAwardComponent);
+    // wrappedComponent = wrappedFixture.componentInstance;
+    // wrappedElement = wrappedFixture.nativeElement.querySelector('div');
+    // wrappedFixture.detectChanges();
   });
 
   it('should create itself', () => {
@@ -153,45 +153,143 @@ describe('SprkAwardComponent', () => {
     expect(element.getAttribute('data-id')).toBeNull();
   });
 
-  // it('should respond to updates to title', () => {
-  //   let testString = 'initTitle';
-  //   wrappedComponent.title = testString;
-  //   wrappedFixture.detectChanges();
-  //   expect(wrappedElement.querySelector('h2').textContent).toEqual(testString);
+  it('should respond to updates to title', () => {
+    let testString = 'initTitle';
+    component.title = testString;
+    fixture.detectChanges();
+    expect(element.querySelector('h2').textContent).toEqual(testString);
 
-  //   testString = 'updatedTitle';
+    testString = 'updatedTitle';
 
-  //   wrappedComponent.title = testString;
-  //   wrappedFixture.detectChanges();
-  //   expect(wrappedElement.querySelector('h2').textContent).toEqual(testString);
+    component.title = testString;
+    fixture.detectChanges();
+    expect(element.querySelector('h2').textContent).toEqual(testString);
+  });
+
+  it('should respond to updates to heading', () => {
+    let testString = 'initHeading';
+    component.heading = testString;
+    fixture.detectChanges();
+    expect(element.querySelector('h2').textContent).toEqual(testString);
+
+    testString = 'updatedHeading';
+
+    component.heading = testString;
+    fixture.detectChanges();
+    expect(element.querySelector('h2').textContent).toEqual(testString);
+  });
+
+  it('should prefer heading over title', () => {
+    component.title = 'title2';
+    component.heading = 'heading2';
+    fixture.detectChanges();
+    expect(element.querySelector('h2').textContent).toEqual('heading2');
+  });
+
+  it('should respond to updates to analyticsStringImgOne', () => {
+    let testString = 'test1';
+    component.analyticsStringImgOne = testString;
+    fixture.detectChanges();
+    expect(element.querySelector('a').getAttribute('data-analytics')).toEqual(
+      testString,
+    );
+
+    testString = 'test2';
+    component.analyticsStringImgOne = testString;
+    fixture.detectChanges();
+    expect(element.querySelector('a').getAttribute('data-analytics')).toEqual(
+      testString,
+    );
+  });
+
+  // it('should prefer imgOneAnalyticsString over analyticsStringImgOne', () => {
+  //   component.imgOneAnalyticsString = 'testNewInput';
+  //   component.analyticsStringImgOne = 'testOldInput';
+  //   fixture.detectChanges;
+  //   console.log(element.outerHTML)
+  //   expect(element.querySelector('a').getAttribute('data-analytics')).toEqual(
+  //     'testNewInput',
+  //   );
   // });
-
-  // it('should prefer heading over title', () => {
-  //   wrappedComponent.title = 'title';
-  //   wrappedComponent.heading = 'heading';
-  //   wrappedFixture.detectChanges();
-  //   expect(wrappedElement.querySelector('h2').textContent).toEqual('heading');
-  // });
-
-  it('should respond to updates to analyticsStringImgOne', () => {});
-
-  it('should prefer imgOneAnalyticsString over analyticsStringImgOne', () => {});
 
   it('should respond to updates to analyticsStringImgTwo', () => {});
 
   it('should prefer imgTwoAnalyticsString over analyticsStringImgTwo', () => {});
 
-  it('should respond to updates to analyticsStringDisclaimer', () => {});
+  // it('should respond to updates to analyticsStringDisclaimer', () => {
+  //   let testString = "testDisclaimer";
+  //   // disclaimer inputs aren't showing up?
+  //   component.disclaimerCopy="foo";
+  //   component.disclaimerTitle="bar";
+  //   component.analyticsStringDisclaimer = testString;
+  //   fixture.detectChanges;
+  //   console.log(element.outerHTML);
+  //   expect(element.querySelector('button').getAttribute('data-analytics')).toEqual(
+  //     testString,
+  //   );
+  // });
 
   it('should prefer disclaimerAnalyticsString over analyticsStringDisclaimer', () => {});
 
-  it('should respond to updates to additionalClassesImgOne', () => {});
+  it('should respond to updates to additionalClassesImgOne', () => {
+    let testString = 'testClass';
+    component.additionalClassesImgOne = testString;
+    fixture.detectChanges();
+    expect(element.querySelector('img').classList.contains(testString)).toBe(
+      true,
+    );
 
-  it('should prefer imgOneAdditionalClasses over additionalClassesImgOne', () => {});
+    testString = 'anotherClass';
+    component.additionalClassesImgOne = testString;
+    fixture.detectChanges();
+    expect(element.querySelector('img').classList.contains(testString)).toBe(
+      true,
+    );
+  });
 
-  it('should respond to updates to additionalClassesImgTwo', () => {});
+  it('should prefer imgOneAdditionalClasses over additionalClassesImgOne', () => {
+    const testOldProp = 'testClass';
+    const testNewProp = 'testNewClass';
+    component.additionalClassesImgOne = testOldProp;
+    component.imgOneAdditionalClasses = testNewProp;
+    fixture.detectChanges();
+    expect(element.querySelector('img').classList.contains(testNewProp)).toBe(
+      true,
+    );
+    expect(element.querySelector('img').classList.contains(testOldProp)).toBe(
+      false,
+    );
+  });
 
-  it('should prefer imgTwoAdditionalClasses over additionalClassesImgTwo', () => {});
+  it('should respond to updates to additionalClassesImgTwo', () => {
+    let testString = 'testClass';
+    component.additionalClassesImgTwo = testString;
+    fixture.detectChanges();
+    expect(
+      element.querySelectorAll('img')[1].classList.contains(testString),
+    ).toBe(true);
+
+    testString = 'anotherClass';
+    component.additionalClassesImgTwo = testString;
+    fixture.detectChanges();
+    expect(
+      element.querySelectorAll('img')[1].classList.contains(testString),
+    ).toBe(true);
+  });
+
+  it('should prefer imgTwoAdditionalClasses over additionalClassesImgTwo', () => {
+    const testOldProp = 'testClass';
+    const testNewProp = 'testNewClass';
+    component.additionalClassesImgTwo = testOldProp;
+    component.imgTwoAdditionalClasses = testNewProp;
+    fixture.detectChanges();
+    expect(
+      element.querySelectorAll('img')[1].classList.contains(testNewProp),
+    ).toBe(true);
+    expect(
+      element.querySelectorAll('img')[1].classList.contains(testOldProp),
+    ).toBe(false);
+  });
 
   it('should only display the toggle if both Inputs are provided', () => {
     fixture.detectChanges();

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -5,27 +5,12 @@ import { SprkAwardComponent } from './sprk-award.component';
 import { SprkToggleComponent } from '../sprk-toggle/sprk-toggle.component';
 import { SprkStackComponent } from '../sprk-stack/sprk-stack.component';
 import { SprkStackItemDirective } from '../../directives/sprk-stack-item/sprk-stack-item.directive';
-import { Component } from '@angular/core';
-
 import { SprkIconComponent } from '../sprk-icon/sprk-icon.component';
-
-// @Component({
-//   selector: `sprk-test`,
-//   template: ` <sprk-award [title]="title" [heading]="heading"></sprk-award>`,
-// })
-// class WrappedAwardComponent {
-//   title: string; // = '';
-//   heading: string; // = '';
-// }
 
 describe('SprkAwardComponent', () => {
   let component: SprkAwardComponent;
   let fixture: ComponentFixture<SprkAwardComponent>;
   let element: HTMLElement;
-
-  // let wrappedComponent: WrappedAwardComponent;
-  // let wrappedFixture: ComponentFixture<WrappedAwardComponent>;
-  // let wrappedElement: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -37,7 +22,6 @@ describe('SprkAwardComponent', () => {
         SprkStackComponent,
         SprkStackItemDirective,
         SprkIconComponent,
-        // WrappedAwardComponent,
       ],
     }).compileComponents();
   }));
@@ -47,11 +31,6 @@ describe('SprkAwardComponent', () => {
     component = fixture.componentInstance;
     element = fixture.nativeElement.querySelector('div');
     fixture.detectChanges();
-
-    // wrappedFixture = TestBed.createComponent(WrappedAwardComponent);
-    // wrappedComponent = wrappedFixture.componentInstance;
-    // wrappedElement = wrappedFixture.nativeElement.querySelector('div');
-    // wrappedFixture.detectChanges();
   });
 
   it('should create itself', () => {
@@ -202,34 +181,63 @@ describe('SprkAwardComponent', () => {
     );
   });
 
-  // it('should prefer imgOneAnalyticsString over analyticsStringImgOne', () => {
-  //   component.imgOneAnalyticsString = 'testNewInput';
-  //   component.analyticsStringImgOne = 'testOldInput';
-  //   fixture.detectChanges;
-  //   console.log(element.outerHTML)
-  //   expect(element.querySelector('a').getAttribute('data-analytics')).toEqual(
-  //     'testNewInput',
-  //   );
-  // });
+  it('should prefer imgOneAnalyticsString over analyticsStringImgOne', () => {
+    component.imgOneAnalyticsString = 'testNewInput';
+    component.analyticsStringImgOne = 'testOldInput';
+    fixture.detectChanges();
+    expect(element.querySelector('a').getAttribute('data-analytics')).toEqual(
+      'testNewInput',
+    );
+  });
 
-  it('should respond to updates to analyticsStringImgTwo', () => {});
+  it('should respond to updates to analyticsStringImgTwo', () => {
+    let testString = 'test1';
+    component.analyticsStringImgTwo = testString;
+    fixture.detectChanges();
+    expect(
+      element.querySelectorAll('a')[1].getAttribute('data-analytics'),
+    ).toEqual(testString);
 
-  it('should prefer imgTwoAnalyticsString over analyticsStringImgTwo', () => {});
+    testString = 'test2';
+    component.analyticsStringImgTwo = testString;
+    fixture.detectChanges();
+    expect(
+      element.querySelectorAll('a')[1].getAttribute('data-analytics'),
+    ).toEqual(testString);
+  });
 
-  // it('should respond to updates to analyticsStringDisclaimer', () => {
-  //   let testString = "testDisclaimer";
-  //   // disclaimer inputs aren't showing up?
-  //   component.disclaimerCopy="foo";
-  //   component.disclaimerTitle="bar";
-  //   component.analyticsStringDisclaimer = testString;
-  //   fixture.detectChanges;
-  //   console.log(element.outerHTML);
-  //   expect(element.querySelector('button').getAttribute('data-analytics')).toEqual(
-  //     testString,
-  //   );
-  // });
+  it('should prefer imgTwoAnalyticsString over analyticsStringImgTwo', () => {
+    component.imgTwoAnalyticsString = 'testNewInput';
+    component.analyticsStringImgTwo = 'testOldInput';
+    fixture.detectChanges();
+    expect(
+      element.querySelectorAll('a')[1].getAttribute('data-analytics'),
+    ).toEqual('testNewInput');
+  });
 
-  it('should prefer disclaimerAnalyticsString over analyticsStringDisclaimer', () => {});
+  it('should respond to updates to analyticsStringDisclaimer', () => {
+    let testString = 'testDisclaimer';
+    component.disclaimerCopy = 'foo';
+    component.disclaimerTitle = 'bar';
+    component.analyticsStringDisclaimer = testString;
+    fixture.detectChanges();
+    expect(
+      element.querySelector('button').getAttribute('data-analytics'),
+    ).toEqual(testString);
+  });
+
+  it('should prefer disclaimerAnalyticsString over analyticsStringDisclaimer', () => {
+    const testOldProp = 'oldTest';
+    const testNewProp = 'newTest';
+    component.disclaimerCopy = 'foo';
+    component.disclaimerTitle = 'bar';
+    component.analyticsStringDisclaimer = testOldProp;
+    component.disclaimerAnalyticsString = testNewProp;
+    fixture.detectChanges();
+    expect(
+      element.querySelector('button').getAttribute('data-analytics'),
+    ).toEqual(testNewProp);
+  });
 
   it('should respond to updates to additionalClassesImgOne', () => {
     let testString = 'testClass';

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.spec.ts
@@ -157,33 +157,33 @@ describe('SprkAwardComponent', () => {
     let testString = 'initTitle';
     component.title = testString;
     fixture.detectChanges();
-    expect(element.querySelector('h2').textContent).toEqual(testString);
+    expect(element.querySelector('h2').textContent.trim()).toEqual(testString);
 
     testString = 'updatedTitle';
 
     component.title = testString;
     fixture.detectChanges();
-    expect(element.querySelector('h2').textContent).toEqual(testString);
+    expect(element.querySelector('h2').textContent.trim()).toEqual(testString);
   });
 
   it('should respond to updates to heading', () => {
     let testString = 'initHeading';
     component.heading = testString;
     fixture.detectChanges();
-    expect(element.querySelector('h2').textContent).toEqual(testString);
+    expect(element.querySelector('h2').textContent.trim()).toEqual(testString);
 
     testString = 'updatedHeading';
 
     component.heading = testString;
     fixture.detectChanges();
-    expect(element.querySelector('h2').textContent).toEqual(testString);
+    expect(element.querySelector('h2').textContent.trim()).toEqual(testString);
   });
 
   it('should prefer heading over title', () => {
     component.title = 'title2';
     component.heading = 'heading2';
     fixture.detectChanges();
-    expect(element.querySelector('h2').textContent).toEqual('heading2');
+    expect(element.querySelector('h2').textContent.trim()).toEqual('heading2');
   });
 
   it('should respond to updates to analyticsStringImgOne', () => {

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -22,9 +22,7 @@ import { Component, Input } from '@angular/core';
       </h2>
 
       <div sprkStackItem [ngClass]="getClasses()">
-        <div
-          [ngClass]="getImgContainerClasses()"
-        >
+        <div [ngClass]="getImgContainerClasses()">
           <a
             sprkLink
             variant="unstyled"
@@ -39,9 +37,7 @@ import { Component, Input } from '@angular/core';
             />
           </a>
         </div>
-        <div
-          [ngClass]="getImgContainerClasses()"
-        >
+        <div [ngClass]="getImgContainerClasses()">
           <a
             sprkLink
             variant="unstyled"
@@ -69,128 +65,145 @@ import { Component, Input } from '@angular/core';
         <p class="sprk-b-TypeBodyFour">{{ disclaimerCopy }}</p>
       </sprk-toggle>
     </sprk-stack>
-  `
+  `,
 })
 export class SprkAwardComponent {
   /**
-   * The relative size of the viewport that
-   * the Award component should switch
-   * from a stacked layout to a side by side
-   * layout. You will need to experiment
-   * with your content to see which value
-   * is the best fit. Can be `tiny`,
-   * `small`, `medium`, `large` or `huge`.
+   * The relative size of the viewport that the Award component should switch
+   * from a stacked layout to a side by side layout. You will need to
+   * experiment with your content to see which value is the best fit. Can
+   * be `tiny`, `small`, `medium`, `large` or `huge`.
    */
   @Input()
   splitAt: string;
   /**
-   * The `alt` text that will be applied
-   * to the first image.
+   * This is used as the amount of spacing between the elements in the Award.
+   * The value supplied can be `tiny`, `small`, `medium`, `large`, or `huge`.
+   */
+  @Input()
+  itemSpacing: string;
+  /**
+   * The `alt` text that will be applied to the first image.
    */
   @Input()
   imgOneAlt: string;
   /**
-   * The image `href` value that will be
-   * applied to the first image.
+   * The image `href` value that will be applied to the first image.
    */
   @Input()
   imgOneHref: string;
   /**
-   * The image `href` value that will be
-   * applied to the second image.
+   * The image `href` value that will be applied to the second image.
    */
   @Input()
   imgTwoHref: string;
   /**
-   * The `alt` text that will be applied
-   * 'to the second image.
+   * The `alt` text that will be applied 'to the second image.
    */
   @Input()
   imgTwoAlt: string;
   /**
-   * The image source that will be
-   * applied to the first image.
+   * The image source that will be applied to the first image.
    */
   @Input()
   imgOneSrc: string;
   /**
-   * The image source that will be
-   * applied to the second image.
+   * The image source that will be applied to the second image.
    */
   @Input()
   imgTwoSrc: string;
   /**
-   * The string that will be assigned to the
-   * `data-analytics` attribute of the first image.
+   * Deprecated - use ` imgOneAnalyticsString` instead. The string that
+   * will be assigned to the `data-analytics` attribute of the first image.
    */
   @Input()
   analyticsStringImgOne: string;
   /**
-   * The string that will be assigned to the
-   * `data-analytics` attribute of the second image.
+   * The string that will be assigned to the `data-analytics` attribute of
+   * the first image.
+   */
+  @Input()
+  imgOneAnalyticsString: string;
+  /**
+   * Deprecated - use ` imgTwoAnalyticsString` instead. The string that
+   * will be assigned to the `data-analytics` attribute of the second image.
    */
   @Input()
   analyticsStringImgTwo: string;
   /**
-   * The string that will be assigned to the
-   * `data-analytics` attribute of
-   * the clickable disclaimer.
+   * The string that will be assigned to the `data-analytics` attribute of
+   * the first image.
+   */
+  @Input()
+  imgTwoAnalyticsString: string;
+  /**
+   * Deprecated - use `disclaimerAnalyticsString` instead. The string that
+   * will be assigned to the `data-analytics` attribute of the clickable
+   * disclaimer.
    */
   @Input()
   analyticsStringDisclaimer: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
+   * The string that will be assigned to the `data-analytics` attribute of
+   * the clickable disclaimer.
+   */
+  @Input()
+  disclaimerAnalyticsString: string;
+  /**
+   * Expects a space separated string of classes to be added to the
    * component.
    */
   @Input()
   additionalClasses: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * first image.
+   * Deprecated - use `imgOneAdditionalClasses` instead. Expects a space
+   * separated string of classes to be added to the second image.
    */
   @Input()
   additionalClassesImgOne: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * second image.
+   * Deprecated - use `imgTwoAdditionalClasses` instead. Expects a space
+   * separated string of classes to be added to the second image.
    */
   @Input()
   additionalClassesImgTwo: string;
   /**
-   * The text that appears above the
-   * images and serves as the heading
+   * Expects a space separated string of classes to be added to the first
+   * image.
+   */
+  @Input()
+  imgOneAdditionalClasses: string;
+  /**
+   * Expects a space separated string of classes to be added to the
+   * second image.
+   */
+  @Input()
+  imgTwoAdditionalClasses: string;
+  /**
+   * The text that appears above the images and serves as the heading
    * for the Award.
    */
   @Input()
   title: string;
   /**
-   * The text that will be the clickable
-   * title of the disclaimer toggle.
+   * The text that will be the clickable title of the disclaimer toggle.
    */
   @Input()
   disclaimerTitle: string;
   /**
-   * The text that will be inside the
-   * disclaimer toggle.
+   * The text that will be inside the disclaimer toggle.
    */
   @Input()
   disclaimerCopy: string;
   /**
-   * If `false`, the disclaimer
-   * toggle will not be rendered.
+   * If `false`, the disclaimer toggle will not be rendered.
    */
   @Input()
   disclaimer: string;
   /**
-   * The value supplied will be assigned
-   * to the `data-id` attribute on the
-   * component. This is intended to be
-   * used as a selector for automated
-   * tools. This value should be unique
-   * per page.
+   * The value supplied will be assigned to the `data-id` attribute on the
+   * component. This is intended to be used as a selector for automated tools.
+   * This value should be unique per page.
    */
   @Input()
   idString: string;
@@ -200,7 +213,7 @@ export class SprkAwardComponent {
    */
   getClasses(): string {
     const classArray: string[] = [
-      'sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack__item sprk-o-Stack__item--center-column'
+      'sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack__item sprk-o-Stack__item--center-column',
     ];
 
     // Handle the choice of item split
@@ -232,9 +245,7 @@ export class SprkAwardComponent {
    * @ignore
    */
   getImgContainerClasses(): string {
-    const classArray: string[] = [
-      'sprk-o-Stack__item'
-    ];
+    const classArray: string[] = ['sprk-o-Stack__item'];
 
     // Handle the choice of item split
     // breakpoint by adding CSS class
@@ -265,11 +276,11 @@ export class SprkAwardComponent {
    */
   getClassesImgOne(): string {
     const classArray: string[] = [
-      'sprk-o-Stack__item sprk-o-Stack__item--center-column'
+      'sprk-o-Stack__item sprk-o-Stack__item--center-column',
     ];
 
     if (this.additionalClassesImgOne) {
-      this.additionalClassesImgOne.split(' ').forEach(className => {
+      this.additionalClassesImgOne.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }
@@ -281,11 +292,11 @@ export class SprkAwardComponent {
    */
   getClassesImgTwo(): string {
     const classArray: string[] = [
-      'sprk-o-Stack__item sprk-o-Stack__item--center-column'
+      'sprk-o-Stack__item sprk-o-Stack__item--center-column',
     ];
 
     if (this.additionalClassesImgTwo) {
-      this.additionalClassesImgTwo.split(' ').forEach(className => {
+      this.additionalClassesImgTwo.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -4,7 +4,7 @@ import { Component, Input } from '@angular/core';
   selector: 'sprk-award',
   template: `
     <sprk-stack
-      itemSpacing="medium"
+      itemSpacing="{{ itemSpacing }}"
       additionalClasses="{{ additionalClasses }}"
     >
       <h2
@@ -81,7 +81,7 @@ export class SprkAwardComponent {
    * The value supplied can be `tiny`, `small`, `medium`, `large`, or `huge`.
    */
   @Input()
-  itemSpacing: string;
+  itemSpacing: 'tiny' | 'small' | 'medium' | 'large' | 'huge' = 'medium';
   /**
    * The `alt` text that will be applied to the first image.
    */
@@ -180,11 +180,17 @@ export class SprkAwardComponent {
   @Input()
   imgTwoAdditionalClasses: string;
   /**
+   * Deprecated - use `heading` instead. The text that appears above the
+   * images and serves as the heading for the Award.
+   */
+  @Input()
+  title: string;
+  /**
    * The text that appears above the images and serves as the heading
    * for the Award.
    */
   @Input()
-  title: string;
+  heading: string;
   /**
    * The text that will be the clickable title of the disclaimer toggle.
    */

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -140,7 +140,7 @@ export class SprkAwardComponent {
   analyticsStringImgTwo: string;
   /**
    * The string that will be assigned to the `data-analytics` attribute of
-   * the first image.
+   * the second image.
    */
   @Input()
   imgTwoAnalyticsString: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -104,7 +104,7 @@ export class SprkAwardComponent {
   @Input()
   imgTwoHref: string;
   /**
-   * The `alt` text that will be applied 'to the second image.
+   * The `alt` text that will be applied to the second image.
    */
   @Input()
   imgTwoAlt: string;
@@ -167,7 +167,7 @@ export class SprkAwardComponent {
   // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use `imgOneAdditionalClasses` instead. Expects a space
-   * separated string of classes to be added to the second image.
+   * separated string of classes to be added to the first image.
    */
   @Input()
   additionalClassesImgOne: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -224,7 +224,7 @@ export class SprkAwardComponent {
    * This value should be unique per page.
    */
   @Input()
-  idString: string = null;
+  idString: string;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -6,10 +6,10 @@ import { Component, Input } from '@angular/core';
     <sprk-stack
       itemSpacing="{{ itemSpacing }}"
       additionalClasses="{{ additionalClasses }}"
+      idString="{{ idString }}"
     >
       <h2
         sprkStackItem
-        [attr.data-id]="idString"
         class="
           sprk-o-Stack__item
           sprk-b-TypeDisplayFive

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -18,7 +18,7 @@ import { Component, Input } from '@angular/core';
           sprk-o-Stack__item--center-column
         "
       >
-        {{ title }}
+        {{ heading || title }}
       </h2>
 
       <div sprkStackItem [ngClass]="getClasses()">

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -94,12 +94,12 @@ export class SprkAwardComponent {
   @Input()
   imgOneAlt: string;
   /**
-   * The image `href` value that will be applied to the first image.
+   * The `href` value that will be applied to the first image link.
    */
   @Input()
   imgOneHref: string;
   /**
-   * The image `href` value that will be applied to the second image.
+   * The `href` value that will be applied to the second image link.
    */
   @Input()
   imgTwoHref: string;
@@ -120,41 +120,46 @@ export class SprkAwardComponent {
   imgTwoSrc: string;
   // TODO - Remove as part of Issue 1279
   /**
-   * Deprecated - use ` imgOneAnalyticsString` instead. The string that
-   * will be assigned to the `data-analytics` attribute of the first image.
+   * Deprecated - use ` imgOneAnalyticsString` instead. The value supplied will
+   * be assigned to the `data-analytics` attribute on the first image link in
+   * the component. Intended for an outside library to capture data.
    */
   @Input()
   analyticsStringImgOne: string;
   /**
-   * The string that will be assigned to the `data-analytics` attribute of
-   * the first image.
+   * The value supplied will be assigned to the `data-analytics` attribute on
+   * the first image link in the component. Intended for an outside library to
+   * capture data.
    */
   @Input()
   imgOneAnalyticsString: string;
   // TODO - Remove as part of Issue 1279
   /**
-   * Deprecated - use ` imgTwoAnalyticsString` instead. The string that
-   * will be assigned to the `data-analytics` attribute of the second image.
+   * Deprecated - use ` imgTwoAnalyticsString` instead. The value supplied
+   * will be assigned to the `data-analytics` attribute on the second image
+   * link in the component. Intended for an outside library to capture data.
    */
   @Input()
   analyticsStringImgTwo: string;
   /**
-   * The string that will be assigned to the `data-analytics` attribute of
-   * the second image.
+   * The value supplied will be assigned to the `data-analytics` attribute
+   * on the second image link in the component. Intended for an outside
+   * library to capture data.
    */
   @Input()
   imgTwoAnalyticsString: string;
   // TODO - Remove as part of Issue 1279
   /**
-   * Deprecated - use `disclaimerAnalyticsString` instead. The string that
-   * will be assigned to the `data-analytics` attribute of the clickable
-   * disclaimer.
+   * Deprecated - use `disclaimerAnalyticsString` instead. The value supplied
+   * will be assigned to the `data-analytics` attribute on the toggle button
+   * in the component. Intended for an outside library to capture data.
    */
   @Input()
   analyticsStringDisclaimer: string;
   /**
-   * The string that will be assigned to the `data-analytics` attribute of
-   * the clickable disclaimer.
+   * The value supplied will be assigned to the `data-analytics` attribute on
+   * the  toggle button in the component. Intended for an outside library to
+   * capture data.
    */
   @Input()
   disclaimerAnalyticsString: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -75,7 +75,7 @@ export class SprkAwardComponent {
    * be `tiny`, `small`, `medium`, `large` or `huge`.
    */
   @Input()
-  splitAt: string;
+  splitAt: 'tiny' | 'small' | 'medium' | 'large' | 'huge';
   /**
    * This is used as the amount of spacing between the elements in the Award.
    * The value supplied can be `tiny`, `small`, `medium`, `large`, or `huge`.

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -55,7 +55,10 @@ import { Component, Input } from '@angular/core';
       </div>
 
       <sprk-toggle
-        *ngIf="disclaimer !== 'false'"
+        *ngIf="
+          disclaimer !== 'false' &&
+          (disclaimerTitle !== undefined || disclaimerCopy !== undefined)
+        "
         sprkStackItem
         additionalClasses="sprk-o-Stack__item--start-column"
         toggleType="base"

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -43,7 +43,7 @@ import { Component, Input } from '@angular/core';
             variant="unstyled"
             class="sprk-o-Stack"
             [attr.href]="imgTwoHref"
-            [analyticsString]="analyticsStringImgTwo"
+            [analyticsString]="imgTwoAnalyticsString || analyticsStringImgTwo"
           >
             <img
               [ngClass]="getClassesImgTwo()"
@@ -64,7 +64,9 @@ import { Component, Input } from '@angular/core';
         additionalClasses="sprk-o-Stack__item--start-column"
         toggleType="base"
         title="{{ disclaimerTitle }}"
-        analyticsString="{{ analyticsStringDisclaimer }}"
+        analyticsString="{{
+          disclaimerAnalyticsString || analyticsStringDisclaimer
+        }}"
       >
         <p class="sprk-b-TypeBodyFour">{{ disclaimerCopy }}</p>
       </sprk-toggle>

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -118,6 +118,7 @@ export class SprkAwardComponent {
    */
   @Input()
   imgTwoSrc: string;
+  // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use ` imgOneAnalyticsString` instead. The string that
    * will be assigned to the `data-analytics` attribute of the first image.
@@ -130,6 +131,7 @@ export class SprkAwardComponent {
    */
   @Input()
   imgOneAnalyticsString: string;
+  // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use ` imgTwoAnalyticsString` instead. The string that
    * will be assigned to the `data-analytics` attribute of the second image.
@@ -142,6 +144,7 @@ export class SprkAwardComponent {
    */
   @Input()
   imgTwoAnalyticsString: string;
+  // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use `disclaimerAnalyticsString` instead. The string that
    * will be assigned to the `data-analytics` attribute of the clickable
@@ -161,12 +164,14 @@ export class SprkAwardComponent {
    */
   @Input()
   additionalClasses: string;
+  // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use `imgOneAdditionalClasses` instead. Expects a space
    * separated string of classes to be added to the second image.
    */
   @Input()
   additionalClassesImgOne: string;
+  // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use `imgTwoAdditionalClasses` instead. Expects a space
    * separated string of classes to be added to the second image.
@@ -185,6 +190,7 @@ export class SprkAwardComponent {
    */
   @Input()
   imgTwoAdditionalClasses: string;
+  // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use `heading` instead. The text that appears above the
    * images and serves as the heading for the Award.

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -57,7 +57,7 @@ import { Component, Input } from '@angular/core';
       <sprk-toggle
         *ngIf="
           disclaimer !== 'false' &&
-          (disclaimerTitle !== undefined || disclaimerCopy !== undefined)
+          disclaimerTitle !== undefined && disclaimerCopy !== undefined
         "
         sprkStackItem
         additionalClasses="sprk-o-Stack__item--start-column"

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -28,7 +28,6 @@ import { Component, Input } from '@angular/core';
             variant="unstyled"
             class="sprk-o-Stack"
             [attr.href]="imgOneHref"
-            [attr.routerLink]="imgOneRouterLink"
             [analyticsString]="imgOneAnalyticsString || analyticsStringImgOne"
           >
             <img
@@ -44,7 +43,6 @@ import { Component, Input } from '@angular/core';
             variant="unstyled"
             class="sprk-o-Stack"
             [attr.href]="imgTwoHref"
-            [attr.routerLink]="imgTwoRouterLink"
             [analyticsString]="imgTwoAnalyticsString || analyticsStringImgTwo"
           >
             <img
@@ -192,16 +190,6 @@ export class SprkAwardComponent {
    */
   @Input()
   imgTwoAdditionalClasses: string;
-  /**
-   * The routerLink attribute to use for the first image.
-   */
-  @Input()
-  imgOneRouterLink: string;
-  /**
-   * The routerLink attribute to use for the second image.
-   */
-  @Input()
-  imgTwoRouterLink: string;
   // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use `heading` instead. The text that appears above the

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -6,7 +6,7 @@ import { Component, Input } from '@angular/core';
     <sprk-stack
       itemSpacing="{{ itemSpacing }}"
       additionalClasses="{{ additionalClasses }}"
-      idString="{{ idString }}"
+      [idString]="idString"
     >
       <h2
         sprkStackItem
@@ -218,7 +218,7 @@ export class SprkAwardComponent {
    * This value should be unique per page.
    */
   @Input()
-  idString: string;
+  idString: string = null;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -28,6 +28,7 @@ import { Component, Input } from '@angular/core';
             variant="unstyled"
             class="sprk-o-Stack"
             [attr.href]="imgOneHref"
+            [attr.routerLink]="imgOneRouterLink"
             [analyticsString]="imgOneAnalyticsString || analyticsStringImgOne"
           >
             <img
@@ -43,6 +44,7 @@ import { Component, Input } from '@angular/core';
             variant="unstyled"
             class="sprk-o-Stack"
             [attr.href]="imgTwoHref"
+            [attr.routerLink]="imgTwoRouterLink"
             [analyticsString]="imgTwoAnalyticsString || analyticsStringImgTwo"
           >
             <img
@@ -190,6 +192,16 @@ export class SprkAwardComponent {
    */
   @Input()
   imgTwoAdditionalClasses: string;
+  /**
+   * The routerLink attribute to use for the first image.
+   */
+  @Input()
+  imgOneRouterLink: string;
+  /**
+   * The routerLink attribute to use for the second image.
+   */
+  @Input()
+  imgTwoRouterLink: string;
   // TODO - Remove as part of Issue 1279
   /**
    * Deprecated - use `heading` instead. The text that appears above the

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -28,7 +28,7 @@ import { Component, Input } from '@angular/core';
             variant="unstyled"
             class="sprk-o-Stack"
             [attr.href]="imgOneHref"
-            [analyticsString]="analyticsStringImgOne"
+            [analyticsString]="imgOneAnalyticsString || analyticsStringImgOne"
           >
             <img
               [ngClass]="getClassesImgOne()"
@@ -57,7 +57,8 @@ import { Component, Input } from '@angular/core';
       <sprk-toggle
         *ngIf="
           disclaimer !== 'false' &&
-          disclaimerTitle !== undefined && disclaimerCopy !== undefined
+          disclaimerTitle !== undefined &&
+          disclaimerCopy !== undefined
         "
         sprkStackItem
         additionalClasses="sprk-o-Stack__item--start-column"
@@ -288,7 +289,11 @@ export class SprkAwardComponent {
       'sprk-o-Stack__item sprk-o-Stack__item--center-column',
     ];
 
-    if (this.additionalClassesImgOne) {
+    if (this.imgOneAdditionalClasses) {
+      this.imgOneAdditionalClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    } else if (this.additionalClassesImgOne) {
       this.additionalClassesImgOne.split(' ').forEach((className) => {
         classArray.push(className);
       });
@@ -304,7 +309,11 @@ export class SprkAwardComponent {
       'sprk-o-Stack__item sprk-o-Stack__item--center-column',
     ];
 
-    if (this.additionalClassesImgTwo) {
+    if (this.imgTwoAdditionalClasses) {
+      this.imgTwoAdditionalClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    } else if (this.additionalClassesImgTwo) {
       this.additionalClassesImgTwo.split(' ').forEach((className) => {
         classArray.push(className);
       });

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.stories.ts
@@ -9,10 +9,9 @@ export default {
   component: SprkAwardComponent,
   decorators: [
     storyWrapper(
-      storyContent => (
-        `<div class="sprk-o-Box sprk-o-CenteredColumn">${ storyContent }<div>`
-      )
-    )
+      (storyContent) =>
+        `<div class="sprk-o-Box sprk-o-CenteredColumn">${storyContent}<div>`,
+    ),
   ],
   parameters: {
     info: `${markdownDocumentationLinkBuilder('award')}`,
@@ -21,10 +20,7 @@ export default {
 };
 
 const modules = {
-  imports: [
-    SprkAwardModule,
-    BrowserAnimationsModule,
-  ],
+  imports: [SprkAwardModule, BrowserAnimationsModule],
 };
 
 export const defaultStory = () => ({
@@ -39,8 +35,15 @@ export const defaultStory = () => ({
       imgOneHref="#nogo"
       imgTwoHref="#nogo"
       imgTwoAlt="placeholder!"
-      disclaimerCopy="This is some copy for the disclaimer about disclaimer things."
-      disclaimerTitle="My disclaimer title"
+      disclaimerCopy="This is an example of disclaimer content.
+        The aria-expanded='true' attribute will be
+        viewable in the DOM on the toggle link when
+        this content is shown. When this content is
+        hidden the aria-expanded attribute will have
+        the value of false. This helps accessibilty
+        devices in understanding that the link is a
+        control for expandable content."
+      disclaimerTitle="My Disclaimer"
       analyticsStringImgOne="Foo"
       analyticsStringImgTwo="Test"
       idString="award-1"

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.stories.ts
@@ -44,8 +44,8 @@ export const defaultStory = () => ({
         devices in understanding that the link is a
         control for expandable content."
       disclaimerTitle="My Disclaimer"
-      imgOneAnalyticsString="Foo"
-      imgTwoAnalyticsString="Test"
+      imgOneAnalyticsString="image-one-data-analytics"
+      imgTwoAnalyticsString="image-two-data-analytics"
     >
     </sprk-award>
   `,

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.stories.ts
@@ -28,7 +28,7 @@ export const defaultStory = () => ({
   template: `
     <sprk-award
       splitAt="tiny"
-      title="Award Component Heading"
+      heading="Award Component Heading"
       imgOneSrc="https://spark-assets.netlify.app/spark-logo-updated.svg"
       imgTwoSrc="https://spark-assets.netlify.app/spark-logo-updated.svg"
       imgOneAlt="placeholder!"
@@ -44,9 +44,8 @@ export const defaultStory = () => ({
         devices in understanding that the link is a
         control for expandable content."
       disclaimerTitle="My Disclaimer"
-      analyticsStringImgOne="Foo"
-      analyticsStringImgTwo="Test"
-      idString="award-1"
+      imgOneAnalyticsString="Foo"
+      imgTwoAnalyticsString="Test"
     >
     </sprk-award>
   `,

--- a/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.component.spec.ts
@@ -8,7 +8,7 @@ describe('SprkStackComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SprkStackComponent]
+      declarations: [SprkStackComponent],
     }).compileComponents();
   }));
 
@@ -91,15 +91,25 @@ describe('SprkStackComponent', () => {
     component.additionalClasses = 'sprk-u-pam sprk-u-man';
     fixture.detectChanges();
     expect(component.getClasses()).toEqual(
-      'sprk-o-Stack sprk-u-pam sprk-u-man'
+      'sprk-o-Stack sprk-u-pam sprk-u-man',
     );
   });
 
-  it('should set the data-analytics attribute' +
-    ' given a value in the analyticsString Input', () => {
-    component.analyticsString = 'Stack 1';
+  it(
+    'should set the data-analytics attribute' +
+      ' given a value in the analyticsString Input',
+    () => {
+      component.analyticsString = 'Stack 1';
+      fixture.detectChanges();
+      expect(element.hasAttribute('data-analytics')).toEqual(true);
+      expect(element.getAttribute('data-analytics')).toEqual('Stack 1');
+    },
+  );
+
+  it('should correctly apply data-id', () => {
+    component.idString = 'Stack 1';
     fixture.detectChanges();
-    expect(element.hasAttribute('data-analytics')).toEqual(true);
-    expect(element.getAttribute('data-analytics')).toEqual('Stack 1');
+    expect(element.hasAttribute('data-id')).toEqual(true);
+    expect(element.getAttribute('data-id')).toEqual('Stack 1');
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.component.ts
@@ -3,10 +3,14 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'sprk-stack',
   template: `
-    <div [ngClass]="getClasses()" [attr.data-analytics]="analyticsString">
+    <div
+      [ngClass]="getClasses()"
+      [attr.data-id]="idString"
+      [attr.data-analytics]="analyticsString"
+    >
       <ng-content></ng-content>
     </div>
-  `
+  `,
 })
 export class SprkStackComponent {
   /**
@@ -23,6 +27,13 @@ export class SprkStackComponent {
    */
   @Input()
   itemSpacing: string;
+  /**
+   * The value supplied will be assigned to the `data-id` attribute on the
+   * component. This is intended to be used as a selector for automated tools.
+   * This value should be unique per page.
+   */
+  @Input()
+  idString: string;
   /**
    * The value supplied will be assigned to the `data-analytics` attribute on
    * the component. Intended for an outside library to capture data.
@@ -84,7 +95,7 @@ export class SprkStackComponent {
     }
 
     if (this.additionalClasses) {
-      this.additionalClasses.split(' ').forEach(className => {
+      this.additionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -87,7 +87,7 @@ describe('SprkToggle:', () => {
     expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
   });
 
-  it(`should add aria-controls="custom_control" and id="custom_control" 
+  it(`should add aria-controls="custom_control" and id="custom_control"
     when the contentId is passed`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" contentId="custom_control">
@@ -113,7 +113,7 @@ describe('SprkToggle:', () => {
     expect(wrapper.find(`div#${toggleContentId}`).length).toBe(1);
   });
 
-  it(`should add classes to the content if contentAdditionalClasses 
+  it(`should add classes to the content if contentAdditionalClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" contentAdditionalClasses="test">
@@ -124,7 +124,7 @@ describe('SprkToggle:', () => {
     expect(toggleContent.hasClass('test')).toBe(true);
   });
 
-  it(`should add classes to the icon if iconAdditionalClasses 
+  it(`should add classes to the icon if iconAdditionalClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" iconAdditionalClasses="test">
@@ -135,7 +135,7 @@ describe('SprkToggle:', () => {
     expect(toggleIcon.hasClass('test')).toBe(true);
   });
 
-  it(`should add classes to the icon if iconAddClasses 
+  it(`should add classes to the icon if iconAddClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" iconAddClasses="test">
@@ -162,7 +162,7 @@ describe('SprkToggle:', () => {
     expect(toggleIcon.hasClass('test')).toBe(false);
   });
 
-  it(`should add classes to the title if titleAdditionalClasses 
+  it(`should add classes to the title if titleAdditionalClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" titleAdditionalClasses="test">
@@ -173,7 +173,7 @@ describe('SprkToggle:', () => {
     expect(toggleTitle.hasClass('test')).toBe(true);
   });
 
-  it(`should add classes to the title if titleAddClasses 
+  it(`should add classes to the title if titleAddClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" titleAddClasses="test">
@@ -184,7 +184,7 @@ describe('SprkToggle:', () => {
     expect(toggleTitle.hasClass('test')).toBe(true);
   });
 
-  it(`should prefer titleAdditionalClasses to titleAddClasses if both 
+  it(`should prefer titleAdditionalClasses to titleAddClasses if both
   are set`, () => {
     const wrapper = mount(
       <SprkToggle
@@ -198,5 +198,23 @@ describe('SprkToggle:', () => {
     const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
     expect(toggleTitle.hasClass('newTest')).toBe(true);
     expect(toggleTitle.hasClass('test')).toBe(false);
+  });
+
+  it(`should add title (deprecated)`, () => {
+    const wrapper = mount(
+      <SprkToggle title="Toggle title">Body text</SprkToggle>,
+    );
+    const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
+    expect(toggleTitle.text()).toEqual('Toggle title');
+  });
+
+  it(`should prefer triggerText over title`, () => {
+    const wrapper = mount(
+      <SprkToggle triggerText="Toggle title" title="old title">
+        Body text
+      </SprkToggle>,
+    );
+    const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
+    expect(toggleTitle.text()).toEqual('Toggle title');
   });
 });


### PR DESCRIPTION
## What does this PR do?
- deprecate `title` and add `heading`
- deprecate `analyticsStringImgOne ` in favor of `imgOneAnalyticsString `
- deprecate `analyticsStringImgTwo ` in favor of `imgTwoAnalyticsString `
- deprecate `analyticsStringDisclaimer ` in favor of `disclaimerAnalyticsString `
- deprecate `additionalClassesImgOne ` in favor of `imgOneAdditionalClasses `
- deprecate `additionalClassesImgTwo ` in favor of `imgTwoAdditionalClasses `
- Add in string typings for the `splitAt` prop. (`tiny`,`small`, `medium`, `large` or `huge`.
- new Input `itemSpacing`
- move `data-id` from the `h2` inside the component to the outer container of component. This required adding a new `idString` Input to `sprk-stack`.

### Associated Issue
Fixes #3314 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)
