### PR TITLE
Top Navigation uses same link style as side Navigation

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -18,7 +18,7 @@ const Header = ({ setContext }) => {
         setContext('installing-spark');
       }}
       additionalClasses="sprk-c-Masthead__link"
-      variant="plain"
+      variant="simple"
       element={Link}
       to="/installing-spark"
     >
@@ -29,7 +29,7 @@ const Header = ({ setContext }) => {
         setContext('using-spark');
       }}
       additionalClasses="sprk-c-Masthead__link"
-      variant="plain"
+      variant="simple"
       element={Link}
       to="/using-spark"
     >
@@ -40,7 +40,7 @@ const Header = ({ setContext }) => {
         setContext('principles');
       }}
       additionalClasses="sprk-c-Masthead__link"
-      variant="plain"
+      variant="simple"
       element={Link}
       to="/principles/design-principles"
     >


### PR DESCRIPTION
## What does this PR do?
Updated masthead links to use `variant="simple"` instead of `variant="plain"` on the `<SprkLink>`'s.

### Associated Issue
Fixes #3491 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Mozilla Firefox

### Screenshots
![Screen Shot 2020-10-07 at 10 40 16 AM](https://user-images.githubusercontent.com/181652/95346178-8d5a9e00-0889-11eb-83cf-a0e55a74fefd.png)
