### PR TITLE
React Accordion Updates

### DIFF
--- a/react/src/components/accordions/SprkAccordion.js
+++ b/react/src/components/accordions/SprkAccordion.js
@@ -8,7 +8,7 @@ class SprkAccordion extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      items: props.children.map(item => ({
+      items: props.children.map((item) => ({
         id: uniqueId('accordion-item-'),
         ...item,
       })),
@@ -40,7 +40,8 @@ class SprkAccordion extends Component {
 
 SprkAccordion.propTypes = {
   /**
-   * A space-separated string of classes to add to the outermost container of the component.
+   * A space-separated string of classes to add to the outermost container
+   * of the component.
    */
   additionalClasses: PropTypes.string,
   /**
@@ -48,7 +49,8 @@ SprkAccordion.propTypes = {
    */
   children: PropTypes.node.isRequired,
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as a unique selector for
+   * automated tools.
    */
   idString: PropTypes.string,
 };

--- a/react/src/components/accordions/SprkAccordion.stories.js
+++ b/react/src/components/accordions/SprkAccordion.stories.js
@@ -22,7 +22,7 @@ export const defaultStory = () => (
   <SprkAccordion>
     <SprkAccordionItem
       heading="This is an accordion heading"
-      contentAddClasses="sprk-o-Stack sprk-o-Stack--medium"
+      contentAdditionalClasses="sprk-o-Stack sprk-o-Stack--medium"
     >
       <p className="sprk-b-TypeBodyTwo sprk-o-Stack__item">
         This is an example of accordion content. This is an example of accordion

--- a/react/src/components/accordions/SprkAccordion.stories.js
+++ b/react/src/components/accordions/SprkAccordion.stories.js
@@ -23,8 +23,6 @@ export const defaultStory = () => (
     <SprkAccordionItem
       heading="This is an accordion heading"
       contentAddClasses="sprk-o-Stack sprk-o-Stack--medium"
-      idString="accordion-item-1"
-      analyticsString="analytics_string_goes_here"
     >
       <p className="sprk-b-TypeBodyTwo sprk-o-Stack__item">
         This is an example of accordion content. This is an example of accordion
@@ -33,11 +31,7 @@ export const defaultStory = () => (
       </p>
     </SprkAccordionItem>
 
-    <SprkAccordionItem
-      heading="This is an accordion heading"
-      idString="accordion-item-2"
-      analyticsString="analytics_string_goes_here"
-    >
+    <SprkAccordionItem heading="This is an accordion heading">
       <p className="sprk-b-TypeBodyTwo">
         This is an example of accordion content. This is an example of accordion
         content. This is an example of accordion content. This is an example of
@@ -45,11 +39,7 @@ export const defaultStory = () => (
       </p>
     </SprkAccordionItem>
 
-    <SprkAccordionItem
-      heading="This is an accordion heading"
-      idString="accordion-item-3"
-      analyticsString="analytics_string_goes_here"
-    >
+    <SprkAccordionItem heading="This is an accordion heading">
       <p className="sprk-b-TypeBodyTwo">
         This is an example of accordion content. This is an example of accordion
         content. This is an example of accordion content. This is an example of

--- a/react/src/components/accordions/SprkAccordion.test.js
+++ b/react/src/components/accordions/SprkAccordion.test.js
@@ -77,7 +77,7 @@ describe('SprkAccordion:', () => {
     );
   });
 
-  it(`should display not render out an accordion item for elements that are
+  it(`should not render out an accordion item for elements that are
   not SprkAccordionItem`, () => {
     const wrapper = mount(
       <SprkAccordion>
@@ -144,5 +144,39 @@ describe('SprkAccordion:', () => {
       </SprkAccordion>,
     );
     expect(wrapper.find(SprkAccordionItem).length).toBe(3);
+  });
+
+  it('should use custom open icon when open', () => {
+    const wrapper = mount(
+      <SprkAccordion>
+        <SprkAccordionItem
+          heading="title"
+          iconTypeOpen="pinterest"
+          isDefaultOpen
+        >
+          content
+        </SprkAccordionItem>
+        <SprkAccordionItem heading="title2">content</SprkAccordionItem>
+      </SprkAccordion>,
+    );
+
+    expect(
+      wrapper.find('use').first().getDOMNode().getAttribute('xlink:href'),
+    ).toBe('#pinterest');
+  });
+
+  it('should use custom closed icon when closed', () => {
+    const wrapper = mount(
+      <SprkAccordion>
+        <SprkAccordionItem heading="title" iconTypeClosed="facebook">
+          content
+        </SprkAccordionItem>
+        <SprkAccordionItem heading="title2">content</SprkAccordionItem>
+      </SprkAccordion>,
+    );
+
+    expect(
+      wrapper.find('use').first().getDOMNode().getAttribute('xlink:href'),
+    ).toBe('#facebook');
   });
 });

--- a/react/src/components/accordions/SprkAccordion.test.js
+++ b/react/src/components/accordions/SprkAccordion.test.js
@@ -1,4 +1,4 @@
-/* global it expect jest */
+/* global it expect */
 import React from 'react';
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -18,22 +18,16 @@ describe('SprkAccordion:', () => {
           analyticsString="analytics_string_goes_here"
         >
           <p className="sprk-b-TypeBodyTwo sprk-o-Stack__item">
-            This is an example of multiple HTML elements
-            used for the content in an accordion item.
+            This is an example of multiple HTML elements used for the content in
+            an accordion item.
           </p>
 
           <ul className="sprk-b-List sprk-b-List--indented sprk-o-Stack__item">
-            <li>
-              List Item One
-            </li>
+            <li>List Item One</li>
 
-            <li>
-              List Item Two
-            </li>
+            <li>List Item Two</li>
 
-            <li>
-              List Item Three
-            </li>
+            <li>List Item Three</li>
           </ul>
         </SprkAccordionItem>
 
@@ -44,22 +38,16 @@ describe('SprkAccordion:', () => {
           analyticsString="analytics_string_goes_here"
         >
           <p className="sprk-b-TypeBodyTwo sprk-o-Stack__item">
-            This is an example of multiple HTML elements
-            used for the content in an accordion item.
+            This is an example of multiple HTML elements used for the content in
+            an accordion item.
           </p>
 
           <ul className="sprk-b-List sprk-b-List--indented sprk-o-Stack__item">
-            <li>
-              List Item One
-            </li>
+            <li>List Item One</li>
 
-            <li>
-              List Item Two
-            </li>
+            <li>List Item Two</li>
 
-            <li>
-              List Item Three
-            </li>
+            <li>List Item Three</li>
           </ul>
         </SprkAccordionItem>
 
@@ -70,30 +58,27 @@ describe('SprkAccordion:', () => {
           analyticsString="analytics_string_goes_here"
         >
           <p className="sprk-b-TypeBodyTwo sprk-o-Stack__item">
-            This is an example of multiple HTML elements
-            used for the content in an accordion item.
+            This is an example of multiple HTML elements used for the content in
+            an accordion item.
           </p>
 
           <ul className="sprk-b-List sprk-b-List--indented sprk-o-Stack__item">
-            <li>
-              List Item One
-            </li>
+            <li>List Item One</li>
 
-            <li>
-              List Item Two
-            </li>
+            <li>List Item Two</li>
 
-            <li>
-              List Item Three
-            </li>
+            <li>List Item Three</li>
           </ul>
         </SprkAccordionItem>
       </SprkAccordion>,
     );
-    expect(wrapper.find('ul.sprk-c-Accordion.sprk-o-VerticalList').length).toBe(1);
+    expect(wrapper.find('ul.sprk-c-Accordion.sprk-o-VerticalList').length).toBe(
+      1,
+    );
   });
 
-  it('should display not render out an accordion item for elements that are not SprkAccordionItem', () => {
+  it(`should display not render out an accordion item for elements that are
+  not SprkAccordionItem`, () => {
     const wrapper = mount(
       <SprkAccordion>
         <p>Test text</p>
@@ -104,22 +89,16 @@ describe('SprkAccordion:', () => {
           analyticsString="analytics_string_goes_here"
         >
           <p className="sprk-b-TypeBodyTwo sprk-o-Stack__item">
-            This is an example of multiple HTML elements
-            used for the content in an accordion item.
+            This is an example of multiple HTML elements used for the content in
+            an accordion item.
           </p>
 
           <ul className="sprk-b-List sprk-b-List--indented sprk-o-Stack__item">
-            <li>
-              List Item One
-            </li>
+            <li>List Item One</li>
 
-            <li>
-              List Item Two
-            </li>
+            <li>List Item Two</li>
 
-            <li>
-              List Item Three
-            </li>
+            <li>List Item Three</li>
           </ul>
         </SprkAccordionItem>
 
@@ -130,22 +109,16 @@ describe('SprkAccordion:', () => {
           analyticsString="analytics_string_goes_here"
         >
           <p className="sprk-b-TypeBodyTwo sprk-o-Stack__item">
-            This is an example of multiple HTML elements
-            used for the content in an accordion item.
+            This is an example of multiple HTML elements used for the content in
+            an accordion item.
           </p>
 
           <ul className="sprk-b-List sprk-b-List--indented sprk-o-Stack__item">
-            <li>
-              List Item One
-            </li>
+            <li>List Item One</li>
 
-            <li>
-              List Item Two
-            </li>
+            <li>List Item Two</li>
 
-            <li>
-              List Item Three
-            </li>
+            <li>List Item Three</li>
           </ul>
         </SprkAccordionItem>
 
@@ -156,22 +129,16 @@ describe('SprkAccordion:', () => {
           analyticsString="analytics_string_goes_here"
         >
           <p className="sprk-b-TypeBodyTwo sprk-o-Stack__item">
-            This is an example of multiple HTML elements
-            used for the content in an accordion item.
+            This is an example of multiple HTML elements used for the content in
+            an accordion item.
           </p>
 
           <ul className="sprk-b-List sprk-b-List--indented sprk-o-Stack__item">
-            <li>
-              List Item One
-            </li>
+            <li>List Item One</li>
 
-            <li>
-              List Item Two
-            </li>
+            <li>List Item Two</li>
 
-            <li>
-              List Item Three
-            </li>
+            <li>List Item Three</li>
           </ul>
         </SprkAccordionItem>
       </SprkAccordion>,

--- a/react/src/components/accordions/SprkAccordion.test.js
+++ b/react/src/components/accordions/SprkAccordion.test.js
@@ -149,11 +149,7 @@ describe('SprkAccordion:', () => {
   it('should use custom open icon when open', () => {
     const wrapper = mount(
       <SprkAccordion>
-        <SprkAccordionItem
-          heading="title"
-          iconTypeOpen="pinterest"
-          isDefaultOpen
-        >
+        <SprkAccordionItem heading="title" iconNameOpen="pinterest" isOpen>
           content
         </SprkAccordionItem>
         <SprkAccordionItem heading="title2">content</SprkAccordionItem>
@@ -168,7 +164,7 @@ describe('SprkAccordion:', () => {
   it('should use custom closed icon when closed', () => {
     const wrapper = mount(
       <SprkAccordion>
-        <SprkAccordionItem heading="title" iconTypeClosed="facebook">
+        <SprkAccordionItem heading="title" iconNameClosed="facebook">
           content
         </SprkAccordionItem>
         <SprkAccordionItem heading="title2">content</SprkAccordionItem>

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -40,8 +40,8 @@ class SprkAccordionItem extends Component {
       iconAddClasses,
       iconAdditionalClasses = iconAddClasses,
       id,
-      iconTypeOpen,
-      iconTypeClosed,
+      iconNameOpen,
+      iconNameClosed,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
@@ -77,7 +77,7 @@ class SprkAccordionItem extends Component {
         >
           <h3 className={headingClassNames}>{heading}</h3>
           <SprkIcon
-            iconName={isOpen ? iconTypeOpen : iconTypeClosed}
+            iconName={isOpen ? iconNameOpen : iconNameClosed}
             additionalClasses={iconClasses}
           />
         </SprkLink>
@@ -99,9 +99,8 @@ class SprkAccordionItem extends Component {
 }
 
 SprkAccordionItem.defaultProps = {
-  isOpen: false,
-  iconTypeOpen: 'chevron-up-circle',
-  iconTypeClosed: 'chevron-up-circle',
+  iconNameOpen: 'chevron-up-circle',
+  iconNameClosed: 'chevron-up-circle',
 };
 
 SprkAccordionItem.propTypes = {
@@ -179,11 +178,11 @@ SprkAccordionItem.propTypes = {
   /**
    * The name of the icon to use when the Accordion item is open
    */
-  iconTypeOpen: PropTypes.string,
+  iconNameOpen: PropTypes.string,
   /**
    * The name of the icon to use when the Accordion item is closed
    */
-  iconTypeClosed: PropTypes.string,
+  iconNameClosed: PropTypes.string,
 };
 
 export default SprkAccordionItem;

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -42,6 +42,7 @@ class SprkAccordionItem extends Component {
       id,
       iconNameOpen,
       iconNameClosed,
+      leadingIcon,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
@@ -75,6 +76,14 @@ class SprkAccordionItem extends Component {
           onClick={this.toggle}
           aria-expanded={isOpen ? 'true' : 'false'}
         >
+          {leadingIcon && (
+            <SprkIcon
+              iconName={leadingIcon}
+              additionalClasses="
+                      sprk-c-Icon--filled-current-color
+                      sprk-c-Icon--xl sprk-u-mrs"
+            />
+          )}
           <h3 className={headingClassNames}>{heading}</h3>
           <SprkIcon
             iconName={isOpen ? iconNameOpen : iconNameClosed}
@@ -183,6 +192,12 @@ SprkAccordionItem.propTypes = {
    * The name of the icon to use when the Accordion item is closed
    */
   iconNameClosed: PropTypes.string,
+  /**
+   * The name of the icon to use before
+   * the title in the Accordion item.
+   * This is optional.
+   */
+  leadingIcon: PropTypes.string,
 };
 
 export default SprkAccordionItem;

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -46,6 +46,7 @@ class SprkAccordionItem extends Component {
       iconNameOpen,
       iconNameClosed,
       leadingIcon,
+      leadingIconAdditionalClasses,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
@@ -68,6 +69,13 @@ class SprkAccordionItem extends Component {
       headingAdditionalClasses,
     );
 
+    const leadingIconClasses = classnames(
+      'sprk-c-Icon--filled-current-color',
+      'sprk-c-Icon--xl',
+      'sprk-u-mrs',
+      leadingIconAdditionalClasses,
+    );
+
     return (
       <li className={itemClassNames} data-id={idString} {...other}>
         <SprkLink
@@ -82,9 +90,7 @@ class SprkAccordionItem extends Component {
           {leadingIcon && (
             <SprkIcon
               iconName={leadingIcon}
-              additionalClasses="
-                      sprk-c-Icon--filled-current-color
-                      sprk-c-Icon--xl sprk-u-mrs"
+              additionalClasses={leadingIconClasses}
             />
           )}
           <h3 className={headingClassNames}>{heading}</h3>
@@ -202,6 +208,11 @@ SprkAccordionItem.propTypes = {
    * This is optional.
    */
   leadingIcon: PropTypes.string,
+  /**
+   * Expects a space separated string of classes to be added to the leading
+   * icon.
+   */
+  leadingIconAdditionalClasses: PropTypes.string,
 };
 
 export default SprkAccordionItem;

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -189,11 +189,11 @@ SprkAccordionItem.propTypes = {
    */
   onToggle: PropTypes.func,
   /**
-   * The name of the icon to use when the Accordion item is open
+   * The name of the icon to use when the Accordion item is open.
    */
   iconNameOpen: PropTypes.string,
   /**
-   * The name of the icon to use when the Accordion item is closed
+   * The name of the icon to use when the Accordion item is closed.
    */
   iconNameClosed: PropTypes.string,
   /**

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -8,10 +8,10 @@ import SprkLink from '../../../../base/links/SprkLink';
 class SprkAccordionItem extends Component {
   constructor(props) {
     super(props);
-    const { isDefaultOpen } = this.props;
+    const { isDefaultOpen, isOpen = isDefaultOpen } = this.props;
     this.state = {
-      isOpen: isDefaultOpen || false,
-      height: isDefaultOpen ? 'auto' : 0,
+      isOpen: isOpen || false,
+      height: isOpen ? 'auto' : 0,
     };
     this.toggle = this.toggle.bind(this);
   }
@@ -33,13 +33,12 @@ class SprkAccordionItem extends Component {
       children,
       heading,
       headingAddClasses,
-      headingAdditionalClasses,
+      headingAdditionalClasses = headingAddClasses,
       additionalClasses,
       contentAddClasses,
-      contentAdditionalClasses,
+      contentAdditionalClasses = contentAddClasses,
       iconAddClasses,
-      iconAdditionalClasses,
-      isDefaultOpen,
+      iconAdditionalClasses = iconAddClasses,
       id,
       iconTypeOpen,
       iconTypeClosed,
@@ -50,7 +49,7 @@ class SprkAccordionItem extends Component {
     const iconClasses = classnames(
       'sprk-c-Icon--toggle sprk-c-Accordion__icon sprk-c-Icon--xl',
       { 'sprk-c-Icon--open': isOpen },
-      iconAdditionalClasses || iconAddClasses,
+      iconAdditionalClasses,
     );
 
     const itemClassNames = classnames(
@@ -62,7 +61,7 @@ class SprkAccordionItem extends Component {
     const headingClassNames = classnames(
       'sprk-c-Accordion__heading',
       'sprk-b-TypeDisplaySeven',
-      headingAdditionalClasses || headingAddClasses,
+      headingAdditionalClasses,
     );
 
     return (
@@ -87,7 +86,7 @@ class SprkAccordionItem extends Component {
           <div
             className={classnames(
               'sprk-c-Accordion__content',
-              contentAdditionalClasses || contentAddClasses,
+              contentAdditionalClasses,
             )}
             id={id}
           >
@@ -100,7 +99,7 @@ class SprkAccordionItem extends Component {
 }
 
 SprkAccordionItem.defaultProps = {
-  isDefaultOpen: false,
+  isOpen: false,
   iconTypeOpen: 'chevron-up-circle',
   iconTypeClosed: 'chevron-up-circle',
 };
@@ -140,9 +139,14 @@ SprkAccordionItem.propTypes = {
    */
   idString: PropTypes.string,
   /**
+   * Deprecated - Use `isOpen` instead.
    * Used to specify whether the item should be open by default.
    */
   isDefaultOpen: PropTypes.bool,
+  /**
+   * Used to specify whether the item is opened or closed.
+   */
+  isOpen: PropTypes.bool,
   // TODO remove as part of Issue XXXX
   /**
    * Deprecated - use `iconAdditionalClasses` instead. Expects a space
@@ -169,7 +173,7 @@ SprkAccordionItem.propTypes = {
    */
   id: PropTypes.string,
   /**
-   * An function to be called when the accordion item is toggled.
+   * An function to be called when the Accordion item is toggled.
    */
   onToggle: PropTypes.func,
   /**

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -41,6 +41,8 @@ class SprkAccordionItem extends Component {
       iconAdditionalClasses,
       isDefaultOpen,
       id,
+      iconTypeOpen,
+      iconTypeClosed,
       ...other
     } = this.props;
     const { isOpen, height } = this.state;
@@ -76,7 +78,7 @@ class SprkAccordionItem extends Component {
         >
           <h3 className={headingClassNames}>{heading}</h3>
           <SprkIcon
-            iconName="chevron-up-circle"
+            iconName={isOpen ? iconTypeOpen : iconTypeClosed}
             additionalClasses={iconClasses}
           />
         </SprkLink>
@@ -99,6 +101,8 @@ class SprkAccordionItem extends Component {
 
 SprkAccordionItem.defaultProps = {
   isDefaultOpen: false,
+  iconTypeOpen: 'chevron-up-circle',
+  iconTypeClosed: 'chevron-up-circle',
 };
 
 SprkAccordionItem.propTypes = {
@@ -168,6 +172,14 @@ SprkAccordionItem.propTypes = {
    * An function to be called when the accordion item is toggled.
    */
   onToggle: PropTypes.func,
+  /**
+   * The name of the icon to use when the Accordion item is open
+   */
+  iconTypeOpen: PropTypes.string,
+  /**
+   * The name of the icon to use when the Accordion item is closed
+   */
+  iconTypeClosed: PropTypes.string,
 };
 
 export default SprkAccordionItem;

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -33,9 +33,12 @@ class SprkAccordionItem extends Component {
       children,
       heading,
       headingAddClasses,
+      headingAdditionalClasses,
       additionalClasses,
       contentAddClasses,
+      contentAdditionalClasses,
       iconAddClasses,
+      iconAdditionalClasses,
       isDefaultOpen,
       id,
       ...other
@@ -45,7 +48,7 @@ class SprkAccordionItem extends Component {
     const iconClasses = classnames(
       'sprk-c-Icon--toggle sprk-c-Accordion__icon sprk-c-Icon--xl',
       { 'sprk-c-Icon--open': isOpen },
-      iconAddClasses,
+      iconAdditionalClasses || iconAddClasses,
     );
 
     const itemClassNames = classnames(
@@ -57,7 +60,7 @@ class SprkAccordionItem extends Component {
     const headingClassNames = classnames(
       'sprk-c-Accordion__heading',
       'sprk-b-TypeDisplaySeven',
-      headingAddClasses,
+      headingAdditionalClasses || headingAddClasses,
     );
 
     return (
@@ -82,7 +85,7 @@ class SprkAccordionItem extends Component {
           <div
             className={classnames(
               'sprk-c-Accordion__content',
-              contentAddClasses,
+              contentAdditionalClasses || contentAddClasses,
             )}
             id={id}
           >
@@ -112,10 +115,16 @@ SprkAccordionItem.propTypes = {
    * The text for the item heading.
    */
   heading: PropTypes.string.isRequired,
+  // TODO remove as part of Issue XXXX
+  /**
+   * Deprecated - use `headingAdditionalClasses` instead. Expects a space
+   * separated string of classes to be added to the heading.
+   */
+  headingAddClasses: PropTypes.string,
   /**
    * Expects a space separated string of classes to be added to the heading.
    */
-  headingAddClasses: PropTypes.string,
+  headingAdditionalClasses: PropTypes.string,
   /**
    * A space-separated string of classes to add to the outermost container of
    * the component.
@@ -130,15 +139,27 @@ SprkAccordionItem.propTypes = {
    * Used to specify whether the item should be open by default.
    */
   isDefaultOpen: PropTypes.bool,
+  // TODO remove as part of Issue XXXX
+  /**
+   * Deprecated - use `iconAdditionalClasses` instead. Expects a space
+   * separated string of classes to be added to the icon.
+   */
+  iconAddClasses: PropTypes.string,
   /**
    * Expects a space separated string of classes to be added to the icon.
    */
-  iconAddClasses: PropTypes.string,
+  iconAdditionalClasses: PropTypes.string,
+  // TODO remove as part of Issue XXXX
+  /**
+   * Deprecated - use `contentAdditionalClasses` instead. Expects a space
+   * separated string of classes to be added to the toggle content.
+   */
+  contentAddClasses: PropTypes.string,
   /**
    * Expects a space separated string of classes to be added to the toggle
    * content.
    */
-  contentAddClasses: PropTypes.string,
+  contentAdditionalClasses: PropTypes.string,
   /**
    * A unique ID for the accordion item.
    */

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -8,6 +8,7 @@ import SprkLink from '../../../../base/links/SprkLink';
 class SprkAccordionItem extends Component {
   constructor(props) {
     super(props);
+    // TODO: Remove isDefaultOpen in future issue #1299
     const { isDefaultOpen, isOpen = isDefaultOpen } = this.props;
     this.state = {
       isOpen: isOpen || false,
@@ -26,6 +27,8 @@ class SprkAccordionItem extends Component {
     if (onToggle) onToggle(e);
   }
 
+  /* TODO: Remove headingAddClasses, contentAddClasses,
+  iconAddClasses in future issue #1299 */
   render() {
     const {
       analyticsString,
@@ -126,7 +129,7 @@ SprkAccordionItem.propTypes = {
    * The text for the item heading.
    */
   heading: PropTypes.string.isRequired,
-  // TODO remove as part of Issue XXXX
+  // TODO remove as part of Issue 1299
   /**
    * Deprecated - use `headingAdditionalClasses` instead. Expects a space
    * separated string of classes to be added to the heading.
@@ -146,6 +149,7 @@ SprkAccordionItem.propTypes = {
    * automated tools.
    */
   idString: PropTypes.string,
+  // TODO remove as part of Issue 1299
   /**
    * Deprecated - Use `isOpen` instead.
    * Used to specify whether the item should be open by default.
@@ -155,7 +159,7 @@ SprkAccordionItem.propTypes = {
    * Used to specify whether the item is opened or closed.
    */
   isOpen: PropTypes.bool,
-  // TODO remove as part of Issue XXXX
+  // TODO remove as part of Issue 1299
   /**
    * Deprecated - use `iconAdditionalClasses` instead. Expects a space
    * separated string of classes to be added to the icon.
@@ -165,7 +169,7 @@ SprkAccordionItem.propTypes = {
    * Expects a space separated string of classes to be added to the icon.
    */
   iconAdditionalClasses: PropTypes.string,
-  // TODO remove as part of Issue XXXX
+  // TODO remove as part of Issue 1299
   /**
    * Deprecated - use `contentAdditionalClasses` instead. Expects a space
    * separated string of classes to be added to the toggle content.
@@ -181,7 +185,7 @@ SprkAccordionItem.propTypes = {
    */
   id: PropTypes.string,
   /**
-   * An function to be called when the Accordion item is toggled.
+   * A function to be called when the Accordion item is toggled.
    */
   onToggle: PropTypes.func,
   /**

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -19,7 +19,7 @@ class SprkAccordionItem extends Component {
   toggle(e) {
     const { onToggle } = this.props;
     e.preventDefault();
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isOpen: !prevState.isOpen,
       height: !prevState.isOpen ? 'auto' : 0,
     }));
@@ -104,23 +104,26 @@ SprkAccordionItem.propTypes = {
    */
   children: PropTypes.node,
   /**
-   * Assigned to the `data-analytics` attribute serving as a unique selector for outside libraries to capture data.
+   * Assigned to the `data-analytics` attribute serving as a unique selector
+   * for outside libraries to capture data.
    */
   analyticsString: PropTypes.string,
-  /** The text for the item heading. */
+  /**
+   * The text for the item heading.
+   */
   heading: PropTypes.string.isRequired,
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * heading.
+   * Expects a space separated string of classes to be added to the heading.
    */
   headingAddClasses: PropTypes.string,
   /**
-   * A space-separated string of classes to add to the outermost container of the component.
+   * A space-separated string of classes to add to the outermost container of
+   * the component.
    */
   additionalClasses: PropTypes.string,
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as a unique selector for
+   * automated tools.
    */
   idString: PropTypes.string,
   /**
@@ -128,17 +131,22 @@ SprkAccordionItem.propTypes = {
    */
   isDefaultOpen: PropTypes.bool,
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * icon.
+   * Expects a space separated string of classes to be added to the icon.
    */
   iconAddClasses: PropTypes.string,
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * toggle content.
+   * Expects a space separated string of classes to be added to the toggle
+   * content.
    */
   contentAddClasses: PropTypes.string,
+  /**
+   * A unique ID for the accordion item.
+   */
+  id: PropTypes.string,
+  /**
+   * An function to be called when the accordion item is toggled.
+   */
+  onToggle: PropTypes.func,
 };
 
 export default SprkAccordionItem;

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -70,25 +70,18 @@ describe('SprkAccordionItem:', () => {
 
   it('should have aria-controls attribute value equal to content value', () => {
     const wrapper = mount(
-      <SprkAccordionItem
-        heading="test"
-        id="test-id">
-          test
+      <SprkAccordionItem heading="test" id="test-id">
+        test
       </SprkAccordionItem>,
     );
 
     wrapper.find('button').simulate('click');
-    expect(
-      wrapper
-      .find('.sprk-c-Accordion__content')
-      .getDOMNode().id
-    ).toEqual('test-id');
+    expect(wrapper.find('.sprk-c-Accordion__content').getDOMNode().id).toEqual(
+      'test-id',
+    );
 
     expect(
-      wrapper
-        .find('button')
-        .getDOMNode()
-        .getAttribute('aria-controls')
+      wrapper.find('button').getDOMNode().getAttribute('aria-controls'),
     ).toEqual('test-id');
   });
 });

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -179,4 +179,17 @@ describe('SprkAccordionItem:', () => {
     wrapper = mount(<SprkAccordionItem leadingIcon="exclamation" />);
     expect(wrapper.find('.sprk-c-Icon').length).toBe(2);
   });
+
+  it(`should add a leading icon classes if 
+  leadingIconAdditionalClasses is provided`, () => {
+    const wrapper = mount(
+      <SprkAccordionItem
+        leadingIcon="exclamation"
+        leadingIconAdditionalClasses="test"
+      />,
+    );
+    const leadingIcon = wrapper.find('.sprk-c-Icon').at(0);
+    expect(wrapper.find('.sprk-c-Icon').length).toBe(2);
+    expect(leadingIcon.hasClass('test')).toBe(true);
+  });
 });

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -14,7 +14,16 @@ describe('SprkAccordionItem:', () => {
     expect(wrapper.find('li.sprk-c-Accordion__item').length).toBe(1);
   });
 
-  it('should default to open if defaultOpen is true', () => {
+  it('should default to open if isOpen is true', () => {
+    const wrapper = mount(
+      <SprkAccordionItem heading="test" isOpen>
+        test
+      </SprkAccordionItem>,
+    );
+    expect(wrapper.state().isOpen).toBe(true);
+  });
+
+  it('should default to open if isDefaultOpen is true', () => {
     const wrapper = mount(
       <SprkAccordionItem heading="test" isDefaultOpen>
         test
@@ -85,6 +94,18 @@ describe('SprkAccordionItem:', () => {
     ).toEqual('test-id');
   });
 
+  it('should add classes to heading if headingAdditionalClasses is set', () => {
+    const wrapper = mount(
+      <SprkAccordionItem headingAdditionalClasses="test" />,
+    );
+    expect(wrapper.find('.sprk-c-Accordion__heading.test').length).toBe(1);
+  });
+
+  it('should add classes to heading if headingAddClasses is set', () => {
+    const wrapper = mount(<SprkAccordionItem headingAddClasses="test" />);
+    expect(wrapper.find('.sprk-c-Accordion__heading.test').length).toBe(1);
+  });
+
   it('should prefer headingAdditionalClasses over headingAddClasses', () => {
     let wrapper = mount(
       <SprkAccordionItem
@@ -100,6 +121,18 @@ describe('SprkAccordionItem:', () => {
     expect(wrapper.find('.sprk-c-Accordion__heading.test2').length).toBe(1);
   });
 
+  it('should add classes to content if contentAdditionalClasses is set', () => {
+    const wrapper = mount(
+      <SprkAccordionItem contentAdditionalClasses="test" />,
+    );
+    expect(wrapper.find('.sprk-c-Accordion__content.test').length).toBe(1);
+  });
+
+  it('should add classes to content if contentAddClasses is set', () => {
+    const wrapper = mount(<SprkAccordionItem contentAddClasses="test" />);
+    expect(wrapper.find('.sprk-c-Accordion__content.test').length).toBe(1);
+  });
+
   it('should prefer contentAdditionalClasses over contentAddClasses', () => {
     let wrapper = mount(
       <SprkAccordionItem
@@ -113,6 +146,16 @@ describe('SprkAccordionItem:', () => {
     wrapper = mount(<SprkAccordionItem contentAddClasses="test2" />);
     expect(wrapper.find('.sprk-c-Accordion__content.test').length).toBe(0);
     expect(wrapper.find('.sprk-c-Accordion__content.test2').length).toBe(1);
+  });
+
+  it('should add classes to icon if iconAdditionalClasses is set', () => {
+    const wrapper = mount(<SprkAccordionItem iconAdditionalClasses="test" />);
+    expect(wrapper.find('.sprk-c-Icon--toggle.test').length).toBe(1);
+  });
+
+  it('should add classes to icon if iconAddClasses is set', () => {
+    const wrapper = mount(<SprkAccordionItem iconAddClasses="test" />);
+    expect(wrapper.find('.sprk-c-Icon--toggle.test').length).toBe(1);
   });
 
   it('should prefer iconAdditionalClasses over iconAddClasses', () => {

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -4,6 +4,9 @@ import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import SprkAccordionItem from './SprkAccordionItem';
 
+/* TODO: Remove isDefaultOpen, headingAddClasses, contentAddClasses,
+iconAddClasses in future issue #1299 */
+
 Enzyme.configure({ adapter: new Adapter() });
 
 describe('SprkAccordionItem:', () => {

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -169,4 +169,11 @@ describe('SprkAccordionItem:', () => {
     expect(wrapper.find('.sprk-c-Icon--toggle.test').length).toBe(0);
     expect(wrapper.find('.sprk-c-Icon--toggle.test2').length).toBe(1);
   });
+
+  it('should add a leadingIcon if one is provided', () => {
+    let wrapper = mount(<SprkAccordionItem />);
+    expect(wrapper.find('.sprk-c-Icon').length).toBe(1);
+    wrapper = mount(<SprkAccordionItem leadingIcon="exclamation" />);
+    expect(wrapper.find('.sprk-c-Icon').length).toBe(2);
+  });
 });

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -84,4 +84,46 @@ describe('SprkAccordionItem:', () => {
       wrapper.find('button').getDOMNode().getAttribute('aria-controls'),
     ).toEqual('test-id');
   });
+
+  it('should prefer headingAdditionalClasses over headingAddClasses', () => {
+    let wrapper = mount(
+      <SprkAccordionItem
+        headingAdditionalClasses="test"
+        headingAddClasses="test2"
+      />,
+    );
+    expect(wrapper.find('.sprk-c-Accordion__heading.test').length).toBe(1);
+    expect(wrapper.find('.sprk-c-Accordion__heading.test2').length).toBe(0);
+
+    wrapper = mount(<SprkAccordionItem headingAddClasses="test2" />);
+    expect(wrapper.find('.sprk-c-Accordion__heading.test').length).toBe(0);
+    expect(wrapper.find('.sprk-c-Accordion__heading.test2').length).toBe(1);
+  });
+
+  it('should prefer contentAdditionalClasses over contentAddClasses', () => {
+    let wrapper = mount(
+      <SprkAccordionItem
+        contentAdditionalClasses="test"
+        contentAddClasses="test2"
+      />,
+    );
+    expect(wrapper.find('.sprk-c-Accordion__content.test').length).toBe(1);
+    expect(wrapper.find('.sprk-c-Accordion__content.test2').length).toBe(0);
+
+    wrapper = mount(<SprkAccordionItem contentAddClasses="test2" />);
+    expect(wrapper.find('.sprk-c-Accordion__content.test').length).toBe(0);
+    expect(wrapper.find('.sprk-c-Accordion__content.test2').length).toBe(1);
+  });
+
+  it('should prefer iconAdditionalClasses over iconAddClasses', () => {
+    let wrapper = mount(
+      <SprkAccordionItem iconAdditionalClasses="test" iconAddClasses="test2" />,
+    );
+    expect(wrapper.find('.sprk-c-Icon--toggle.test').length).toBe(1);
+    expect(wrapper.find('.sprk-c-Icon--toggle.test2').length).toBe(0);
+
+    wrapper = mount(<SprkAccordionItem iconAddClasses="test2" />);
+    expect(wrapper.find('.sprk-c-Icon--toggle.test').length).toBe(0);
+    expect(wrapper.find('.sprk-c-Icon--toggle.test2').length).toBe(1);
+  });
 });


### PR DESCRIPTION
## What does this PR do?
- [x] Add propTypes for `onToggle` in the SprkAccordionItem.
- [x] Change `headingAddClasses` to `headingAdditionalClasses`
- [x] Change `contentAddClasses` to `contentAdditionalClasses`
- [x] Change `iconAddClasses` to `iconAdditionalClasses`
- [x] Add props `iconNameOpen` and `iconNameClosed` to allow for custom icons.
- [x] Update `isDefaultOpen` to be `isOpen`. 
- [x] Add `leadingIcon` prop. (Per Jane, we want to allow this)
- [x] Follow up issue for removal of deprecated props - https://github.com/sparkdesignsystem/Backlog/issues/1299

### Associated Issue
Fixes #3493

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)
