### PR TITLE
React Tabs Updates

### DIFF
--- a/react/src/components/tabs/SprkTabs.js
+++ b/react/src/components/tabs/SprkTabs.js
@@ -7,10 +7,10 @@ import SprkTabsPanel from './components/SprkTabsPanel/SprkTabsPanel';
 import SprkTabsButton from './components/SprkTabsButton/SprkTabsButton';
 
 /*
-* This component expects SprkTabsPanel children.
-* It loops through each provided SprkTabsPanel
-* and creates a SprkTabsButton for each tab.
-*/
+ * This component expects SprkTabsPanel children.
+ * It loops through each provided SprkTabsPanel
+ * and creates a SprkTabsButton for each tab.
+ */
 class SprkTabs extends Component {
   constructor(props) {
     super(props);
@@ -28,11 +28,11 @@ class SprkTabs extends Component {
   }
 
   /*
-  * Immediately invoke setDefaultActiveTab()
-  * when component is inserted into the tree
-  * and update state with the ID of the tab that's active by default.
-  * Update aria-orientation and listen for resizes for future updates.
-  */
+   * Immediately invoke setDefaultActiveTab()
+   * when component is inserted into the tree
+   * and update state with the ID of the tab that's active by default.
+   * Update aria-orientation and listen for resizes for future updates.
+   */
   componentDidMount() {
     const { breakpoint } = this.props;
 
@@ -44,10 +44,10 @@ class SprkTabs extends Component {
   }
 
   /*
-  * Find the SprkTabsButton that we want
-  * active by default (isDefaultActive would be set on tab panel)
-  * and update state with that tab button ID.
-  */
+   * Find the SprkTabsButton that we want
+   * active by default (isDefaultActive would be set on tab panel)
+   * and update state with that tab button ID.
+   */
   setDefaultActiveTab() {
     const { children } = this.props;
     const { btnIds } = this.state;
@@ -67,9 +67,9 @@ class SprkTabs extends Component {
   }
 
   /*
-  * Get the index of the active tab
-  * by finding it from our state array of btn IDs.
-  */
+   * Get the index of the active tab
+   * by finding it from our state array of btn IDs.
+   */
   getActiveTabIndex() {
     const { isActive, btnIds } = this.state;
     let tabIndex;
@@ -99,7 +99,7 @@ class SprkTabs extends Component {
 
   advanceTab() {
     const { btnIds } = this.state;
-    if ((this.getActiveTabIndex() + 1) < btnIds.length) {
+    if (this.getActiveTabIndex() + 1 < btnIds.length) {
       const newActiveTabIndex = this.getActiveTabIndex() + 1;
       this.setState({
         isActive: btnIds[newActiveTabIndex],
@@ -114,10 +114,10 @@ class SprkTabs extends Component {
   }
 
   /*
-  * Tabs uses arrow keys to move from tab to tab.
-  * Depending on the key pressed we need to
-  * set a new active tab.
-  */
+   * Tabs uses arrow keys to move from tab to tab.
+   * Depending on the key pressed we need to
+   * set a new active tab.
+   */
   handleKeyboardEvent(e) {
     const { btnIds } = this.state;
     const keys = {
@@ -152,9 +152,9 @@ class SprkTabs extends Component {
   }
 
   /*
-  * Switch aria-orientation to vertical on
-  * narrow viewports (based on _tabs.scss breakpoint).
-  */
+   * Switch aria-orientation to vertical on
+   * narrow viewports (based on _tabs.scss breakpoint).
+   */
   updateAriaOrientation(width, breakpoint) {
     const tabsContainer = this.tabsContainerRef;
 
@@ -166,31 +166,26 @@ class SprkTabs extends Component {
   }
 
   /*
-  * Get the ID of the clicked tab
-  * and update state with the active tab ID.
-  */
+   * Get the ID of the clicked tab
+   * and update state with the active tab ID.
+   */
   handleTabClick(e) {
     const btnTabId = e.currentTarget.id;
     this.setState({ isActive: btnTabId });
   }
 
   render() {
-    const {
-      children,
-      idString,
-      additionalClasses,
-      ...other
-    } = this.props;
+    const { children, idString, additionalClasses, ...other } = this.props;
 
     const buttons = [];
     const panels = [];
 
     /*
-    * Loop through all the SprkTabsPanels and
-    * generate a SprkTabsButton for each one.
-    * Don't render a SprkTabsButton
-    * for an element that is not a SprkTabsPanel.
-    */
+     * Loop through all the SprkTabsPanels and
+     * generate a SprkTabsButton for each one.
+     * Don't render a SprkTabsButton
+     * for an element that is not a SprkTabsPanel.
+     */
     const generateTabs = () => {
       children.forEach((tabPanel, index) => {
         const {
@@ -258,17 +253,15 @@ class SprkTabs extends Component {
           className="sprk-c-Tabs__buttons"
           role="tablist"
         >
-          { buttons }
+          {buttons}
         </div>
-        { panels }
+        {panels}
       </div>
     );
   }
 }
 
 SprkTabs.defaultProps = {
-  idString: '',
-  additionalClasses: '',
   breakpoint: 736,
 };
 
@@ -278,11 +271,13 @@ SprkTabs.propTypes = {
    */
   children: PropTypes.node.isRequired,
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as a unique selector for
+   * automated tools.
    */
   idString: PropTypes.string,
   /**
-   * A space-separated string of classes to add to the outermost container of the component.
+   * A space-separated string of classes to add to the outermost container of
+   * the component.
    */
   additionalClasses: PropTypes.string,
   /** Breakpoint for the aria-orientation switch from y to x. */

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
@@ -98,21 +98,24 @@ SprkTabsButton.propTypes = {
    */
   ariaSelected: PropTypes.bool,
   /**
-   * The function that runs upon  clicking a tab.
+   * The function that runs upon clicking a tab.
    */
   onTabClick: PropTypes.func,
   /**
-   * The id used for the data-id attribute
+   * Assigned to the `data-id` attribute serving as a unique selector
+   * for automated tools.
    */
   tabBtnDataId: PropTypes.string,
   // TODO remove as part of Issue 3566
   /**
-   * Deprecated - use `tabBtnAnalyticsString` instead. The value used for
-   * the data-analytics attribute.
+   * Deprecated - use `tabBtnAnalyticsString` instead. Assigned to the
+   * `data-analytics` attribute serving as a unique selector for outside
+   * libraries to capture data.
    */
   tabBtnAnalytics: PropTypes.string,
   /**
-   * The value used for the data-analytics attribute.
+   * Assigned to the `data-analytics` attribute serving as a unique selector
+   * for outside libraries to capture data.
    */
   tabBtnAnalyticsString: PropTypes.string,
 };

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
@@ -20,18 +20,20 @@ class SprkTabsButton extends Component {
       tabBtnChildren,
       tabBtnId,
       tabBtnAddClasses,
+      tabBtnAdditionalClasses,
       ariaControls,
       ariaSelected,
       isActive,
       onTabClick,
       tabBtnDataId,
       tabBtnAnalytics,
+      tabBtnAnalyticsString,
     } = this.props;
     return (
       <button
         className={classnames(
           'sprk-c-Tabs__button',
-          tabBtnAddClasses,
+          tabBtnAdditionalClasses || tabBtnAddClasses,
           // eslint-disable-next-line prettier/prettier
           { 'sprk-c-Tabs__button--active': isActive },
         )}
@@ -44,7 +46,7 @@ class SprkTabsButton extends Component {
         tabIndex={isActive ? undefined : '-1'}
         ref={this.tabBtnRef}
         data-id={tabBtnDataId}
-        data-analytics={tabBtnAnalytics}
+        data-analytics={tabBtnAnalyticsString || tabBtnAnalytics}
       >
         {tabBtnChildren}
       </button>
@@ -55,12 +57,8 @@ class SprkTabsButton extends Component {
 SprkTabsButton.defaultProps = {
   isActive: false,
   isFocused: false,
-  ariaControls: '',
-  tabBtnAddClasses: '',
   ariaSelected: false,
   onTabClick: () => {},
-  tabBtnAnalytics: '',
-  tabBtnDataId: '',
 };
 
 SprkTabsButton.propTypes = {
@@ -69,11 +67,12 @@ SprkTabsButton.propTypes = {
    */
   tabBtnChildren: PropTypes.node.isRequired,
   /**
-   * Value that determines
-   * if button is active.
+   * Value that determines if button is active.
    */
   isActive: PropTypes.bool,
-  /** A unique ID for each tab button. */
+  /**
+   * A unique ID for each tab button.
+   */
   tabBtnId: PropTypes.string.isRequired,
   /**
    * Determines if tab is focused.
@@ -83,17 +82,21 @@ SprkTabsButton.propTypes = {
    * The aria ID to use for each tab panel so it corresponds to the button
    */
   ariaControls: PropTypes.string,
+  // TODO remove as part of Issue XXXX
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * tab panel.
+   * Deprecated - use `tabBtnAdditionalClasses` instead. Expects a space
+   * separated string of classes to be added to the tab panel.
    */
   tabBtnAddClasses: PropTypes.string,
+  /**
+   * Expects a space separated string of classes to be added to the
+   * tab panel.
+   */
+  tabBtnAdditionalClasses: PropTypes.string,
   /**
    * Toggles the aria selected state for accessibility.
    */
   ariaSelected: PropTypes.bool,
-  // The click handler for the Tab
   /**
    * The function that runs upon  clicking a tab.
    */
@@ -102,11 +105,16 @@ SprkTabsButton.propTypes = {
    * The id used for the data-id attribute
    */
   tabBtnDataId: PropTypes.string,
+  // TODO remove as part of Issue XXXX
   /**
-   *
-   The value used for the data-analytics attribute
+   * Deprecated - use `tabBtnAnalyticsString` instead. The value used for
+   * the data-analytics attribute
    */
   tabBtnAnalytics: PropTypes.string,
+  /**
+   * The value used for the data-analytics attribute
+   */
+  tabBtnAnalyticsString: PropTypes.string,
 };
 
 export default SprkTabsButton;

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
@@ -20,20 +20,20 @@ class SprkTabsButton extends Component {
       tabBtnChildren,
       tabBtnId,
       tabBtnAddClasses,
-      tabBtnAdditionalClasses,
+      tabBtnAdditionalClasses = tabBtnAddClasses,
       ariaControls,
       ariaSelected,
       isActive,
       onTabClick,
       tabBtnDataId,
       tabBtnAnalytics,
-      tabBtnAnalyticsString,
+      tabBtnAnalyticsString = tabBtnAnalytics,
     } = this.props;
     return (
       <button
         className={classnames(
           'sprk-c-Tabs__button',
-          tabBtnAdditionalClasses || tabBtnAddClasses,
+          tabBtnAdditionalClasses,
           // eslint-disable-next-line prettier/prettier
           { 'sprk-c-Tabs__button--active': isActive },
         )}
@@ -46,7 +46,7 @@ class SprkTabsButton extends Component {
         tabIndex={isActive ? undefined : '-1'}
         ref={this.tabBtnRef}
         data-id={tabBtnDataId}
-        data-analytics={tabBtnAnalyticsString || tabBtnAnalytics}
+        data-analytics={tabBtnAnalyticsString}
       >
         {tabBtnChildren}
       </button>
@@ -108,11 +108,11 @@ SprkTabsButton.propTypes = {
   // TODO remove as part of Issue 3566
   /**
    * Deprecated - use `tabBtnAnalyticsString` instead. The value used for
-   * the data-analytics attribute
+   * the data-analytics attribute.
    */
   tabBtnAnalytics: PropTypes.string,
   /**
-   * The value used for the data-analytics attribute
+   * The value used for the data-analytics attribute.
    */
   tabBtnAnalyticsString: PropTypes.string,
 };

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
@@ -82,7 +82,7 @@ SprkTabsButton.propTypes = {
    * The aria ID to use for each tab panel so it corresponds to the button
    */
   ariaControls: PropTypes.string,
-  // TODO remove as part of Issue XXXX
+  // TODO remove as part of Issue 3566
   /**
    * Deprecated - use `tabBtnAdditionalClasses` instead. Expects a space
    * separated string of classes to be added to the tab panel.
@@ -105,7 +105,7 @@ SprkTabsButton.propTypes = {
    * The id used for the data-id attribute
    */
   tabBtnDataId: PropTypes.string,
-  // TODO remove as part of Issue XXXX
+  // TODO remove as part of Issue 3566
   /**
    * Deprecated - use `tabBtnAnalyticsString` instead. The value used for
    * the data-analytics attribute

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
@@ -19,6 +19,7 @@ class SprkTabsButton extends Component {
     const {
       tabBtnChildren,
       tabBtnId,
+      // TODO remove as part of Issue 3566
       tabBtnAddClasses,
       tabBtnAdditionalClasses = tabBtnAddClasses,
       ariaControls,
@@ -26,17 +27,15 @@ class SprkTabsButton extends Component {
       isActive,
       onTabClick,
       tabBtnDataId,
+      // TODO remove as part of Issue 3566
       tabBtnAnalytics,
       tabBtnAnalyticsString = tabBtnAnalytics,
     } = this.props;
     return (
       <button
-        className={classnames(
-          'sprk-c-Tabs__button',
-          tabBtnAdditionalClasses,
-          // eslint-disable-next-line prettier/prettier
-          { 'sprk-c-Tabs__button--active': isActive },
-        )}
+        className={classnames('sprk-c-Tabs__button', tabBtnAdditionalClasses, {
+          'sprk-c-Tabs__button--active': isActive,
+        })}
         role="tab"
         onClick={onTabClick}
         aria-controls={ariaControls}

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.js
@@ -32,6 +32,7 @@ class SprkTabsButton extends Component {
         className={classnames(
           'sprk-c-Tabs__button',
           tabBtnAddClasses,
+          // eslint-disable-next-line prettier/prettier
           { 'sprk-c-Tabs__button--active': isActive },
         )}
         role="tab"

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
@@ -107,6 +107,24 @@ describe('SprkTabsButton:', () => {
     ).toBe(true);
   });
 
+  // TODO remove as part of Issue 3566
+  it('should add additional classes from deprecated tabBtnAddClasses', () => {
+    const wrapper = mount(
+      <SprkTabsButton tabBtnAddClasses="test">Test Content 1</SprkTabsButton>,
+    );
+    expect(wrapper.find('.sprk-c-Tabs__button.test').length).toBe(1);
+  });
+
+  it('should add additional classes from tabBtnAdditionalClasses', () => {
+    const wrapper = mount(
+      <SprkTabsButton tabBtnAdditionalClasses="test">
+        Test Content 1
+      </SprkTabsButton>,
+    );
+    expect(wrapper.find('.sprk-c-Tabs__button.test').length).toBe(1);
+  });
+
+  // TODO remove as part of Issue 3566
   it('should prefer tabBtnAdditionalClasses over tabBtnAddClasses', () => {
     const wrapper = mount(
       <SprkTabsButton tabBtnAdditionalClasses="test" tabBtnAddClasses="test2">

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
@@ -1,4 +1,4 @@
-/* global it expect describe document jest */
+/* global it expect describe document */
 import React from 'react';
 import Enzyme, { mount, shallow } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
@@ -10,12 +10,20 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('SprkTabsButton:', () => {
   it('should display a Tab Button element with the correct base class', () => {
-    const wrapper = shallow(<SprkTabsButton tabBtnChildren="Tab 1" tabBtnId="tab-22">Test Content 1</SprkTabsButton>);
+    const wrapper = shallow(
+      <SprkTabsButton tabBtnChildren="Tab 1" tabBtnId="tab-22">
+        Test Content 1
+      </SprkTabsButton>,
+    );
     expect(wrapper.find('.sprk-c-Tabs__button').length).toBe(1);
   });
 
   it('should have the active class if isActive is true', () => {
-    const wrapper = shallow(<SprkTabsButton tabBtnChildren="Tab 1" isActive tabBtnId="tab-22">Test Content 1</SprkTabsButton>);
+    const wrapper = shallow(
+      <SprkTabsButton tabBtnChildren="Tab 1" isActive tabBtnId="tab-22">
+        Test Content 1
+      </SprkTabsButton>,
+    );
     expect(wrapper.find('.sprk-c-Tabs__button--active').length).toBe(1);
   });
 
@@ -25,41 +33,80 @@ describe('SprkTabsButton:', () => {
         tabBtnChildren="Tab 1"
         isFocused={false}
         tabindex="0"
-        tabBtnId="tab-52">
-          Test Content 1
-      </SprkTabsButton>
+        tabBtnId="tab-52"
+      >
+        Test Content 1
+      </SprkTabsButton>,
     );
-    expect(document.activeElement.classList.contains('sprk-c-Tabs__button')).toBe(false);
+    expect(
+      document.activeElement.classList.contains('sprk-c-Tabs__button'),
+    ).toBe(false);
     wrapper.setProps({ isFocused: true });
-    expect(document.activeElement.classList.contains('sprk-c-Tabs__button')).toBe(true);
+    expect(
+      document.activeElement.classList.contains('sprk-c-Tabs__button'),
+    ).toBe(true);
   });
 
   it('should not focus if isFocused is updated to false', () => {
-    const wrapper = mount(<SprkTabsButton tabBtnChildren="Tab 1" isFocused tabBtnId="tab-52" tabBtnAddClasses="test">Test Content 1</SprkTabsButton>);
-    const wrapper2 = mount(<SprkTabsButton tabBtnChildren="Tab 1" tabBtnId="tab-52">Test Content 1</SprkTabsButton>);
+    const wrapper = mount(
+      <SprkTabsButton
+        tabBtnChildren="Tab 1"
+        isFocused
+        tabBtnId="tab-52"
+        tabBtnAddClasses="test"
+      >
+        Test Content 1
+      </SprkTabsButton>,
+    );
+    const wrapper2 = mount(
+      <SprkTabsButton tabBtnChildren="Tab 1" tabBtnId="tab-52">
+        Test Content 1
+      </SprkTabsButton>,
+    );
     wrapper.setProps({ isFocused: false });
     wrapper2.setProps({ isFocused: true });
     expect(document.activeElement.classList.contains('test')).toBe(false);
   });
 
   it('should add classes when tabBtnAddClasses has a value', () => {
-    const wrapper = mount(<SprkTabsButton tabBtnChildren="Tab 1" isFocused tabBtnId="tab-52" tabBtnAddClasses="test">Test Content 1</SprkTabsButton>);
+    const wrapper = mount(
+      <SprkTabsButton
+        tabBtnChildren="Tab 1"
+        isFocused
+        tabBtnId="tab-52"
+        tabBtnAddClasses="test"
+      >
+        Test Content 1
+      </SprkTabsButton>,
+    );
     wrapper.find('.sprk-c-Tabs__button').simulate('click');
     expect(wrapper.find('.sprk-c-Tabs__button.test').length).toBe(1);
   });
 
-  it('should focus the next Tab Button when the right arrow key is pressed', () => {
-    const wrapper = mount(
-      <SprkTabs>
-        <SprkTabsPanel isDefaultActive tabBtnChildren="Tab 1">Test Content 1</SprkTabsPanel>
-        <SprkTabsPanel tabBtnChildren="Tab 2">Test Content 2</SprkTabsPanel>
-      </SprkTabs>,
-    );
-    // First, tab into the Tab Button area
-    wrapper.find('div.sprk-c-Tabs__buttons').simulate('keydown', { keyCode: 9 });
-    // Second, hit the right arrow key
-    wrapper.find('div.sprk-c-Tabs__buttons').simulate('keydown', { keyCode: 39 });
-    const button = wrapper.find(SprkTabsButton).last();
-    expect(button.getDOMNode().classList.contains('sprk-c-Tabs__button--active')).toBe(true);
-  });
+  it(
+    // eslint-disable-next-line prettier/prettier
+    'should focus the next Tab Button when the right arrow key' + ' is pressed',
+    () => {
+      const wrapper = mount(
+        <SprkTabs>
+          <SprkTabsPanel isDefaultActive tabBtnChildren="Tab 1">
+            Test Content 1
+          </SprkTabsPanel>
+          <SprkTabsPanel tabBtnChildren="Tab 2">Test Content 2</SprkTabsPanel>
+        </SprkTabs>,
+      );
+      // First, tab into the Tab Button area
+      wrapper
+        .find('div.sprk-c-Tabs__buttons')
+        .simulate('keydown', { keyCode: 9 });
+      // Second, hit the right arrow key
+      wrapper
+        .find('div.sprk-c-Tabs__buttons')
+        .simulate('keydown', { keyCode: 39 });
+      const button = wrapper.find(SprkTabsButton).last();
+      expect(
+        button.getDOMNode().classList.contains('sprk-c-Tabs__button--active'),
+      ).toBe(true);
+    },
+  );
 });

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
@@ -135,6 +135,7 @@ describe('SprkTabsButton:', () => {
     expect(wrapper.find('.sprk-c-Tabs__button.test2').length).toBe(0);
   });
 
+  // TODO remove as part of Issue 3566
   it('should add data-analytics from tabBtnAnalytics', () => {
     const wrapper = mount(
       <SprkTabsButton tabBtnAnalytics="test">Test Content 1</SprkTabsButton>,
@@ -144,6 +145,18 @@ describe('SprkTabsButton:', () => {
     ).toBe(1);
   });
 
+  it('should add data-analytics from tabBtnAnalyticsString', () => {
+    const wrapper = mount(
+      <SprkTabsButton tabBtnAnalyticsString="test">
+        Test Content 1
+      </SprkTabsButton>,
+    );
+    expect(
+      wrapper.find('.sprk-c-Tabs__button[data-analytics="test"]').length,
+    ).toBe(1);
+  });
+
+  // TODO remove as part of Issue 3566
   it('should prefer tabBtnAnalyticsString over tabBtnAnalytics', () => {
     const wrapper = mount(
       <SprkTabsButton tabBtnAnalyticsString="test" tabBtnAnalytics="test2">

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
@@ -135,6 +135,15 @@ describe('SprkTabsButton:', () => {
     expect(wrapper.find('.sprk-c-Tabs__button.test2').length).toBe(0);
   });
 
+  it('should add data-analytics from tabBtnAnalytics', () => {
+    const wrapper = mount(
+      <SprkTabsButton tabBtnAnalytics="test">Test Content 1</SprkTabsButton>,
+    );
+    expect(
+      wrapper.find('.sprk-c-Tabs__button[data-analytics="test"]').length,
+    ).toBe(1);
+  });
+
   it('should prefer tabBtnAnalyticsString over tabBtnAnalytics', () => {
     const wrapper = mount(
       <SprkTabsButton tabBtnAnalyticsString="test" tabBtnAnalytics="test2">

--- a/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
+++ b/react/src/components/tabs/components/SprkTabsButton/SprkTabsButton.test.js
@@ -53,7 +53,7 @@ describe('SprkTabsButton:', () => {
         tabBtnChildren="Tab 1"
         isFocused
         tabBtnId="tab-52"
-        tabBtnAddClasses="test"
+        tabBtnAdditionalClasses="test"
       >
         Test Content 1
       </SprkTabsButton>,
@@ -68,13 +68,13 @@ describe('SprkTabsButton:', () => {
     expect(document.activeElement.classList.contains('test')).toBe(false);
   });
 
-  it('should add classes when tabBtnAddClasses has a value', () => {
+  it('should add classes when tabBtnAdditionalClasses has a value', () => {
     const wrapper = mount(
       <SprkTabsButton
         tabBtnChildren="Tab 1"
         isFocused
         tabBtnId="tab-52"
-        tabBtnAddClasses="test"
+        tabBtnAdditionalClasses="test"
       >
         Test Content 1
       </SprkTabsButton>,
@@ -83,30 +83,51 @@ describe('SprkTabsButton:', () => {
     expect(wrapper.find('.sprk-c-Tabs__button.test').length).toBe(1);
   });
 
-  it(
-    // eslint-disable-next-line prettier/prettier
-    'should focus the next Tab Button when the right arrow key' + ' is pressed',
-    () => {
-      const wrapper = mount(
-        <SprkTabs>
-          <SprkTabsPanel isDefaultActive tabBtnChildren="Tab 1">
-            Test Content 1
-          </SprkTabsPanel>
-          <SprkTabsPanel tabBtnChildren="Tab 2">Test Content 2</SprkTabsPanel>
-        </SprkTabs>,
-      );
-      // First, tab into the Tab Button area
-      wrapper
-        .find('div.sprk-c-Tabs__buttons')
-        .simulate('keydown', { keyCode: 9 });
-      // Second, hit the right arrow key
-      wrapper
-        .find('div.sprk-c-Tabs__buttons')
-        .simulate('keydown', { keyCode: 39 });
-      const button = wrapper.find(SprkTabsButton).last();
-      expect(
-        button.getDOMNode().classList.contains('sprk-c-Tabs__button--active'),
-      ).toBe(true);
-    },
-  );
+  it(`should focus the next Tab Button when the right arrow key
+  is pressed`, () => {
+    const wrapper = mount(
+      <SprkTabs>
+        <SprkTabsPanel isDefaultActive tabBtnChildren="Tab 1">
+          Test Content 1
+        </SprkTabsPanel>
+        <SprkTabsPanel tabBtnChildren="Tab 2">Test Content 2</SprkTabsPanel>
+      </SprkTabs>,
+    );
+    // First, tab into the Tab Button area
+    wrapper
+      .find('div.sprk-c-Tabs__buttons')
+      .simulate('keydown', { keyCode: 9 });
+    // Second, hit the right arrow key
+    wrapper
+      .find('div.sprk-c-Tabs__buttons')
+      .simulate('keydown', { keyCode: 39 });
+    const button = wrapper.find(SprkTabsButton).last();
+    expect(
+      button.getDOMNode().classList.contains('sprk-c-Tabs__button--active'),
+    ).toBe(true);
+  });
+
+  it('should prefer tabBtnAdditionalClasses over tabBtnAddClasses', () => {
+    const wrapper = mount(
+      <SprkTabsButton tabBtnAdditionalClasses="test" tabBtnAddClasses="test2">
+        Test Content 1
+      </SprkTabsButton>,
+    );
+    expect(wrapper.find('.sprk-c-Tabs__button.test').length).toBe(1);
+    expect(wrapper.find('.sprk-c-Tabs__button.test2').length).toBe(0);
+  });
+
+  it('should prefer tabBtnAnalyticsString over tabBtnAnalytics', () => {
+    const wrapper = mount(
+      <SprkTabsButton tabBtnAnalyticsString="test" tabBtnAnalytics="test2">
+        Test Content 1
+      </SprkTabsButton>,
+    );
+    expect(
+      wrapper.find('.sprk-c-Tabs__button[data-analytics="test"]').length,
+    ).toBe(1);
+    expect(
+      wrapper.find('.sprk-c-Tabs__button[data-analytics="test2"]').length,
+    ).toBe(0);
+  });
 });

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.js
@@ -56,7 +56,7 @@ SprkTabsPanel.propTypes = {
    * A string of additional classes to be applied to the tab panel.
    */
   tabPanelAdditionalClasses: PropTypes.string,
-  // TODO remove as part of Issue XXXX
+  // TODO remove as part of Issue 3566
   /**
    * Deprecated - use `tabBtnAnalyticsString` instead. A string of additional
    * classes to be applied to the tab panel.

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.js
@@ -10,6 +10,7 @@ class SprkTabsPanel extends Component {
       tabBtnId,
       ariaControls,
       tabPanelAddClasses,
+      tabPanelAdditionalClasses,
     } = this.props;
 
     return (
@@ -19,7 +20,7 @@ class SprkTabsPanel extends Component {
           {
             'sprk-u-Display--none': !isActive,
           },
-          tabPanelAddClasses,
+          tabPanelAdditionalClasses || tabPanelAddClasses,
         )}
         role="tabpanel"
         tabIndex="0"
@@ -40,11 +41,12 @@ SprkTabsPanel.propTypes = {
    */
   children: PropTypes.node,
   /**
-   * Value that determines
-   * if panel is active.
+   * Value that determines if panel is active.
    */
   isActive: PropTypes.bool,
-  // A unique ID for each tab button
+  /**
+   * A unique ID for each tab button
+   */
   tabBtnId: PropTypes.string,
   /**
    * The aria ID to use for each tab panel so it corresponds to the button
@@ -52,6 +54,12 @@ SprkTabsPanel.propTypes = {
   ariaControls: PropTypes.string,
   /**
    * A string of additional classes to be applied to the tab panel.
+   */
+  tabPanelAdditionalClasses: PropTypes.string,
+  // TODO remove as part of Issue XXXX
+  /**
+   * Deprecated - use `tabBtnAnalyticsString` instead. A string of additional
+   * classes to be applied to the tab panel.
    */
   tabPanelAddClasses: PropTypes.string,
 };

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.js
@@ -59,8 +59,8 @@ SprkTabsPanel.propTypes = {
   tabPanelAdditionalClasses: PropTypes.string,
   // TODO remove as part of Issue 3566
   /**
-   * Deprecated - use `tabBtnAnalyticsString` instead. A string of additional
-   * classes to be applied to the tab panel.
+   * Deprecated - use `tabPanelAdditionalClasses` instead. A string of
+   * additional classes to be applied to the tab panel.
    */
   tabPanelAddClasses: PropTypes.string,
 };

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.js
@@ -9,8 +9,9 @@ class SprkTabsPanel extends Component {
       isActive,
       tabBtnId,
       ariaControls,
+      // TODO remove as part of Issue 3566
       tabPanelAddClasses,
-      tabPanelAdditionalClasses,
+      tabPanelAdditionalClasses = tabPanelAddClasses,
     } = this.props;
 
     return (
@@ -20,7 +21,7 @@ class SprkTabsPanel extends Component {
           {
             'sprk-u-Display--none': !isActive,
           },
-          tabPanelAdditionalClasses || tabPanelAddClasses,
+          tabPanelAdditionalClasses,
         )}
         role="tabpanel"
         tabIndex="0"
@@ -45,11 +46,11 @@ SprkTabsPanel.propTypes = {
    */
   isActive: PropTypes.bool,
   /**
-   * A unique ID for each tab button
+   * A unique ID for each tab button.
    */
   tabBtnId: PropTypes.string,
   /**
-   * The aria ID to use for each tab panel so it corresponds to the button
+   * The aria ID to use for each tab panel so it corresponds to the button.
    */
   ariaControls: PropTypes.string,
   /**

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
@@ -9,27 +9,45 @@ Enzyme.configure({ adapter: new Adapter() });
 
 describe('SprkTabsPanel:', () => {
   it('should display a Tab Panel element with the correct base class', () => {
-    const wrapper = shallow(<SprkTabsPanel tabBtnChildren="Tab 1">Test Content 1</SprkTabsPanel>);
+    const wrapper = shallow(
+      <SprkTabsPanel tabBtnChildren="Tab 1">Test Content 1</SprkTabsPanel>,
+    );
     expect(wrapper.find('.sprk-c-Tabs__content').length).toBe(1);
   });
 
   it('should add classes when tabPanelAddClasses has a value', () => {
-    const wrapper = mount(<SprkTabsPanel tabBtnChildren="Tab 1" tabPanelAddClasses="test">Test Content 1</SprkTabsPanel>);
+    const wrapper = mount(
+      <SprkTabsPanel tabBtnChildren="Tab 1" tabPanelAddClasses="test">
+        Test Content 1
+      </SprkTabsPanel>,
+    );
     expect(wrapper.find('.sprk-c-Tabs__content.test').length).toBe(1);
   });
 
-  it('should focus the corresponding Tab Panel when the tab key is pressed', () => {
-    const wrapper = mount(
-      <SprkTabs>
-        <SprkTabsPanel isDefaultActive tabBtnChildren="Tab 1">Test Content 1</SprkTabsPanel>
-        <SprkTabsPanel tabBtnChildren="Tab 2">Test Content 2</SprkTabsPanel>
-      </SprkTabs>,
-    );
-    // First, tab into the Tab Button area
-    wrapper.find('div.sprk-c-Tabs__buttons').simulate('keydown', { keyCode: 9 });
-    // Second, hit the Tab key to move to the panel
-    wrapper.find('div.sprk-c-Tabs__buttons').simulate('keydown', { keyCode: 9 });
-    const panel = wrapper.find(SprkTabsPanel).first();
-    expect(panel.getDOMNode().classList.contains('sprk-u-Display--none')).toBe(false);
-  });
+  // eslint-disable-next-line prettier/prettier
+  it(
+    'should focus the corresponding Tab Panel when the tab key' + ' is pressed',
+    () => {
+      const wrapper = mount(
+        <SprkTabs>
+          <SprkTabsPanel isDefaultActive tabBtnChildren="Tab 1">
+            Test Content 1
+          </SprkTabsPanel>
+          <SprkTabsPanel tabBtnChildren="Tab 2">Test Content 2</SprkTabsPanel>
+        </SprkTabs>,
+      );
+      // First, tab into the Tab Button area
+      wrapper
+        .find('div.sprk-c-Tabs__buttons')
+        .simulate('keydown', { keyCode: 9 });
+      // Second, hit the Tab key to move to the panel
+      wrapper
+        .find('div.sprk-c-Tabs__buttons')
+        .simulate('keydown', { keyCode: 9 });
+      const panel = wrapper.find(SprkTabsPanel).first();
+      expect(
+        panel.getDOMNode().classList.contains('sprk-u-Display--none'),
+      ).toBe(false);
+    },
+  );
 });

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
@@ -15,39 +15,49 @@ describe('SprkTabsPanel:', () => {
     expect(wrapper.find('.sprk-c-Tabs__content').length).toBe(1);
   });
 
-  it('should add classes when tabPanelAddClasses has a value', () => {
+  it('should add classes when tabPanelAdditionalClasses has a value', () => {
     const wrapper = mount(
-      <SprkTabsPanel tabBtnChildren="Tab 1" tabPanelAddClasses="test">
+      <SprkTabsPanel tabBtnChildren="Tab 1" tabPanelAdditionalClasses="test">
         Test Content 1
       </SprkTabsPanel>,
     );
     expect(wrapper.find('.sprk-c-Tabs__content.test').length).toBe(1);
   });
 
-  // eslint-disable-next-line prettier/prettier
-  it(
-    'should focus the corresponding Tab Panel when the tab key' + ' is pressed',
-    () => {
-      const wrapper = mount(
-        <SprkTabs>
-          <SprkTabsPanel isDefaultActive tabBtnChildren="Tab 1">
-            Test Content 1
-          </SprkTabsPanel>
-          <SprkTabsPanel tabBtnChildren="Tab 2">Test Content 2</SprkTabsPanel>
-        </SprkTabs>,
-      );
-      // First, tab into the Tab Button area
-      wrapper
-        .find('div.sprk-c-Tabs__buttons')
-        .simulate('keydown', { keyCode: 9 });
-      // Second, hit the Tab key to move to the panel
-      wrapper
-        .find('div.sprk-c-Tabs__buttons')
-        .simulate('keydown', { keyCode: 9 });
-      const panel = wrapper.find(SprkTabsPanel).first();
-      expect(
-        panel.getDOMNode().classList.contains('sprk-u-Display--none'),
-      ).toBe(false);
-    },
-  );
+  it('should prefer tabPanelAdditionalClasses over SprkTabsPanel', () => {
+    const wrapper = mount(
+      <SprkTabsPanel
+        tabPanelAdditionalClasses="test"
+        tabPanelAddClasses="test2"
+      >
+        Test Content 1
+      </SprkTabsPanel>,
+    );
+    expect(wrapper.find('.sprk-c-Tabs__content.test').length).toBe(1);
+    expect(wrapper.find('.sprk-c-Tabs__content.test2').length).toBe(0);
+  });
+
+  it(`should focus the corresponding Tab Panel when
+    the tab key is pressed`, () => {
+    const wrapper = mount(
+      <SprkTabs>
+        <SprkTabsPanel isDefaultActive tabBtnChildren="Tab 1">
+          Test Content 1
+        </SprkTabsPanel>
+        <SprkTabsPanel tabBtnChildren="Tab 2">Test Content 2</SprkTabsPanel>
+      </SprkTabs>,
+    );
+    // First, tab into the Tab Button area
+    wrapper
+      .find('div.sprk-c-Tabs__buttons')
+      .simulate('keydown', { keyCode: 9 });
+    // Second, hit the Tab key to move to the panel
+    wrapper
+      .find('div.sprk-c-Tabs__buttons')
+      .simulate('keydown', { keyCode: 9 });
+    const panel = wrapper.find(SprkTabsPanel).first();
+    expect(panel.getDOMNode().classList.contains('sprk-u-Display--none')).toBe(
+      false,
+    );
+  });
 });

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
@@ -24,6 +24,7 @@ describe('SprkTabsPanel:', () => {
     expect(wrapper.find('.sprk-c-Tabs__content.test').length).toBe(1);
   });
 
+  // TODO remove as part of Issue 3566
   it('should add classes when tabPanelAddClasses has a value', () => {
     const wrapper = mount(
       <SprkTabsPanel tabBtnChildren="Tab 1" tabPanelAddClasses="test">
@@ -33,6 +34,7 @@ describe('SprkTabsPanel:', () => {
     expect(wrapper.find('.sprk-c-Tabs__content.test').length).toBe(1);
   });
 
+  // TODO remove as part of Issue 3566
   it('should prefer tabPanelAdditionalClasses over tabPanelAddClasses', () => {
     const wrapper = mount(
       <SprkTabsPanel

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
@@ -24,7 +24,7 @@ describe('SprkTabsPanel:', () => {
     expect(wrapper.find('.sprk-c-Tabs__content.test').length).toBe(1);
   });
 
-  it('should prefer tabPanelAdditionalClasses over SprkTabsPanel', () => {
+  it('should prefer tabPanelAdditionalClasses over tabPanelAddClasses', () => {
     const wrapper = mount(
       <SprkTabsPanel
         tabPanelAdditionalClasses="test"

--- a/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
+++ b/react/src/components/tabs/components/SprkTabsPanel/SprkTabsPanel.test.js
@@ -24,6 +24,15 @@ describe('SprkTabsPanel:', () => {
     expect(wrapper.find('.sprk-c-Tabs__content.test').length).toBe(1);
   });
 
+  it('should add classes when tabPanelAddClasses has a value', () => {
+    const wrapper = mount(
+      <SprkTabsPanel tabBtnChildren="Tab 1" tabPanelAddClasses="test">
+        Test Content 1
+      </SprkTabsPanel>,
+    );
+    expect(wrapper.find('.sprk-c-Tabs__content.test').length).toBe(1);
+  });
+
   it('should prefer tabPanelAdditionalClasses over tabPanelAddClasses', () => {
     const wrapper = mount(
       <SprkTabsPanel

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -87,7 +87,7 @@ describe('SprkToggle:', () => {
     expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
   });
 
-  it(`should add aria-controls="custom_control" and id="custom_control" 
+  it(`should add aria-controls="custom_control" and id="custom_control"
     when the contentId is passed`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" contentId="custom_control">
@@ -113,7 +113,7 @@ describe('SprkToggle:', () => {
     expect(wrapper.find(`div#${toggleContentId}`).length).toBe(1);
   });
 
-  it(`should add classes to the content if contentAdditionalClasses 
+  it(`should add classes to the content if contentAdditionalClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" contentAdditionalClasses="test">
@@ -124,7 +124,7 @@ describe('SprkToggle:', () => {
     expect(toggleContent.hasClass('test')).toBe(true);
   });
 
-  it(`should add classes to the icon if iconAdditionalClasses 
+  it(`should add classes to the icon if iconAdditionalClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" iconAdditionalClasses="test">
@@ -135,7 +135,7 @@ describe('SprkToggle:', () => {
     expect(toggleIcon.hasClass('test')).toBe(true);
   });
 
-  it(`should add classes to the icon if iconAddClasses 
+  it(`should add classes to the icon if iconAddClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" iconAddClasses="test">
@@ -162,7 +162,7 @@ describe('SprkToggle:', () => {
     expect(toggleIcon.hasClass('test')).toBe(false);
   });
 
-  it(`should add classes to the title if titleAdditionalClasses 
+  it(`should add classes to the title if titleAdditionalClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" titleAdditionalClasses="test">
@@ -173,7 +173,7 @@ describe('SprkToggle:', () => {
     expect(toggleTitle.hasClass('test')).toBe(true);
   });
 
-  it(`should add classes to the title if titleAddClasses 
+  it(`should add classes to the title if titleAddClasses
   are set`, () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title" titleAddClasses="test">
@@ -184,7 +184,7 @@ describe('SprkToggle:', () => {
     expect(toggleTitle.hasClass('test')).toBe(true);
   });
 
-  it(`should prefer titleAdditionalClasses to titleAddClasses if both 
+  it(`should prefer titleAdditionalClasses to titleAddClasses if both
   are set`, () => {
     const wrapper = mount(
       <SprkToggle
@@ -198,5 +198,23 @@ describe('SprkToggle:', () => {
     const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
     expect(toggleTitle.hasClass('newTest')).toBe(true);
     expect(toggleTitle.hasClass('test')).toBe(false);
+  });
+
+  it(`should add title (deprecated)`, () => {
+    const wrapper = mount(
+      <SprkToggle title="Toggle title">Body text</SprkToggle>,
+    );
+    const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
+    expect(toggleTitle.text()).toEqual('Toggle title');
+  });
+
+  it(`should prefer triggerText over title`, () => {
+    const wrapper = mount(
+      <SprkToggle triggerText="Toggle title" title="old title">
+        Body text
+      </SprkToggle>,
+    );
+    const toggleTitle = wrapper.find('.sprk-c-Toggle__trigger');
+    expect(toggleTitle.text()).toEqual('Toggle title');
   });
 });


### PR DESCRIPTION
## What does this PR do?
- Deprecate `tabBtnAddClasses` and replace with `tabBtnAdditionalClasses`.
- Deprecate `tabBtnAnalytics` and replace with `tabBtnAnalyticsString`.
- Deprecate `tabPanelAddClasses` and replace with `tabPanelAdditionalClasses`.ses
- remove empty default props (Main and in sub components)

### Associated Issue
Fixes #3297 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)