### PR TITLE
Toggle Updates - Angular

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -180,16 +180,16 @@ describe('SprkToggleComponent', () => {
     );
   });
 
-  it('should add the correct classes if triggerTextAdditionalClasses is set', () => {
-    component.triggerTextAdditionalClasses = 'test-1 test-2';
+  it('should add the correct classes if titleAdditionalClasses is set', () => {
+    component.titleAdditionalClasses = 'test-1 test-2';
     fixture.detectChanges();
     expect(triggerElement.classList.toString()).toContain(
       'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
     );
   });
 
-  it('should prefer triggerTextAdditionalClasses over titleFontClass if both are set', () => {
-    component.triggerTextAdditionalClasses = 'test-1 test-2';
+  it('should prefer titleAdditionalClasses over titleFontClass if both are set', () => {
+    component.titleAdditionalClasses = 'test-1 test-2';
     component.titleFontClass = 'test-3 test-4';
     fixture.detectChanges();
     expect(triggerElement.classList.toString()).toContain(

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -161,4 +161,29 @@ describe('SprkToggleComponent', () => {
       element.querySelector('.sprk-c-Toggle__content').classList.toString(),
     ).toContain('sprk-u-pts sprk-u-pbs sprk-c-Toggle__content test-1 test-2');
   });
+
+  it('should add the correct classes if titleFontClass is set', () => {
+    component.titleFontClass = 'test-1 test-2';
+    fixture.detectChanges();
+    expect(triggerElement.classList.toString()).toContain(
+      'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
+    );
+  });
+
+  it('should add the correct classes if triggerTextAdditionalClasses is set', () => {
+    component.triggerTextAdditionalClasses = 'test-1 test-2';
+    fixture.detectChanges();
+    expect(triggerElement.classList.toString()).toContain(
+      'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
+    );
+  });
+
+  it('should prefer triggerTextAdditionalClasses over titleFontClass if both are set', () => {
+    component.triggerTextAdditionalClasses = 'test-1 test-2';
+    component.titleFontClass = 'test-3 test-4';
+    fixture.detectChanges();
+    expect(triggerElement.classList.toString()).toContain(
+      'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
+    );
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -153,4 +153,12 @@ describe('SprkToggleComponent', () => {
     fixture.detectChanges();
     expect(triggerElement.innerHTML).toContain('Test Title');
   });
+
+  it('should add the correct classes if contentAdditionalClasses is set', () => {
+    component.contentAdditionalClasses = 'test-1 test-2';
+    fixture.detectChanges();
+    expect(
+      element.querySelector('.sprk-c-Toggle__content').classList.toString(),
+    ).toContain('sprk-u-pts sprk-u-pbs sprk-c-Toggle__content test-1 test-2');
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -197,12 +197,12 @@ describe('SprkToggleComponent', () => {
     );
   });
 
-  it('should use correct iconName if it is set', () => {
+  it('should use correct toggleIconName if it is set', () => {
     fixture.detectChanges();
     expect(element.querySelector('use').getAttribute('xlink:href')).toEqual(
       '#chevron-down-circle',
     );
-    component.iconName = 'exclamation';
+    component.toggleIconName = 'exclamation';
     fixture.detectChanges();
     expect(element.querySelector('use').getAttribute('xlink:href')).toEqual(
       '#exclamation',

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -198,4 +198,25 @@ describe('SprkToggleComponent', () => {
       '#exclamation',
     );
   });
+
+  it('should emit open and closed events when toggled', (done) => {
+    let openEventEmitted = false;
+    let closedEventEmitted = false;
+
+    component.openedEvent.subscribe((g) => {
+      openEventEmitted = true;
+      done();
+    });
+    component.closedEvent.subscribe((g) => {
+      closedEventEmitted = true;
+      done();
+    });
+
+    element.querySelector('button').click();
+    expect(openEventEmitted).toEqual(true);
+    expect(closedEventEmitted).toEqual(false);
+
+    element.querySelector('button').click();
+    expect(closedEventEmitted).toEqual(true);
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -46,7 +46,7 @@ describe('SprkToggleComponent', () => {
   });
 
   it('should add icon classes to icon when toggle is opened', () => {
-    component.title = 'placeholder';
+    component.triggerText = 'placeholder';
     element.querySelector('button').click();
     fixture.detectChanges();
     expect(
@@ -57,7 +57,7 @@ describe('SprkToggleComponent', () => {
   });
 
   it('should add icon classes to icon when the toggle is opened and then closed', () => {
-    component.title = 'placeholder';
+    component.triggerText = 'placeholder';
     element.querySelector('button').click();
     element.querySelector('button').click();
     fixture.detectChanges();
@@ -133,5 +133,24 @@ describe('SprkToggleComponent', () => {
     expect(triggerElement.getAttribute('aria-controls')).toEqual(
       contentElement.getAttribute('id'),
     );
+  });
+
+  it('should add the correct title when set', () => {
+    component.title = 'Test Title';
+    fixture.detectChanges();
+    expect(triggerElement.innerHTML).toContain('Test Title');
+  });
+
+  it('should add the correct triggerText when set', () => {
+    component.triggerText = 'Test Title';
+    fixture.detectChanges();
+    expect(triggerElement.innerHTML).toContain('Test Title');
+  });
+
+  it('should prefer triggerText over title if both are set', () => {
+    component.triggerText = 'Test Title';
+    component.title = 'Should not be the title';
+    fixture.detectChanges();
+    expect(triggerElement.innerHTML).toContain('Test Title');
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -186,4 +186,16 @@ describe('SprkToggleComponent', () => {
       'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
     );
   });
+
+  it('should use correct iconName if it is set', () => {
+    fixture.detectChanges();
+    expect(element.querySelector('use').getAttribute('xlink:href')).toEqual(
+      '#chevron-down-circle',
+    );
+    component.iconName = 'exclamation';
+    fixture.detectChanges();
+    expect(element.querySelector('use').getAttribute('xlink:href')).toEqual(
+      '#exclamation',
+    );
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -189,8 +189,8 @@ describe('SprkToggleComponent', () => {
     );
   });
 
-  it('should add the correct classes if titleAdditionalClasses is set', () => {
-    component.titleAdditionalClasses = 'test-1 test-2';
+  it('should add the correct classes if triggerTextAdditionalClasses is set', () => {
+    component.triggerTextAdditionalClasses = 'test-1 test-2';
     fixture.detectChanges();
     expect(triggerElement.classList.toString()).toContain(
       'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
@@ -198,8 +198,8 @@ describe('SprkToggleComponent', () => {
   });
 
   // TODO: Remove `titleFontClass` in issue #1305
-  it('should prefer titleAdditionalClasses over titleFontClass if both are set', () => {
-    component.titleAdditionalClasses = 'test-1 test-2';
+  it('should prefer triggerTextAdditionalClasses over titleFontClass if both are set', () => {
+    component.triggerTextAdditionalClasses = 'test-1 test-2';
     component.titleFontClass = 'test-3 test-4';
     fixture.detectChanges();
     expect(triggerElement.classList.toString()).toContain(

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -66,6 +66,16 @@ describe('SprkToggleComponent', () => {
     ).toEqual('sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle');
   });
 
+  it('should render open if isOpen is set to true', () => {
+    component.isOpen = true;
+    fixture.detectChanges();
+    expect(
+      element.querySelector('button .sprk-c-Icon').classList.toString(),
+    ).toEqual(
+      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle sprk-c-Icon--open',
+    );
+  });
+
   it('should add the correct classes if iconClass have values', () => {
     component.iconClass = 'test';
     fixture.detectChanges();

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -14,11 +14,7 @@ describe('SprkToggleComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
       imports: [BrowserAnimationsModule],
-      declarations: [
-        SprkToggleComponent,
-        SprkIconComponent,
-        SprkLinkDirective
-      ]
+      declarations: [SprkToggleComponent, SprkIconComponent, SprkLinkDirective],
     }).compileComponents();
   }));
 
@@ -44,9 +40,9 @@ describe('SprkToggleComponent', () => {
     const str = 'One';
     component.analyticsString = str;
     fixture.detectChanges();
-    expect(element.querySelector('button').getAttribute('data-analytics')).toEqual(
-      str
-    );
+    expect(
+      element.querySelector('button').getAttribute('data-analytics'),
+    ).toEqual(str);
   });
 
   it('should add icon classes to icon when toggle is opened', () => {
@@ -54,9 +50,9 @@ describe('SprkToggleComponent', () => {
     element.querySelector('button').click();
     fixture.detectChanges();
     expect(
-      element.querySelector('button .sprk-c-Icon').classList.toString()
+      element.querySelector('button .sprk-c-Icon').classList.toString(),
     ).toEqual(
-      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle sprk-c-Icon--open'
+      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle sprk-c-Icon--open',
     );
   });
 
@@ -66,15 +62,46 @@ describe('SprkToggleComponent', () => {
     element.querySelector('button').click();
     fixture.detectChanges();
     expect(
-      element.querySelector('button .sprk-c-Icon').classList.toString()
+      element.querySelector('button .sprk-c-Icon').classList.toString(),
     ).toEqual('sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle');
+  });
+
+  it('should add the correct classes if iconClass have values', () => {
+    component.iconClass = 'test';
+    fixture.detectChanges();
+    expect(
+      element.querySelector('button .sprk-c-Icon').classList.toString(),
+    ).toEqual(
+      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle test',
+    );
+  });
+
+  it('should add the correct classes if iconAdditionalClasses have values', () => {
+    component.iconAdditionalClasses = 'test';
+    fixture.detectChanges();
+    expect(
+      element.querySelector('button .sprk-c-Icon').classList.toString(),
+    ).toEqual(
+      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle test',
+    );
+  });
+
+  it('should prefer iconAdditionalClasses if both iconClass and iconAdditionalClasses are set', () => {
+    component.iconAdditionalClasses = 'should-add';
+    component.iconClass = 'should-not-add';
+    fixture.detectChanges();
+    expect(
+      element.querySelector('button .sprk-c-Icon').classList.toString(),
+    ).toEqual(
+      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle should-add',
+    );
   });
 
   it('should add the correct classes if additionalClasses have values', () => {
     component.additionalClasses = 'sprk-u-pam sprk-u-man';
     fixture.detectChanges();
     expect(element.classList.toString()).toEqual(
-      'sprk-c-Toggle sprk-u-pam sprk-u-man'
+      'sprk-c-Toggle sprk-u-pam sprk-u-man',
     );
   });
 
@@ -94,13 +121,17 @@ describe('SprkToggleComponent', () => {
   it('should add aria-controls and id if contentId is not passed', () => {
     fixture.detectChanges();
     expect(contentElement.getAttribute('id')).toMatch(/sprk_toggle_content_\d/);
-    expect(triggerElement.getAttribute('aria-controls')).toEqual(contentElement.getAttribute('id'));
+    expect(triggerElement.getAttribute('aria-controls')).toEqual(
+      contentElement.getAttribute('id'),
+    );
   });
 
   it('should add correct aria-controls and id if contentId is passed', () => {
     component.contentId = 'test_id';
     fixture.detectChanges();
     expect(contentElement.getAttribute('id')).toEqual('test_id');
-    expect(triggerElement.getAttribute('aria-controls')).toEqual(contentElement.getAttribute('id'));
+    expect(triggerElement.getAttribute('aria-controls')).toEqual(
+      contentElement.getAttribute('id'),
+    );
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -74,6 +74,10 @@ describe('SprkToggleComponent', () => {
     ).toEqual(
       'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle sprk-c-Icon--open',
     );
+    expect(contentElement.getAttribute('style')).toContain(
+      'visibility:visible',
+    );
+    expect(triggerElement.getAttribute('aria-expanded')).toEqual('true');
   });
 
   // TODO: Remove `iconClass` in issue #1305

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -76,6 +76,7 @@ describe('SprkToggleComponent', () => {
     );
   });
 
+  // TODO: Remove `iconClass` in issue #1305
   it('should add the correct classes if iconClass have values', () => {
     component.iconClass = 'test';
     fixture.detectChanges();
@@ -96,6 +97,7 @@ describe('SprkToggleComponent', () => {
     );
   });
 
+  // TODO: Remove `iconClass` in issue #1305
   it('should prefer iconAdditionalClasses if both iconClass and iconAdditionalClasses are set', () => {
     component.iconAdditionalClasses = 'should-add';
     component.iconClass = 'should-not-add';
@@ -145,6 +147,7 @@ describe('SprkToggleComponent', () => {
     );
   });
 
+  // TODO: Remove `title` in issue #1305
   it('should add the correct title when set', () => {
     component.title = 'Test Title';
     fixture.detectChanges();
@@ -157,6 +160,7 @@ describe('SprkToggleComponent', () => {
     expect(triggerElement.innerHTML).toContain('Test Title');
   });
 
+  // TODO: Remove `title` in issue #1305
   it('should prefer triggerText over title if both are set', () => {
     component.triggerText = 'Test Title';
     component.title = 'Should not be the title';
@@ -172,6 +176,7 @@ describe('SprkToggleComponent', () => {
     ).toContain('sprk-u-pts sprk-u-pbs sprk-c-Toggle__content test-1 test-2');
   });
 
+  // TODO: Remove `titleFontClass` in issue #1305
   it('should add the correct classes if titleFontClass is set', () => {
     component.titleFontClass = 'test-1 test-2';
     fixture.detectChanges();
@@ -188,6 +193,7 @@ describe('SprkToggleComponent', () => {
     );
   });
 
+  // TODO: Remove `titleFontClass` in issue #1305
   it('should prefer titleAdditionalClasses over titleFontClass if both are set', () => {
     component.titleAdditionalClasses = 'test-1 test-2';
     component.titleFontClass = 'test-3 test-4';

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -75,9 +75,9 @@ export class SprkToggleComponent implements AfterContentInit {
   // TODO: Remove `iconClass` in issue #issueNumber
   /**
    * Deprecated - Use `iconAdditionalClasses` instead.
-   * The value supplied will be assigned as a
-   * CSS class on the icon used in the Toggle.
-   * This is intended for overrides.
+   * Expects a space separated string
+   * of classes to be added to the
+   * icon.
    */
   @Input()
   iconClass: string;
@@ -106,9 +106,9 @@ export class SprkToggleComponent implements AfterContentInit {
   // TODO: Remove `titleFontClass` in future issue #issueNumber.
   /**
    * Deprecated - Use `titleAdditionalClasses` instead.
-   * The value supplied will be assigned as a CSS class
-   * on the clickable title text used in the Toggle.
-   * This is intended for overrides.
+   * Expects a space separated string
+   * of classes to be added to the
+   * trigger text.
    */
   @Input()
   titleFontClass = 'sprk-b-TypeBodyThree';

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -89,13 +89,24 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   @Input()
   contentAdditionalClasses: string;
+  // TODO: Remove `titleFontClass` in future issue #issueNumber.
   /**
+   * Deprecated - Use `triggerTextAdditionalClasses` instead.
    * The value supplied will be assigned as a CSS class
    * on the clickable title text used in the Toggle.
    * This is intended for overrides.
    */
   @Input()
   titleFontClass = 'sprk-b-TypeBodyThree';
+  // TODO: Move the default value from titleFontClass to
+  // triggerTextAdditionalClasses in future issue #issueNumber.
+  /**
+   * Expects a space separated string
+   * of classes to be added to the
+   * trigger text.
+   */
+  @Input()
+  triggerTextAdditionalClasses: string;
   /**
    * The value supplied will be assigned
    * to the `data-id` attribute on the
@@ -151,10 +162,13 @@ export class SprkToggleComponent implements AfterViewInit {
   /**
    * @ignore
    */
+  // TODO: Remove `titleFontClass` in future issue #issueNumber.
   getClasses(): string {
+    const additionalClasses =
+      this.triggerTextAdditionalClasses || this.titleFontClass;
     const classArray: string[] = [
       'sprk-c-Toggle__trigger sprk-u-TextCrop--none',
-      this.titleFontClass,
+      additionalClasses,
     ];
     return classArray.join(' ');
   }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -21,7 +21,7 @@ import 'focus-visible';
         type="button"
       >
         <sprk-icon
-          iconType="chevron-down-circle"
+          [iconName]="iconName"
           [additionalClasses]="getIconClasses()"
         ></sprk-icon>
         {{ triggerText || title }}
@@ -82,6 +82,14 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   @Input()
   iconAdditionalClasses: string;
+  /**
+   * Determines which icon is rendered.
+   * Expects the value to match the exact name
+   * of the icon found in the docs
+   * (i.e. `chevron-down`, instead of `chevron down`).
+   */
+  @Input()
+  iconName = 'chevron-down-circle';
   /**
    * Expects a space separated string
    * of classes to be added to the

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -3,6 +3,7 @@ import { toggleAnimations } from './sprk-toggle-animations';
 import { uniqueId } from 'lodash';
 import 'focus-visible';
 
+// TODO: Remove `title` in issue #issueNumber
 @Component({
   selector: 'sprk-toggle',
   template: `
@@ -23,7 +24,7 @@ import 'focus-visible';
           iconType="chevron-down-circle"
           [additionalClasses]="getIconClasses()"
         ></sprk-icon>
-        {{ title }}
+        {{ triggerText || title }}
       </button>
 
       <div [@toggleContent]="animState" [id]="contentId">
@@ -51,12 +52,21 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   @Input()
   additionalClasses: string;
+  // TODO: Remove `title` in issue #issueNumber
   /**
+   * Deprecated - Use `triggerText` instead.
    * The value supplied will be
    * rendered as the main Toggle link text.
    */
   @Input()
   title: string;
+  /**
+   * The value supplied will be
+   * rendered as the main Toggle link text.
+   */
+  @Input()
+  triggerText: string;
+  // TODO: Remove `iconClass` in issue #issueNumber
   /**
    * Deprecated - Use `iconAdditionalClasses` instead.
    * The value supplied will be assigned as a
@@ -146,6 +156,7 @@ export class SprkToggleComponent implements AfterViewInit {
    * @ignore
    */
   getIconClasses(): string {
+    // TODO: Remove `iconClass` in issue #issueNumber
     const additionalClasses = this.iconAdditionalClasses || this.iconClass;
     const classArray: string[] = [
       'sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle',

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -21,11 +21,7 @@ import 'focus-visible';
       >
         <sprk-icon
           iconType="chevron-down-circle"
-          additionalClasses="{{
-            iconClass
-          }} sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle {{
-            iconStateClass
-          }}"
+          [additionalClasses]="getIconClasses()"
         ></sprk-icon>
         {{ title }}
       </button>
@@ -62,12 +58,20 @@ export class SprkToggleComponent implements AfterViewInit {
   @Input()
   title: string;
   /**
+   * Deprecated - Use `iconAdditionalClasses` instead.
    * The value supplied will be assigned as a
    * CSS class on the icon used in the Toggle.
    * This is intended for overrides.
    */
   @Input()
   iconClass: string;
+  /**
+   * Expects a space separated string
+   * of classes to be added to the
+   * icon.
+   */
+  @Input()
+  iconAdditionalClasses: string;
   /**
    * The value supplied will be assigned as a CSS class
    * on the clickable title text used in the Toggle.
@@ -135,6 +139,23 @@ export class SprkToggleComponent implements AfterViewInit {
       'sprk-c-Toggle__trigger sprk-u-TextCrop--none',
       this.titleFontClass,
     ];
+    return classArray.join(' ');
+  }
+
+  /**
+   * @ignore
+   */
+  getIconClasses(): string {
+    const additionalClasses = this.iconAdditionalClasses || this.iconClass;
+    const classArray: string[] = [
+      'sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle',
+      this.iconStateClass,
+    ];
+    if (additionalClasses) {
+      additionalClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    }
     return classArray.join(' ');
   }
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -17,30 +17,29 @@ import 'focus-visible';
         [attr.aria-expanded]="isOpen ? 'true' : 'false'"
         [attr.data-analytics]="analyticsString"
         [attr.aria-controls]="contentId"
+        type="button"
       >
         <sprk-icon
           iconType="chevron-down-circle"
           additionalClasses="{{
             iconClass
-          }} sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle {{ iconStateClass }}"
+          }} sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle {{
+            iconStateClass
+          }}"
         ></sprk-icon>
         {{ title }}
       </button>
 
-      <div
-        [@toggleContent]="animState"
-        [id]="contentId"
-      >
+      <div [@toggleContent]="animState" [id]="contentId">
         <div class="sprk-u-pts sprk-u-pbs sprk-c-Toggle__content">
           <ng-content></ng-content>
         </div>
       </div>
     </div>
   `,
-  animations: [toggleAnimations.toggleContent]
+  animations: [toggleAnimations.toggleContent],
 })
 export class SprkToggleComponent implements AfterViewInit {
-
   /**
    * The value supplied will be assigned to the
    * `data-analytics` attribute on the component.

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -28,7 +28,7 @@ import 'focus-visible';
       </button>
 
       <div [@toggleContent]="animState" [id]="contentId">
-        <div class="sprk-u-pts sprk-u-pbs sprk-c-Toggle__content">
+        <div [ngClass]="getContentClasses()">
           <ng-content></ng-content>
         </div>
       </div>
@@ -82,6 +82,13 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   @Input()
   iconAdditionalClasses: string;
+  /**
+   * Expects a space separated string
+   * of classes to be added to the
+   * content.
+   */
+  @Input()
+  contentAdditionalClasses: string;
   /**
    * The value supplied will be assigned as a CSS class
    * on the clickable title text used in the Toggle.
@@ -164,6 +171,21 @@ export class SprkToggleComponent implements AfterViewInit {
     ];
     if (additionalClasses) {
       additionalClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    }
+    return classArray.join(' ');
+  }
+
+  /**
+   * @ignore
+   */
+  getContentClasses(): string {
+    const classArray: string[] = [
+      'sprk-u-pts sprk-u-pbs sprk-c-Toggle__content',
+    ];
+    if (this.contentAdditionalClasses) {
+      this.contentAdditionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,7 +1,7 @@
 import {
   Component,
   Input,
-  AfterViewInit,
+  AfterContentInit,
   Output,
   EventEmitter,
 } from '@angular/core';
@@ -42,7 +42,7 @@ import 'focus-visible';
   `,
   animations: [toggleAnimations.toggleContent],
 })
-export class SprkToggleComponent implements AfterViewInit {
+export class SprkToggleComponent implements AfterContentInit {
   /**
    * The value supplied will be assigned to the
    * `data-analytics` attribute on the component.
@@ -236,7 +236,7 @@ export class SprkToggleComponent implements AfterViewInit {
     return classArray.join(' ');
   }
 
-  ngAfterViewInit() {
+  ngAfterContentInit() {
     this.toggleState();
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -27,7 +27,7 @@ import 'focus-visible';
         type="button"
       >
         <sprk-icon
-          [iconName]="iconName"
+          [iconName]="toggleIconName"
           [additionalClasses]="getIconClasses()"
         ></sprk-icon>
         {{ triggerText || title }}
@@ -95,7 +95,7 @@ export class SprkToggleComponent implements AfterContentInit {
    * (i.e. `chevron-down`, instead of `chevron down`).
    */
   @Input()
-  iconName = 'chevron-down-circle';
+  toggleIconName = 'chevron-down-circle';
   /**
    * Expects a space separated string
    * of classes to be added to the

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -9,7 +9,7 @@ import { toggleAnimations } from './sprk-toggle-animations';
 import { uniqueId } from 'lodash';
 import 'focus-visible';
 
-// TODO: Remove `title` in issue #issueNumber
+// TODO: Remove `title` in issue #1305
 @Component({
   selector: 'sprk-toggle',
   template: `
@@ -58,7 +58,7 @@ export class SprkToggleComponent implements AfterContentInit {
    */
   @Input()
   additionalClasses: string;
-  // TODO: Remove `title` in issue #issueNumber
+  // TODO: Remove `title` in issue #1305
   /**
    * Deprecated - Use `triggerText` instead.
    * The value supplied will be
@@ -72,7 +72,7 @@ export class SprkToggleComponent implements AfterContentInit {
    */
   @Input()
   triggerText: string;
-  // TODO: Remove `iconClass` in issue #issueNumber
+  // TODO: Remove `iconClass` in issue #1305
   /**
    * Deprecated - Use `iconAdditionalClasses` instead.
    * Expects a space separated string
@@ -103,7 +103,7 @@ export class SprkToggleComponent implements AfterContentInit {
    */
   @Input()
   contentAdditionalClasses: string;
-  // TODO: Remove `titleFontClass` in future issue #issueNumber.
+  // TODO: Remove `titleFontClass` in future issue #1305.
   /**
    * Deprecated - Use `titleAdditionalClasses` instead.
    * Expects a space separated string
@@ -113,7 +113,7 @@ export class SprkToggleComponent implements AfterContentInit {
   @Input()
   titleFontClass = 'sprk-b-TypeBodyThree';
   // TODO: Move the default value from titleFontClass to
-  // titleAdditionalClasses in future issue #issueNumber.
+  // titleAdditionalClasses in future issue #1305.
   /**
    * Expects a space separated string
    * of classes to be added to the
@@ -192,7 +192,7 @@ export class SprkToggleComponent implements AfterContentInit {
   /**
    * @ignore
    */
-  // TODO: Remove `titleFontClass` in future issue #issueNumber.
+  // TODO: Remove `titleFontClass` in future issue #1305.
   getClasses(): string {
     const additionalClasses =
       this.titleAdditionalClasses || this.titleFontClass;
@@ -207,7 +207,7 @@ export class SprkToggleComponent implements AfterContentInit {
    * @ignore
    */
   getIconClasses(): string {
-    // TODO: Remove `iconClass` in issue #issueNumber
+    // TODO: Remove `iconClass` in issue #1305
     const additionalClasses = this.iconAdditionalClasses || this.iconClass;
     const classArray: string[] = [
       'sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle',

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -68,7 +68,7 @@ export class SprkToggleComponent implements AfterContentInit {
   title: string;
   /**
    * The value supplied will be
-   * rendered as the main Toggle link text.
+   * rendered as the main Toggle button text.
    */
   @Input()
   triggerText: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -105,7 +105,7 @@ export class SprkToggleComponent implements AfterContentInit {
   contentAdditionalClasses: string;
   // TODO: Remove `titleFontClass` in future issue #issueNumber.
   /**
-   * Deprecated - Use `triggerTextAdditionalClasses` instead.
+   * Deprecated - Use `titleAdditionalClasses` instead.
    * The value supplied will be assigned as a CSS class
    * on the clickable title text used in the Toggle.
    * This is intended for overrides.
@@ -113,14 +113,14 @@ export class SprkToggleComponent implements AfterContentInit {
   @Input()
   titleFontClass = 'sprk-b-TypeBodyThree';
   // TODO: Move the default value from titleFontClass to
-  // triggerTextAdditionalClasses in future issue #issueNumber.
+  // titleAdditionalClasses in future issue #issueNumber.
   /**
    * Expects a space separated string
    * of classes to be added to the
    * trigger text.
    */
   @Input()
-  triggerTextAdditionalClasses: string;
+  titleAdditionalClasses: string;
   /**
    * The value supplied will be assigned
    * to the `data-id` attribute on the
@@ -195,7 +195,7 @@ export class SprkToggleComponent implements AfterContentInit {
   // TODO: Remove `titleFontClass` in future issue #issueNumber.
   getClasses(): string {
     const additionalClasses =
-      this.triggerTextAdditionalClasses || this.titleFontClass;
+      this.titleAdditionalClasses || this.titleFontClass;
     const classArray: string[] = [
       'sprk-c-Toggle__trigger sprk-u-TextCrop--none',
       additionalClasses,

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -147,11 +147,12 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   @Output()
   closedEvent = new EventEmitter<any>();
-
   /**
-   * @ignore
+   * If `true`, the Toggle will be open when rendered.
    */
-  public isOpen = false;
+  @Input()
+  isOpen = false;
+
   /**
    * @ignore
    */
@@ -165,13 +166,13 @@ export class SprkToggleComponent implements AfterViewInit {
    * @ignore
    */
   toggleState(): void {
-    this.isOpen === false
-      ? (this.animState = 'closed')
-      : (this.animState = 'open');
-
-    this.isOpen === false
-      ? (this.iconStateClass = '')
-      : (this.iconStateClass = 'sprk-c-Icon--open');
+    if (this.isOpen) {
+      this.animState = 'open';
+      this.iconStateClass = 'sprk-c-Icon--open';
+    } else {
+      this.animState = 'closed';
+      this.iconStateClass = '';
+    }
   }
 
   /**

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -105,7 +105,7 @@ export class SprkToggleComponent implements AfterContentInit {
   contentAdditionalClasses: string;
   // TODO: Remove `titleFontClass` in future issue #1305.
   /**
-   * Deprecated - Use `titleAdditionalClasses` instead.
+   * Deprecated - Use `triggerTextAdditionalClasses` instead.
    * Expects a space separated string
    * of classes to be added to the
    * trigger text.
@@ -113,14 +113,14 @@ export class SprkToggleComponent implements AfterContentInit {
   @Input()
   titleFontClass = 'sprk-b-TypeBodyThree';
   // TODO: Move the default value from titleFontClass to
-  // titleAdditionalClasses in future issue #1305.
+  // triggerTextAdditionalClasses in future issue #1305.
   /**
    * Expects a space separated string
    * of classes to be added to the
    * trigger text.
    */
   @Input()
-  titleAdditionalClasses: string;
+  triggerTextAdditionalClasses: string;
   /**
    * The value supplied will be assigned
    * to the `data-id` attribute on the
@@ -195,7 +195,7 @@ export class SprkToggleComponent implements AfterContentInit {
   // TODO: Remove `titleFontClass` in future issue #1305.
   getClasses(): string {
     const additionalClasses =
-      this.titleAdditionalClasses || this.titleFontClass;
+      this.triggerTextAdditionalClasses || this.titleFontClass;
     const classArray: string[] = [
       'sprk-c-Toggle__trigger sprk-u-TextCrop--none',
       additionalClasses,

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input, AfterViewInit } from '@angular/core';
+import {
+  Component,
+  Input,
+  AfterViewInit,
+  Output,
+  EventEmitter,
+} from '@angular/core';
 import { toggleAnimations } from './sprk-toggle-animations';
 import { uniqueId } from 'lodash';
 import 'focus-visible';
@@ -131,6 +137,16 @@ export class SprkToggleComponent implements AfterViewInit {
    */
   @Input()
   contentId = uniqueId(`sprk_toggle_content_`);
+  /**
+   * When the toggle is opened this event will be emitted.
+   */
+  @Output()
+  openedEvent = new EventEmitter<any>();
+  /**
+   * When the toggle is closed this event will be emitted.
+   */
+  @Output()
+  closedEvent = new EventEmitter<any>();
 
   /**
    * @ignore
@@ -164,6 +180,11 @@ export class SprkToggleComponent implements AfterViewInit {
   toggle(event): void {
     event.preventDefault();
     this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.openedEvent.emit();
+    } else {
+      this.closedEvent.emit();
+    }
     this.toggleState();
   }
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -62,7 +62,7 @@ export class SprkToggleComponent implements AfterContentInit {
   /**
    * Deprecated - Use `triggerText` instead.
    * The value supplied will be
-   * rendered as the main Toggle link text.
+   * rendered as the main Toggle button text.
    */
   @Input()
   title: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.stories.ts
@@ -9,10 +9,8 @@ export default {
   component: SprkToggleComponent,
   decorators: [
     storyWrapper(
-      storyContent => (
-        `<div class="sprk-o-Box">${ storyContent }<div>`
-      )
-    )
+      (storyContent) => `<div class="sprk-o-Box">${storyContent}<div>`,
+    ),
   ],
   parameters: {
     info: `${markdownDocumentationLinkBuilder('toggle')}`,
@@ -21,17 +19,14 @@ export default {
 };
 
 const modules = {
-  imports: [
-    SprkToggleModule,
-    BrowserAnimationsModule,
-  ],
+  imports: [SprkToggleModule, BrowserAnimationsModule],
 };
 
 export const defaultStory = () => ({
   moduleMetadata: modules,
   template: `
     <sprk-toggle
-      title="My Disclaimer"
+      triggerText="My Disclaimer"
       analyticsString="My Disclaimer"
       idString="toggle-1"
     >
@@ -54,8 +49,6 @@ export const defaultStory = () => ({
 defaultStory.story = {
   name: 'Default',
   parameters: {
-    jest: [
-      'sprk-toggle.component',
-    ],
+    jest: ['sprk-toggle.component'],
   },
 };

--- a/react/src/components/footer/components/SprkFooterAwards/SprkFooterAwards.js
+++ b/react/src/components/footer/components/SprkFooterAwards/SprkFooterAwards.js
@@ -59,7 +59,7 @@ class SprkFooterAwards extends Component {
           iconAdditionalClasses="sprk-c-Footer__icon"
           toggleIconName="chevron-down-circle"
           triggerText={awards.disclaimerTitle}
-          titleAdditionalClasses="sprk-b-TypeBodyFour sprk-c-Footer__trigger"
+          triggerTextAdditionalClasses="sprk-b-TypeBodyFour sprk-c-Footer__trigger"
           analyticsString={awards.disclaimerAnalytics}
         >
           <p

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -38,7 +38,7 @@ class SprkToggle extends Component {
       title,
       triggerText = title,
       titleAddClasses,
-      titleAdditionalClasses = titleAddClasses,
+      triggerTextAdditionalClasses = titleAddClasses,
       iconAddClasses,
       iconAdditionalClasses = iconAddClasses,
       toggleIconName,
@@ -55,7 +55,7 @@ class SprkToggle extends Component {
 
     const titleClasses = classnames(
       'sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-u-TextCrop--none',
-      titleAdditionalClasses,
+      triggerTextAdditionalClasses,
     );
     const iconClasses = classnames(
       'sprk-c-Icon--xl sprk-c-Icon--toggle sprk-u-mrs',
@@ -142,12 +142,12 @@ SprkToggle.propTypes = {
    * outermost container of the component.
    */
   additionalClasses: PropTypes.string,
-  /** Deprecated - Use `titleAdditionalClasses` instead.
+  /** Deprecated - Use `triggerTextAdditionalClasses` instead.
    * A space-separated string of classes to add to the title text. */
   // TODO: Remove titleAddClasses in issue #1296
   titleAddClasses: PropTypes.string,
   /** A space-separated string of classes to add to the title text. */
-  titleAdditionalClasses: PropTypes.string,
+  triggerTextAdditionalClasses: PropTypes.string,
   /** Deprecated - Use `iconAdditionalClasses` instead.
    * A space-separated string of classes to add to the toggle icon. */
   // TODO: Remove iconAddClasses in issue #1296

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -162,10 +162,10 @@ describe('SprkToggle:', () => {
     expect(toggleIcon.hasClass('test')).toBe(false);
   });
 
-  it(`should add classes to the title if titleAdditionalClasses
+  it(`should add classes to the title if triggerTextAdditionalClasses
   are set`, () => {
     const wrapper = mount(
-      <SprkToggle triggerText="Toggle title" titleAdditionalClasses="test">
+      <SprkToggle triggerText="Toggle title" triggerTextAdditionalClasses="test">
         Body text
       </SprkToggle>,
     );
@@ -184,13 +184,13 @@ describe('SprkToggle:', () => {
     expect(toggleTitle.hasClass('test')).toBe(true);
   });
 
-  it(`should prefer titleAdditionalClasses to titleAddClasses if both
+  it(`should prefer triggerTextAdditionalClasses to titleAddClasses if both
   are set`, () => {
     const wrapper = mount(
       <SprkToggle
         triggerText="Toggle title"
         titleAddClasses="test"
-        titleAdditionalClasses="newTest"
+        triggerTextAdditionalClasses="newTest"
       >
         Body text
       </SprkToggle>,


### PR DESCRIPTION
## What does this PR do?
- [x] Add ability to have the toggle content open by default - match React naming `isOpen`.
- [x] add type=button
- [x] Add `triggerText` input - continue support for `title` until next release.
- [x] add event emitter for when toggle opens or closes
- [x] add `toggleIconName` input
- [x] add `iconAdditionalClasses` input - continue support for `iconClass` until next release.
- [x] add `titleAdditionalClasses` input - continue support for `titleFontClass` until next release.
- [x] add `contentAdditionalClasses` input
- [x] New follow up issue to remove deprecated inputs - `iconClass`, `title`, `titleFontClass`
https://github.com/sparkdesignsystem/Backlog/issues/1305

### Associated Issue
Fixes #3296 

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team

### Screenshots
![image](https://user-images.githubusercontent.com/15703773/96500861-80409600-121d-11eb-9305-a0beb73ad1cd.png)

