### PR TITLE
Add option "default" for Dropdown component choices [react]

### DIFF
--- a/react/src/components/dropdown/SprkDropdown.js
+++ b/react/src/components/dropdown/SprkDropdown.js
@@ -10,7 +10,7 @@ class SprkDropdown extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      triggerText: props.defaultTriggerText,
+      triggerText: this.getTriggerText(),
       isOpen: false,
       choiceItems: props.choices.items.map(item => ({
         id: uniqueId(),
@@ -36,6 +36,18 @@ class SprkDropdown extends Component {
     window.removeEventListener('keydown', this.closeOnEsc);
     window.removeEventListener('focusin', this.closeOnClickOutside);
     window.removeEventListener('click', this.closeOnClickOutside);
+  }
+
+  componentDidUpdate(prevProps, prevState, snapshot) {
+    if (this.props.choices !== prevProps.choices) {
+      const triggerText = this.getTriggerText();
+
+      if (this.state.triggerText !== triggerText) {
+        this.setState({
+          triggerText,
+        });
+      }
+    }
   }
 
   setSelectedChoice(componentToUpdateId) {
@@ -78,6 +90,18 @@ class SprkDropdown extends Component {
     this.setState({
       isOpen: false,
     });
+  }
+
+  getTriggerText() {
+    if (this.props.variant !== 'informational') {
+      return this.props.defaultTriggerText;
+    }
+
+    const defaultItem = this.props.choices?.items?.find((item) => item.default);
+
+    return defaultItem
+      ? defaultItem.text
+      : this.props.defaultTriggerText;
   }
 
   render() {
@@ -282,6 +306,11 @@ SprkDropdown.propTypes = {
         href: PropTypes.string,
         /** The text inside the choice item. */
         text: PropTypes.string,
+        /**
+         * If `default` is set to `true` and `dropdownType` is set to `informational`
+         * then `triggerText` will be automatically changed to this choice `value`
+         */
+        default: PropTypes.bool,
       }),
     ),
   }),

--- a/react/src/components/dropdown/SprkDropdown.test.js
+++ b/react/src/components/dropdown/SprkDropdown.test.js
@@ -336,4 +336,88 @@ describe('SprkDropdown:', () => {
         .getAttribute('aria-label'),
     ).toBe('My Choices');
   });
+
+  it('should not change trigger text if default choice option was not set', () => {
+    const wrapper = mount(
+      <SprkDropdown
+        defaultTriggerText={'Make a selection'}
+        choices={{
+          items: [
+            { text: 'Item 1', value: 'item-1' },
+            { text: 'Item 2', value: 'item-2' },
+          ],
+        }}
+      />,
+    );
+
+    expect(wrapper.state('triggerText')).toBe('Make a selection');
+  });
+
+  it('should not change trigger text if default choice option specified, but variant is not "informational"', () => {
+    const wrapper = mount(
+      <SprkDropdown
+        defaultTriggerText={'Make a selection'}
+        choices={{
+          items: [
+            { text: 'Item 1', value: 'item-1' },
+            { text: 'Item 2', value: 'item-2', default: true },
+          ],
+        }}
+      />,
+    );
+
+    expect(wrapper.state('triggerText')).toBe('Make a selection');
+  });
+
+  it('should change trigger text if default choice option specified and variant equals "informational"', () => {
+    const wrapper = mount(
+      <SprkDropdown
+        defaultTriggerText={'Make a selection'}
+        variant={'informational'}
+        choices={{
+          items: [
+            { text: 'Item 1', value: 'item-1' },
+            { text: 'Item 2', value: 'item-2', default: true },
+          ],
+        }}
+      />,
+    );
+
+    expect(wrapper.state('triggerText')).toBe('Item 2');
+  });
+
+  it('should change trigger text when choices change', () => {
+    const wrapper = mount(
+      <SprkDropdown
+        defaultTriggerText={'Make a selection'}
+        variant={'informational'}
+        choices={{
+          items: [
+            { text: 'Item 1', value: 'item-1' },
+            { text: 'Item 2', value: 'item-2', default: true },
+          ],
+        }}
+      />,
+    );
+
+    wrapper.setProps({
+      choices: {
+        items: [
+          { text: 'Item First', value: 'item-11', default: true },
+          { text: 'Item Second', value: 'item-22' },
+        ]
+      }
+    })
+    expect(wrapper.state('triggerText')).toBe('Item First');
+
+    wrapper.setProps({
+      choices: {
+        items: [
+          { text: 'Item 5', value: 'item-5'},
+          { text: 'Item 6', value: 'item-6' },
+        ]
+      }
+    })
+    expect(wrapper.state('triggerText')).toBe('Make a selection');
+  })
 });


### PR DESCRIPTION
## What does this PR do?
Add option "default" for dropDown choices items for React Dropdown component. 
According to #3530

### Associated Issue
Fixes #3530

## Please check off completed items as you work.
- Dropdown component

### Documentation
 - [ ] Update Spark Docs

### Code
 - [ ] Build Component in HTML
 - [ ] Build Component in Angular
 - [ ] Build Component in React
 - [ ] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [ ] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [ ] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [ ] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team
