### PR TITLE
Toggle Updates - React

### DIFF
--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -79,7 +79,7 @@ const SprkAward = (props) => {
       </SprkStack>
 
       <SprkToggle
-        title={disclaimerTitle}
+        triggerText={disclaimerTitle}
         analyticsString={disclaimerAnalytics}
         additionalClasses="sprk-o-Stack__item"
       >

--- a/react/src/components/footer/components/SprkFooterAwards/SprkFooterAwards.js
+++ b/react/src/components/footer/components/SprkFooterAwards/SprkFooterAwards.js
@@ -50,10 +50,10 @@ class SprkFooterAwards extends Component {
 
         <SprkToggle
           additionalClasses="sprk-o-Stack__item"
-          iconAddClasses="sprk-c-Footer__icon"
+          iconAdditionalClasses="sprk-c-Footer__icon"
           toggleIconName="chevron-down-circle"
-          title={awards.disclaimerTitle}
-          titleAddClasses="sprk-b-TypeBodyFour sprk-c-Footer__trigger"
+          triggerText={awards.disclaimerTitle}
+          titleAdditionalClasses="sprk-b-TypeBodyFour sprk-c-Footer__trigger"
           analyticsString={awards.disclaimerAnalytics}
         >
           <p className="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs sprk-c-Footer__text">

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -9,7 +9,7 @@ import 'focus-visible';
 class SprkToggle extends Component {
   constructor(props) {
     super(props);
-    // TODO: isDefaultOpen in issue #{issueNumber}
+    // TODO: isDefaultOpen in issue #1296
     const { isDefaultOpen } = this.props;
     let { isOpen } = this.props;
     if (isDefaultOpen !== undefined && isOpen === undefined) {
@@ -31,7 +31,7 @@ class SprkToggle extends Component {
     }));
   }
 
-  // TODO: Remove title, titleAddClasses, iconAddClasses in issue #{issueNumber}
+  // TODO: Remove title, titleAddClasses, iconAddClasses in issue #1296
   render() {
     const {
       children,
@@ -55,12 +55,12 @@ class SprkToggle extends Component {
 
     const containerClasses = classnames('sprk-c-Toggle', additionalClasses);
 
-    // TODO: Remove titleAddClasses in issue #{issueNumber}
+    // TODO: Remove titleAddClasses in issue #1296
     const titleClasses = classnames(
       'sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-u-TextCrop--none',
       titleAdditionalClasses || titleAddClasses,
     );
-    // TODO: Remove iconAddClasses in issue #{issueNumber}
+    // TODO: Remove iconAddClasses in issue #1296
     const iconClasses = classnames(
       'sprk-c-Icon--xl sprk-c-Icon--toggle sprk-u-mrs',
       { 'sprk-c-Icon--open': isOpen },
@@ -83,7 +83,7 @@ class SprkToggle extends Component {
           type="button"
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
-          {/* TODO: Remove title in issue #issueNumber */}
+          {/* TODO: Remove title in issue #1296 */}
           {titleText || title}
         </button>
         <AnimateHeight
@@ -112,7 +112,7 @@ SprkToggle.propTypes = {
    * Deprecated - use titleText instead.
    * The title text for the toggle.
    */
-  // TODO: Remove title is issue #issueNumber
+  // TODO: Remove title is issue #1296
   title: PropTypes.string,
   /**
    * The title text for the toggle.
@@ -134,7 +134,7 @@ SprkToggle.propTypes = {
    * Deprecated - Use `isOpen` instead.
    * Determines if the toggle is open upon loading on the page.
    */
-  // TODO: isDefaultOpen in issue #{issueNumber}
+  // TODO: isDefaultOpen in issue #1296
   isDefaultOpen: PropTypes.bool,
   /** Determines if the toggle is open upon loading on the page. */
   isOpen: PropTypes.bool,
@@ -145,13 +145,13 @@ SprkToggle.propTypes = {
   additionalClasses: PropTypes.string,
   /** Deprecated - Use `titleAdditionalClasses` instead.
    * Additional classes for the title text. */
-  // TODO: Remove titleAddClasses is issue #issueNumber
+  // TODO: Remove titleAddClasses is issue #1296
   titleAddClasses: PropTypes.string,
   /** Additional classes for the title text. */
   titleAdditionalClasses: PropTypes.string,
   /** Deprecated - Use `iconAdditionalClasses` instead.
    * Additional classes for the toggle icon. */
-  // TODO: Remove iconAddClasses is issue #issueNumber
+  // TODO: Remove iconAddClasses is issue #1296
   iconAddClasses: PropTypes.string,
   /** Additional classes for the toggle icon. */
   iconAdditionalClasses: PropTypes.string,
@@ -162,6 +162,8 @@ SprkToggle.propTypes = {
    * and the `aria-controls` for the toggle trigger button.
    */
   contentId: PropTypes.string,
+  /** The event that will fire when the toggle trigger is clicked. */
+  onClick: PropTypes.func,
 };
 
 export default SprkToggle;

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -39,7 +39,7 @@ class SprkToggle extends Component {
       additionalClasses,
       analyticsString,
       title,
-      titleText,
+      triggerText,
       titleAddClasses,
       titleAdditionalClasses,
       iconAddClasses,
@@ -89,7 +89,7 @@ class SprkToggle extends Component {
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
           {/* TODO: Remove title in issue #1296 */}
-          {titleText || title}
+          {triggerText || title}
         </button>
         <AnimateHeight
           duration={300}
@@ -114,7 +114,7 @@ SprkToggle.propTypes = {
    */
   toggleIconName: PropTypes.string,
   /**
-   * Deprecated - use `titleText` instead.
+   * Deprecated - use `triggerText` instead.
    * The title text for the toggle.
    */
   // TODO: Remove title in issue #1296
@@ -122,7 +122,7 @@ SprkToggle.propTypes = {
   /**
    * The title text for the toggle.
    */
-  titleText: PropTypes.string.isRequired,
+  triggerText: PropTypes.string.isRequired,
   /** The content that will show up when the toggle opens. */
   children: PropTypes.node.isRequired,
   /**

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -98,17 +98,20 @@ SprkToggle.propTypes = {
   /** The content that will show up when the toggle opens. */
   children: PropTypes.node.isRequired,
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as
+   * a unique selector for automated tools.
    */
   idString: PropTypes.string,
   /**
-   * Assigned to the `data-analytics` attribute serving as a unique selector for outside libraries to capture data.
-  */
+   * Assigned to the `data-analytics` attribute serving as
+   * a unique selector for outside libraries to capture data.
+   */
   analyticsString: PropTypes.string,
   /** Determines if the toggle is open upon loading on the page. */
   isDefaultOpen: PropTypes.bool,
-   /**
-   * A space-separated string of classes to add to the outermost container of the component.
+  /**
+   * A space-separated string of classes to add to the
+   * outermost container of the component.
    */
   additionalClasses: PropTypes.string,
   /** Additional classes for the title text. */

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -33,6 +33,7 @@ class SprkToggle extends Component {
       additionalClasses,
       analyticsString,
       title,
+      titleText,
       titleAddClasses,
       titleAdditionalClasses,
       iconAddClasses,
@@ -75,7 +76,7 @@ class SprkToggle extends Component {
           type="button"
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
-          {title}
+          {titleText || title}
         </button>
         <AnimateHeight
           duration={300}
@@ -100,9 +101,15 @@ SprkToggle.propTypes = {
    */
   toggleIconName: PropTypes.string,
   /**
+   * Deprecated - use titleText instead.
    * The title text for the toggle.
    */
-  title: PropTypes.string.isRequired,
+  title: PropTypes.string,
+  /**
+   * Deprecated - use titleText instead.
+   * The title text for the toggle.
+   */
+  titleText: PropTypes.string.isRequired,
   /** The content that will show up when the toggle opens. */
   children: PropTypes.node.isRequired,
   /**

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -135,7 +135,7 @@ SprkToggle.propTypes = {
    */
   // TODO: isDefaultOpen in issue #1296
   isDefaultOpen: PropTypes.bool,
-  /** Determines if the toggle is open upon loading on the page. */
+  /** Determines if the toggle is open or closed. */
   isOpen: PropTypes.bool,
   /**
    * A space-separated string of classes to add to the

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -26,6 +26,7 @@ class SprkToggle extends Component {
     }));
   }
 
+  // TODO: Remove title, titleAddClasses, iconAddClasses in issue #{issueNumber}
   render() {
     const {
       children,
@@ -49,15 +50,16 @@ class SprkToggle extends Component {
 
     const containerClasses = classnames('sprk-c-Toggle', additionalClasses);
 
+    // TODO: Remove titleAddClasses in issue #{issueNumber}
     const titleClasses = classnames(
       'sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-u-TextCrop--none',
-      titleAddClasses,
+      titleAdditionalClasses || titleAddClasses,
     );
-
+    // TODO: Remove iconAddClasses in issue #{issueNumber}
     const iconClasses = classnames(
       'sprk-c-Icon--xl sprk-c-Icon--toggle sprk-u-mrs',
       { 'sprk-c-Icon--open': isOpen },
-      iconAddClasses,
+      iconAdditionalClasses || iconAddClasses,
     );
 
     const contentClasses = classnames(
@@ -76,6 +78,7 @@ class SprkToggle extends Component {
           type="button"
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
+          {/* TODO: Remove title in issue #issueNumber */}
           {titleText || title}
         </button>
         <AnimateHeight
@@ -104,6 +107,7 @@ SprkToggle.propTypes = {
    * Deprecated - use titleText instead.
    * The title text for the toggle.
    */
+  // TODO: Remove title is issue #issueNumber
   title: PropTypes.string,
   /**
    * Deprecated - use titleText instead.
@@ -131,11 +135,13 @@ SprkToggle.propTypes = {
   additionalClasses: PropTypes.string,
   /** Deprecated - Use `titleAdditionalClasses` instead.
    * Additional classes for the title text. */
+  // TODO: Remove titleAddClasses is issue #issueNumber
   titleAddClasses: PropTypes.string,
   /** Additional classes for the title text. */
   titleAdditionalClasses: PropTypes.string,
   /** Deprecated - Use `iconAdditionalClasses` instead.
    * Additional classes for the toggle icon. */
+  // TODO: Remove iconAddClasses is issue #issueNumber
   iconAddClasses: PropTypes.string,
   /** Additional classes for the toggle icon. */
   iconAdditionalClasses: PropTypes.string,

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -110,7 +110,6 @@ SprkToggle.propTypes = {
   // TODO: Remove title is issue #issueNumber
   title: PropTypes.string,
   /**
-   * Deprecated - use titleText instead.
    * The title text for the toggle.
    */
   titleText: PropTypes.string.isRequired,

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -9,10 +9,15 @@ import 'focus-visible';
 class SprkToggle extends Component {
   constructor(props) {
     super(props);
+    // TODO: isDefaultOpen in issue #{issueNumber}
     const { isDefaultOpen } = this.props;
+    let { isOpen } = this.props;
+    if (isDefaultOpen !== undefined && isOpen === undefined) {
+      isOpen = isDefaultOpen;
+    }
     this.state = {
-      isOpen: isDefaultOpen || false,
-      height: isDefaultOpen ? 'auto' : 0,
+      isOpen: isOpen || false,
+      height: isOpen ? 'auto' : 0,
     };
 
     this.toggleOpen = this.toggleOpen.bind(this);
@@ -125,8 +130,14 @@ SprkToggle.propTypes = {
    * a unique selector for outside libraries to capture data.
    */
   analyticsString: PropTypes.string,
-  /** Determines if the toggle is open upon loading on the page. */
+  /**
+   * Deprecated - Use `isOpen` instead.
+   * Determines if the toggle is open upon loading on the page.
+   */
+  // TODO: isDefaultOpen in issue #{issueNumber}
   isDefaultOpen: PropTypes.bool,
+  /** Determines if the toggle is open upon loading on the page. */
+  isOpen: PropTypes.bool,
   /**
    * A space-separated string of classes to add to the
    * outermost container of the component.

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -143,18 +143,18 @@ SprkToggle.propTypes = {
    */
   additionalClasses: PropTypes.string,
   /** Deprecated - Use `titleAdditionalClasses` instead.
-   * Additional classes for the title text. */
+   * A space-separated string of classes to add to the title text. */
   // TODO: Remove titleAddClasses in issue #1296
   titleAddClasses: PropTypes.string,
-  /** Additional classes for the title text. */
+  /** A space-separated string of classes to add to the title text. */
   titleAdditionalClasses: PropTypes.string,
   /** Deprecated - Use `iconAdditionalClasses` instead.
-   * Additional classes for the toggle icon. */
+   * A space-separated string of classes to add to the toggle icon. */
   // TODO: Remove iconAddClasses in issue #1296
   iconAddClasses: PropTypes.string,
-  /** Additional classes for the toggle icon. */
+  /** A space-separated string of classes to add to the toggle icon. */
   iconAdditionalClasses: PropTypes.string,
-  /** Additional classes for the content. */
+  /** A space-separated string of classes to add to the content. */
   contentAdditionalClasses: PropTypes.string,
   /**
    * A string that is used to set the `id` on the content

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -114,7 +114,7 @@ SprkToggle.propTypes = {
    */
   toggleIconName: PropTypes.string,
   /**
-   * Deprecated - use titleText instead.
+   * Deprecated - use `titleText` instead.
    * The title text for the toggle.
    */
   // TODO: Remove title is issue #1296

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -34,9 +34,12 @@ class SprkToggle extends Component {
       analyticsString,
       title,
       titleAddClasses,
+      titleAdditionalClasses,
       iconAddClasses,
+      iconAdditionalClasses,
       toggleIconName,
       contentId,
+      contentAdditionalClasses,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
@@ -56,6 +59,11 @@ class SprkToggle extends Component {
       iconAddClasses,
     );
 
+    const contentClasses = classnames(
+      'sprk-c-Toggle__content',
+      contentAdditionalClasses,
+    );
+
     return (
       <div data-id={idString} {...other} className={containerClasses}>
         <button
@@ -72,7 +80,7 @@ class SprkToggle extends Component {
         <AnimateHeight
           duration={300}
           height={height}
-          className="sprk-c-Toggle__content"
+          className={contentClasses}
           id={uniqueIdentifier}
         >
           <div>{children}</div>
@@ -114,10 +122,18 @@ SprkToggle.propTypes = {
    * outermost container of the component.
    */
   additionalClasses: PropTypes.string,
-  /** Additional classes for the title text. */
+  /** Deprecated - Use `titleAdditionalClasses` instead.
+   * Additional classes for the title text. */
   titleAddClasses: PropTypes.string,
-  /** Additional classes for the toggle icon. */
+  /** Additional classes for the title text. */
+  titleAdditionalClasses: PropTypes.string,
+  /** Deprecated - Use `iconAdditionalClasses` instead.
+   * Additional classes for the toggle icon. */
   iconAddClasses: PropTypes.string,
+  /** Additional classes for the toggle icon. */
+  iconAdditionalClasses: PropTypes.string,
+  /** Additional classes for the content. */
+  contentAdditionalClasses: PropTypes.string,
   /**
    * A string that is used to set the `id` on the content
    * and the `aria-controls` for the toggle trigger button.

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -9,7 +9,7 @@ import 'focus-visible';
 class SprkToggle extends Component {
   constructor(props) {
     super(props);
-    // TODO: isDefaultOpen in issue #1296
+    // TODO: Remove isDefaultOpen in issue #1296
     const { isDefaultOpen } = this.props;
     let { isOpen } = this.props;
     if (isDefaultOpen !== undefined && isOpen === undefined) {
@@ -117,7 +117,7 @@ SprkToggle.propTypes = {
    * Deprecated - use `titleText` instead.
    * The title text for the toggle.
    */
-  // TODO: Remove title is issue #1296
+  // TODO: Remove title in issue #1296
   title: PropTypes.string,
   /**
    * The title text for the toggle.
@@ -150,13 +150,13 @@ SprkToggle.propTypes = {
   additionalClasses: PropTypes.string,
   /** Deprecated - Use `titleAdditionalClasses` instead.
    * Additional classes for the title text. */
-  // TODO: Remove titleAddClasses is issue #1296
+  // TODO: Remove titleAddClasses in issue #1296
   titleAddClasses: PropTypes.string,
   /** Additional classes for the title text. */
   titleAdditionalClasses: PropTypes.string,
   /** Deprecated - Use `iconAdditionalClasses` instead.
    * Additional classes for the toggle icon. */
-  // TODO: Remove iconAddClasses is issue #1296
+  // TODO: Remove iconAddClasses in issue #1296
   iconAddClasses: PropTypes.string,
   /** Additional classes for the toggle icon. */
   iconAdditionalClasses: PropTypes.string,

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -10,11 +10,8 @@ class SprkToggle extends Component {
   constructor(props) {
     super(props);
     // TODO: Remove isDefaultOpen in issue #1296
-    const { isDefaultOpen } = this.props;
-    let { isOpen } = this.props;
-    if (isDefaultOpen !== undefined && isOpen === undefined) {
-      isOpen = isDefaultOpen;
-    }
+    const { isDefaultOpen, isOpen = isDefaultOpen } = this.props;
+
     this.state = {
       isOpen: isOpen || false,
       height: isOpen ? 'auto' : 0,
@@ -39,11 +36,11 @@ class SprkToggle extends Component {
       additionalClasses,
       analyticsString,
       title,
-      triggerText,
+      triggerText = title,
       titleAddClasses,
-      titleAdditionalClasses,
+      titleAdditionalClasses = titleAddClasses,
       iconAddClasses,
-      iconAdditionalClasses,
+      iconAdditionalClasses = iconAddClasses,
       toggleIconName,
       contentId,
       contentAdditionalClasses,
@@ -56,16 +53,14 @@ class SprkToggle extends Component {
 
     const containerClasses = classnames('sprk-c-Toggle', additionalClasses);
 
-    // TODO: Remove titleAddClasses in issue #1296
     const titleClasses = classnames(
       'sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-u-TextCrop--none',
-      titleAdditionalClasses || titleAddClasses,
+      titleAdditionalClasses,
     );
-    // TODO: Remove iconAddClasses in issue #1296
     const iconClasses = classnames(
       'sprk-c-Icon--xl sprk-c-Icon--toggle sprk-u-mrs',
       { 'sprk-c-Icon--open': isOpen },
-      iconAdditionalClasses || iconAddClasses,
+      iconAdditionalClasses,
     );
 
     const contentClasses = classnames(
@@ -88,8 +83,7 @@ class SprkToggle extends Component {
           type="button"
         >
           <SprkIcon iconName={toggleIconName} additionalClasses={iconClasses} />
-          {/* TODO: Remove title in issue #1296 */}
-          {triggerText || title}
+          {triggerText}
         </button>
         <AnimateHeight
           duration={300}

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -47,6 +47,7 @@ class SprkToggle extends Component {
       toggleIconName,
       contentId,
       contentAdditionalClasses,
+      onClick,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
@@ -71,13 +72,17 @@ class SprkToggle extends Component {
       'sprk-c-Toggle__content',
       contentAdditionalClasses,
     );
-
     return (
       <div data-id={idString} {...other} className={containerClasses}>
         <button
           className={titleClasses}
           data-analytics={analyticsString}
-          onClick={this.toggleOpen}
+          onClick={(e) => {
+            if (onClick) {
+              onClick();
+            }
+            this.toggleOpen(e);
+          }}
           aria-expanded={isOpen ? 'true' : 'false'}
           aria-controls={uniqueIdentifier}
           type="button"

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -79,7 +79,7 @@ class SprkToggle extends Component {
           data-analytics={analyticsString}
           onClick={(e) => {
             if (onClick) {
-              onClick();
+              onClick(e);
             }
             this.toggleOpen(e);
           }}

--- a/react/src/components/toggle/SprkToggle.stories.js
+++ b/react/src/components/toggle/SprkToggle.stories.js
@@ -5,9 +5,7 @@ import { markdownDocumentationLinkBuilder } from '../../../../storybook-utilitie
 export default {
   title: 'Components/Toggle',
   component: SprkToggle,
-  decorators: [
-    story => <div className="sprk-o-Box">{story()}</div>
-  ],
+  decorators: [(story) => <div className="sprk-o-Box">{story()}</div>],
   parameters: {
     jest: ['SprkToggle'],
     info: `${markdownDocumentationLinkBuilder('toggle')}`,
@@ -17,16 +15,14 @@ export default {
 export const defaultStory = () => (
   <SprkToggle title="My Disclaimer" analyticsString="toggle-1">
     <p className="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
-      This is an example of disclaimer content.
-      The aria-expanded=&quot;true&quot; attribute will be viewable
-      in the DOM on the toggle link when
-      this content is shown. When this content is hidden the
-      aria-expanded attribute will have
-      the value of false. This helps accessibility devices in
-      understanding that the link is a control for expandable content.
+      This is an example of disclaimer content. The
+      aria-expanded=&quot;true&quot; attribute will be viewable in the DOM on
+      the toggle link when this content is shown. When this content is hidden
+      the aria-expanded attribute will have the value of false. This helps
+      accessibility devices in understanding that the link is a control for
+      expandable content.
     </p>
   </SprkToggle>
-
 );
 
 defaultStory.story = {

--- a/react/src/components/toggle/SprkToggle.stories.js
+++ b/react/src/components/toggle/SprkToggle.stories.js
@@ -13,7 +13,7 @@ export default {
 };
 
 export const defaultStory = () => (
-  <SprkToggle title="My Disclaimer" analyticsString="toggle-1">
+  <SprkToggle titleText="My Disclaimer" analyticsString="toggle-1">
     <p className="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
       This is an example of disclaimer content. The
       aria-expanded=&quot;true&quot; attribute will be viewable in the DOM on

--- a/react/src/components/toggle/SprkToggle.stories.js
+++ b/react/src/components/toggle/SprkToggle.stories.js
@@ -13,7 +13,7 @@ export default {
 };
 
 export const defaultStory = () => (
-  <SprkToggle titleText="My Disclaimer" analyticsString="toggle-1">
+  <SprkToggle triggerText="My Disclaimer" analyticsString="toggle-1">
     <p className="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
       This is an example of disclaimer content. The
       aria-expanded=&quot;true&quot; attribute will be viewable in the DOM on

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -9,7 +9,7 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('SprkToggle:', () => {
   it('should display one element with the correct additional classes', () => {
     const wrapper = mount(
-      <SprkToggle title="Toggle title" additionalClasses="sprk-o-Stack">
+      <SprkToggle titleText="Toggle title" additionalClasses="sprk-o-Stack">
         Body text
       </SprkToggle>,
     );
@@ -18,7 +18,7 @@ describe('SprkToggle:', () => {
 
   it('should default to open if defaultOpen is true', () => {
     const wrapper = shallow(
-      <SprkToggle isDefaultOpen title="Toggle title">
+      <SprkToggle isDefaultOpen titleText="Toggle title">
         Body text
       </SprkToggle>,
     );
@@ -27,7 +27,7 @@ describe('SprkToggle:', () => {
 
   it('should toggle open on click', () => {
     const wrapper = mount(
-      <SprkToggle title="Toggle title">Body text</SprkToggle>,
+      <SprkToggle titleText="Toggle title">Body text</SprkToggle>,
     );
     expect(wrapper.state().isOpen).toBe(false);
     wrapper.find('button').simulate('click');
@@ -38,7 +38,7 @@ describe('SprkToggle:', () => {
 
   it('should add a class to icon when opened', () => {
     const wrapper = mount(
-      <SprkToggle title="Toggle title">Body text</SprkToggle>,
+      <SprkToggle titleText="Toggle title">Body text</SprkToggle>,
     );
     wrapper.find('button').simulate('click');
     expect(wrapper.find('.sprk-c-Icon--open').length).toBe(1);
@@ -46,7 +46,7 @@ describe('SprkToggle:', () => {
 
   it('should add aria-expanded="true" when the toggle is open', () => {
     const wrapper = mount(
-      <SprkToggle title="Toggle title">Body text</SprkToggle>,
+      <SprkToggle titleText="Toggle title">Body text</SprkToggle>,
     );
     wrapper.find('button').simulate('click');
     expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
@@ -55,7 +55,7 @@ describe('SprkToggle:', () => {
   it(`should add aria-controls="custom_control" and id="custom_control" 
     when the contentId is passed`, () => {
     const wrapper = mount(
-      <SprkToggle title="Toggle title" contentId="custom_control">
+      <SprkToggle titleText="Toggle title" contentId="custom_control">
         Body text
       </SprkToggle>,
     );
@@ -65,7 +65,7 @@ describe('SprkToggle:', () => {
 
   it('should add aria-controls and id when the contentId is not passed', () => {
     const wrapper = mount(
-      <SprkToggle title="Toggle title">Body text</SprkToggle>,
+      <SprkToggle titleText="Toggle title">Body text</SprkToggle>,
     );
     const ButtonAriaControls = wrapper.find('button').prop('aria-controls');
     const toggleContentId = wrapper
@@ -81,7 +81,9 @@ describe('SprkToggle:', () => {
   it(`should add classes to the content if contentAdditionalClasses 
   are set`, () => {
     const wrapper = mount(
-      <SprkToggle contentAdditionalClasses="test">Body text</SprkToggle>,
+      <SprkToggle titleText="Toggle title" contentAdditionalClasses="test">
+        Body text
+      </SprkToggle>,
     );
     const toggleContent = wrapper.find('.sprk-c-Toggle__content').at(1);
     expect(toggleContent.hasClass('test')).toBe(true);

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -1,6 +1,7 @@
 /* global it expect */
 import React from 'react';
 import Enzyme, { shallow, mount } from 'enzyme';
+import sinon from 'sinon';
 import Adapter from 'enzyme-adapter-react-16';
 import SprkToggle from './SprkToggle';
 
@@ -52,6 +53,22 @@ describe('SprkToggle:', () => {
     expect(wrapper.state().isOpen).toBe(true);
     wrapper.find('button').simulate('click');
     expect(wrapper.state().isOpen).toBe(false);
+  });
+
+  it('should run additional onClick function and toggle on click', () => {
+    const expectedFunc = sinon.spy();
+    const wrapper = mount(
+      <SprkToggle titleText="Toggle title" onClick={expectedFunc}>
+        Body text
+      </SprkToggle>,
+    );
+    expect(wrapper.state().isOpen).toBe(false);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.state().isOpen).toBe(true);
+    expect(expectedFunc.called).toBe(true);
+    wrapper.find('button').simulate('click');
+    expect(wrapper.state().isOpen).toBe(false);
+    expect(expectedFunc.called).toBe(true);
   });
 
   it('should add a class to icon when opened', () => {

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -10,7 +10,7 @@ Enzyme.configure({ adapter: new Adapter() });
 describe('SprkToggle:', () => {
   it('should display one element with the correct additional classes', () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title" additionalClasses="sprk-o-Stack">
+      <SprkToggle triggerText="Toggle title" additionalClasses="sprk-o-Stack">
         Body text
       </SprkToggle>,
     );
@@ -19,7 +19,7 @@ describe('SprkToggle:', () => {
 
   it('should default to open if defaultOpen is true', () => {
     const wrapper = shallow(
-      <SprkToggle isDefaultOpen titleText="Toggle title">
+      <SprkToggle isDefaultOpen triggerText="Toggle title">
         Body text
       </SprkToggle>,
     );
@@ -28,7 +28,7 @@ describe('SprkToggle:', () => {
 
   it('should default to open if isOpen is true', () => {
     const wrapper = shallow(
-      <SprkToggle isOpen titleText="Toggle title">
+      <SprkToggle isOpen triggerText="Toggle title">
         Body text
       </SprkToggle>,
     );
@@ -37,7 +37,7 @@ describe('SprkToggle:', () => {
 
   it('should prefer isOpen to isDefaultOpen if both are set', () => {
     const wrapper = shallow(
-      <SprkToggle isOpen isDefaultOpen={false} titleText="Toggle title">
+      <SprkToggle isOpen isDefaultOpen={false} triggerText="Toggle title">
         Body text
       </SprkToggle>,
     );
@@ -46,7 +46,7 @@ describe('SprkToggle:', () => {
 
   it('should toggle open on click', () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title">Body text</SprkToggle>,
+      <SprkToggle triggerText="Toggle title">Body text</SprkToggle>,
     );
     expect(wrapper.state().isOpen).toBe(false);
     wrapper.find('button').simulate('click');
@@ -58,7 +58,7 @@ describe('SprkToggle:', () => {
   it('should run additional onClick function and toggle on click', () => {
     const expectedFunc = sinon.spy();
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title" onClick={expectedFunc}>
+      <SprkToggle triggerText="Toggle title" onClick={expectedFunc}>
         Body text
       </SprkToggle>,
     );
@@ -73,7 +73,7 @@ describe('SprkToggle:', () => {
 
   it('should add a class to icon when opened', () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title">Body text</SprkToggle>,
+      <SprkToggle triggerText="Toggle title">Body text</SprkToggle>,
     );
     wrapper.find('button').simulate('click');
     expect(wrapper.find('.sprk-c-Icon--open').length).toBe(1);
@@ -81,7 +81,7 @@ describe('SprkToggle:', () => {
 
   it('should add aria-expanded="true" when the toggle is open', () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title">Body text</SprkToggle>,
+      <SprkToggle triggerText="Toggle title">Body text</SprkToggle>,
     );
     wrapper.find('button').simulate('click');
     expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
@@ -90,7 +90,7 @@ describe('SprkToggle:', () => {
   it(`should add aria-controls="custom_control" and id="custom_control" 
     when the contentId is passed`, () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title" contentId="custom_control">
+      <SprkToggle triggerText="Toggle title" contentId="custom_control">
         Body text
       </SprkToggle>,
     );
@@ -100,7 +100,7 @@ describe('SprkToggle:', () => {
 
   it('should add aria-controls and id when the contentId is not passed', () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title">Body text</SprkToggle>,
+      <SprkToggle triggerText="Toggle title">Body text</SprkToggle>,
     );
     const ButtonAriaControls = wrapper.find('button').prop('aria-controls');
     const toggleContentId = wrapper
@@ -116,7 +116,7 @@ describe('SprkToggle:', () => {
   it(`should add classes to the content if contentAdditionalClasses 
   are set`, () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title" contentAdditionalClasses="test">
+      <SprkToggle triggerText="Toggle title" contentAdditionalClasses="test">
         Body text
       </SprkToggle>,
     );
@@ -127,7 +127,7 @@ describe('SprkToggle:', () => {
   it(`should add classes to the icon if iconAdditionalClasses 
   are set`, () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title" iconAdditionalClasses="test">
+      <SprkToggle triggerText="Toggle title" iconAdditionalClasses="test">
         Body text
       </SprkToggle>,
     );
@@ -138,7 +138,7 @@ describe('SprkToggle:', () => {
   it(`should add classes to the icon if iconAddClasses 
   are set`, () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title" iconAddClasses="test">
+      <SprkToggle triggerText="Toggle title" iconAddClasses="test">
         Body text
       </SprkToggle>,
     );
@@ -150,7 +150,7 @@ describe('SprkToggle:', () => {
   are set`, () => {
     const wrapper = mount(
       <SprkToggle
-        titleText="Toggle title"
+        triggerText="Toggle title"
         iconAddClasses="test"
         iconAdditionalClasses="newTest"
       >
@@ -165,7 +165,7 @@ describe('SprkToggle:', () => {
   it(`should add classes to the title if titleAdditionalClasses 
   are set`, () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title" titleAdditionalClasses="test">
+      <SprkToggle triggerText="Toggle title" titleAdditionalClasses="test">
         Body text
       </SprkToggle>,
     );
@@ -176,7 +176,7 @@ describe('SprkToggle:', () => {
   it(`should add classes to the title if titleAddClasses 
   are set`, () => {
     const wrapper = mount(
-      <SprkToggle titleText="Toggle title" titleAddClasses="test">
+      <SprkToggle triggerText="Toggle title" titleAddClasses="test">
         Body text
       </SprkToggle>,
     );
@@ -188,7 +188,7 @@ describe('SprkToggle:', () => {
   are set`, () => {
     const wrapper = mount(
       <SprkToggle
-        titleText="Toggle title"
+        triggerText="Toggle title"
         titleAddClasses="test"
         titleAdditionalClasses="newTest"
       >

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -52,9 +52,12 @@ describe('SprkToggle:', () => {
     expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
   });
 
-  it('should add aria-controls="custom_control" and id="custom_control" when the contentId is passed', () => {
+  it(`should add aria-controls="custom_control" and id="custom_control" 
+    when the contentId is passed`, () => {
     const wrapper = mount(
-      <SprkToggle title="Toggle title" contentId="custom_control">Body text</SprkToggle>,
+      <SprkToggle title="Toggle title" contentId="custom_control">
+        Body text
+      </SprkToggle>,
     );
     expect(wrapper.find('[aria-controls="custom_control"]').length).toBe(1);
     expect(wrapper.find('div#custom_control').length).toBe(1);
@@ -65,7 +68,10 @@ describe('SprkToggle:', () => {
       <SprkToggle title="Toggle title">Body text</SprkToggle>,
     );
     const ButtonAriaControls = wrapper.find('button').prop('aria-controls');
-    const toggleContentId = wrapper.find('.sprk-c-Toggle__content').at(1).prop('id');
+    const toggleContentId = wrapper
+      .find('.sprk-c-Toggle__content')
+      .at(1)
+      .prop('id');
 
     expect(toggleContentId).toMatch(/sprk_toggle_content_\d/);
     expect(toggleContentId).toEqual(ButtonAriaControls);

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -77,4 +77,13 @@ describe('SprkToggle:', () => {
     expect(toggleContentId).toEqual(ButtonAriaControls);
     expect(wrapper.find(`div#${toggleContentId}`).length).toBe(1);
   });
+
+  it(`should add classes to the content if contentAdditionalClasses 
+  are set`, () => {
+    const wrapper = mount(
+      <SprkToggle contentAdditionalClasses="test">Body text</SprkToggle>,
+    );
+    const toggleContent = wrapper.find('.sprk-c-Toggle__content').at(1);
+    expect(toggleContent.hasClass('test')).toBe(true);
+  });
 });

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -25,6 +25,24 @@ describe('SprkToggle:', () => {
     expect(wrapper.state().isOpen).toBe(true);
   });
 
+  it('should default to open if isOpen is true', () => {
+    const wrapper = shallow(
+      <SprkToggle isOpen titleText="Toggle title">
+        Body text
+      </SprkToggle>,
+    );
+    expect(wrapper.state().isOpen).toBe(true);
+  });
+
+  it('should prefer isOpen to isDefaultOpen if both are set', () => {
+    const wrapper = shallow(
+      <SprkToggle isOpen isDefaultOpen={false} titleText="Toggle title">
+        Body text
+      </SprkToggle>,
+    );
+    expect(wrapper.state().isOpen).toBe(true);
+  });
+
   it('should toggle open on click', () => {
     const wrapper = mount(
       <SprkToggle titleText="Toggle title">Body text</SprkToggle>,

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -88,4 +88,80 @@ describe('SprkToggle:', () => {
     const toggleContent = wrapper.find('.sprk-c-Toggle__content').at(1);
     expect(toggleContent.hasClass('test')).toBe(true);
   });
+
+  it(`should add classes to the icon if iconAdditionalClasses 
+  are set`, () => {
+    const wrapper = mount(
+      <SprkToggle titleText="Toggle title" iconAdditionalClasses="test">
+        Body text
+      </SprkToggle>,
+    );
+    const toggleIcon = wrapper.find('.sprk-c-Icon--toggle');
+    expect(toggleIcon.hasClass('test')).toBe(true);
+  });
+
+  it(`should add classes to the icon if iconAddClasses 
+  are set`, () => {
+    const wrapper = mount(
+      <SprkToggle titleText="Toggle title" iconAddClasses="test">
+        Body text
+      </SprkToggle>,
+    );
+    const toggleIcon = wrapper.find('.sprk-c-Icon--toggle');
+    expect(toggleIcon.hasClass('test')).toBe(true);
+  });
+
+  it(`should prefer iconAdditionalClasses to iconAddClasses if both
+  are set`, () => {
+    const wrapper = mount(
+      <SprkToggle
+        titleText="Toggle title"
+        iconAddClasses="test"
+        iconAdditionalClasses="newTest"
+      >
+        Body text
+      </SprkToggle>,
+    );
+    const toggleIcon = wrapper.find('.sprk-c-Icon--toggle');
+    expect(toggleIcon.hasClass('newTest')).toBe(true);
+    expect(toggleIcon.hasClass('test')).toBe(false);
+  });
+
+  it(`should add classes to the title if titleAdditionalClasses 
+  are set`, () => {
+    const wrapper = mount(
+      <SprkToggle titleText="Toggle title" titleAdditionalClasses="test">
+        Body text
+      </SprkToggle>,
+    );
+    const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
+    expect(toggleTitle.hasClass('test')).toBe(true);
+  });
+
+  it(`should add classes to the title if titleAddClasses 
+  are set`, () => {
+    const wrapper = mount(
+      <SprkToggle titleText="Toggle title" titleAddClasses="test">
+        Body text
+      </SprkToggle>,
+    );
+    const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
+    expect(toggleTitle.hasClass('test')).toBe(true);
+  });
+
+  it(`should prefer titleAdditionalClasses to titleAddClasses if both 
+  are set`, () => {
+    const wrapper = mount(
+      <SprkToggle
+        titleText="Toggle title"
+        titleAddClasses="test"
+        titleAdditionalClasses="newTest"
+      >
+        Body text
+      </SprkToggle>,
+    );
+    const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
+    expect(toggleTitle.hasClass('newTest')).toBe(true);
+    expect(toggleTitle.hasClass('test')).toBe(false);
+  });
 });


### PR DESCRIPTION
## What does this PR do?
- [x] Change isDefaultOpen to be isOpen and allow the consumer to be able to have the toggle open by default and also close/open it whenever.
- [x] Update prop name for titleAddClasses to be titleAdditionalClasses
- [x] Update iconAddClasses to be iconAdditionalClasses
- [x] Button element needs type=button
- [x] Fix eslint errors
- [x] add handler function prop to run when toggle is clicked
- [x] change title prop to be triggerText since title causes a11y issues.
- [x] add ability to add classes to the content 
- [x] Create issue for deprecation - isDefaultOpen, titleAddClasses, iconAddClasses, title - https://github.com/sparkdesignsystem/Backlog/issues/1296

### Associated Issue
Fixes #3295 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
