### PR TITLE
Angular Accordion API Upgrades

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -11,6 +11,7 @@ describe('SprkAccordionItemComponent', () => {
   let accordionItemTriggerElement: HTMLElement;
   let accordionHeadingElement: HTMLElement;
   let accordionDetailsElement: HTMLElement;
+  let accordionSvgElement: HTMLElement;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -30,6 +31,7 @@ describe('SprkAccordionItemComponent', () => {
     accordionItemTriggerElement = fixture.nativeElement.querySelector('button');
     accordionHeadingElement = fixture.nativeElement.querySelector('span');
     accordionDetailsElement = fixture.nativeElement.querySelector('div');
+    accordionSvgElement = fixture.nativeElement.querySelector('svg');
   });
 
   it('should create itself', () => {
@@ -165,5 +167,28 @@ describe('SprkAccordionItemComponent', () => {
     expect(
       accordionHeadingElement.classList.contains('sprk-b-TypeDisplaySeven'),
     ).toEqual(true);
+  });
+
+  it('should correctly add default classes to the svg', () => {
+    fixture.detectChanges();
+
+    expect(accordionSvgElement.classList.length).toBe(4);
+    expect(accordionSvgElement.classList.toString()).toContain('sprk-c-Icon');
+    expect(accordionSvgElement.classList.toString()).toContain(
+      'sprk-c-Accordion__icon',
+    );
+    expect(accordionSvgElement.classList.toString()).toContain(
+      'sprk-c-Icon--xl',
+    );
+    expect(accordionSvgElement.classList.toString()).toContain(
+      'sprk-c-Icon--toggle',
+    );
+  });
+
+  it('should correctly add additional classes to the svg', () => {
+    const testString = 'test';
+    component.iconAdditionalClasses = testString;
+    fixture.detectChanges();
+    expect(accordionSvgElement.classList.toString()).toContain(testString);
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -48,12 +48,34 @@ describe('SprkAccordionItemComponent', () => {
     );
   });
 
+  // TODO
   it('should add classes if additionalHeadingClasses has a value', () => {
     component.additionalHeadingClasses = 'sprk-u-man';
     fixture.detectChanges();
     expect(accordionHeadingElement.classList.contains('sprk-u-man')).toEqual(
       true,
     );
+  });
+
+  it('should add classes if headingAdditionalClasses has a value', () => {
+    component.headingAdditionalClasses = 'sprk-u-man';
+    fixture.detectChanges();
+    expect(accordionHeadingElement.classList.contains('sprk-u-man')).toEqual(
+      true,
+    );
+  });
+
+  // TODO
+  it('should prefer headingAdditionalClasses over additionalHeadingClasses', () => {
+    component.headingAdditionalClasses = 'should-add';
+    component.additionalHeadingClasses = 'should-not-add';
+    fixture.detectChanges();
+    expect(accordionHeadingElement.classList.contains('should-add')).toEqual(
+      true,
+    );
+    expect(
+      accordionHeadingElement.classList.contains('should-not-add'),
+    ).toEqual(false);
   });
 
   it('should add an analytics data attribute if analyticsString has a value', () => {

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -87,12 +87,29 @@ describe('SprkAccordionItemComponent', () => {
     expect(component.isOpen).toEqual(false);
   });
 
+  // TODO
   it('should set the heading to title', () => {
     component.title = 'This is a title';
     fixture.detectChanges();
     expect(accordionHeadingElement.textContent.trim()).toEqual(
       'This is a title',
     );
+  });
+
+  it('should set the heading to heading', () => {
+    component.heading = 'This is a title';
+    fixture.detectChanges();
+    expect(accordionHeadingElement.textContent.trim()).toEqual(
+      'This is a title',
+    );
+  });
+
+  // TODO
+  it('should prefer heading over title', () => {
+    component.heading = 'heading';
+    component.title = 'title';
+    fixture.detectChanges();
+    expect(accordionHeadingElement.textContent.trim()).toEqual('heading');
   });
 
   it('details should not be present if isOpen is false', () => {

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -18,8 +18,8 @@ describe('SprkAccordionItemComponent', () => {
       declarations: [
         SprkAccordionItemComponent,
         SprkIconComponent,
-        SprkLinkDirective
-      ]
+        SprkLinkDirective,
+      ],
     }).compileComponents();
   }));
 
@@ -40,7 +40,7 @@ describe('SprkAccordionItemComponent', () => {
     component.additionalClasses = 'sprk-u-man';
     fixture.detectChanges();
     expect(accordionItemElement.classList.toString()).toContain(
-      'sprk-c-Accordion__item sprk-u-Overflow--hidden sprk-u-man'
+      'sprk-c-Accordion__item sprk-u-Overflow--hidden sprk-u-man',
     );
   });
 
@@ -48,7 +48,7 @@ describe('SprkAccordionItemComponent', () => {
     component.additionalHeadingClasses = 'sprk-u-man';
     fixture.detectChanges();
     expect(accordionHeadingElement.classList.contains('sprk-u-man')).toEqual(
-      true
+      true,
     );
   });
 
@@ -56,7 +56,7 @@ describe('SprkAccordionItemComponent', () => {
     component.analyticsString = 'Link Action';
     fixture.detectChanges();
     expect(accordionItemTriggerElement.getAttribute('data-analytics')).toEqual(
-      'Link Action'
+      'Link Action',
     );
   });
 
@@ -64,7 +64,7 @@ describe('SprkAccordionItemComponent', () => {
     component.isOpen = false;
     fixture.detectChanges();
     expect(
-      accordionItemElement.classList.contains('sprk-c-Accordion__item--open')
+      accordionItemElement.classList.contains('sprk-c-Accordion__item--open'),
     ).toEqual(false);
   });
 
@@ -72,7 +72,7 @@ describe('SprkAccordionItemComponent', () => {
     component.isOpen = true;
     fixture.detectChanges();
     expect(
-      accordionItemElement.classList.contains('sprk-c-Accordion__item--open')
+      accordionItemElement.classList.contains('sprk-c-Accordion__item--open'),
     ).toEqual(true);
   });
 
@@ -87,7 +87,7 @@ describe('SprkAccordionItemComponent', () => {
     component.title = 'This is a title';
     fixture.detectChanges();
     expect(accordionHeadingElement.textContent.trim()).toEqual(
-      'This is a title'
+      'This is a title',
     );
   });
 
@@ -102,7 +102,7 @@ describe('SprkAccordionItemComponent', () => {
     component.idString = testString;
     fixture.detectChanges();
     expect(accordionItemTriggerElement.getAttribute('data-id')).toEqual(
-      testString
+      testString,
     );
   });
 
@@ -110,14 +110,6 @@ describe('SprkAccordionItemComponent', () => {
     component.idString = null;
     fixture.detectChanges();
     expect(accordionItemElement.getAttribute('data-id')).toBeNull();
-  });
-
-  it('should set the active class if isActive is true', () => {
-    component.isActive = true;
-    fixture.detectChanges();
-    expect(
-      accordionItemElement.classList.contains('sprk-c-Accordion__item--active')
-    ).toEqual(true);
   });
 
   it('should render with a button element', () => {
@@ -128,11 +120,15 @@ describe('SprkAccordionItemComponent', () => {
   it('should have the aria-controls attribute', () => {
     fixture.detectChanges();
 
-    const ariaControls = accordionItemTriggerElement.getAttribute('aria-controls');
+    const ariaControls = accordionItemTriggerElement.getAttribute(
+      'aria-controls',
+    );
 
     expect(ariaControls).toBeTruthy();
 
-    const contentId = fixture.nativeElement.querySelector('.sprk-c-Accordion__content').getAttribute('id');
+    const contentId = fixture.nativeElement
+      .querySelector('.sprk-c-Accordion__content')
+      .getAttribute('id');
     expect(contentId).toBeTruthy();
 
     expect(ariaControls).toEqual(contentId);
@@ -142,16 +138,22 @@ describe('SprkAccordionItemComponent', () => {
     component.isOpen = false;
     fixture.detectChanges();
 
-    expect(accordionItemTriggerElement.getAttribute('aria-expanded')).toEqual('false');
+    expect(accordionItemTriggerElement.getAttribute('aria-expanded')).toEqual(
+      'false',
+    );
 
     accordionItemTriggerElement.click();
     fixture.detectChanges();
 
-    expect(accordionItemTriggerElement.getAttribute('aria-expanded')).toEqual('true');
+    expect(accordionItemTriggerElement.getAttribute('aria-expanded')).toEqual(
+      'true',
+    );
 
     accordionItemTriggerElement.click();
     fixture.detectChanges();
 
-    expect(accordionItemTriggerElement.getAttribute('aria-expanded')).toEqual('false');
+    expect(accordionItemTriggerElement.getAttribute('aria-expanded')).toEqual(
+      'false',
+    );
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -307,4 +307,25 @@ describe('SprkAccordionItemComponent', () => {
       accordionSvgElement.querySelector('use').getAttribute('xlink:href'),
     ).toEqual('#exclamation');
   });
+
+  it('should emit open and closed events when toggled', (done) => {
+    let openEventEmitted = false;
+    let closedEventEmitted = false;
+
+    component.openedEvent.subscribe((g) => {
+      openEventEmitted = true;
+      done();
+    });
+    component.closedEvent.subscribe((g) => {
+      closedEventEmitted = true;
+      done();
+    });
+
+    accordionItemTriggerElement.click();
+    expect(openEventEmitted).toEqual(true);
+    expect(closedEventEmitted).toEqual(false);
+
+    accordionItemTriggerElement.click();
+    expect(closedEventEmitted).toEqual(true);
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -48,7 +48,7 @@ describe('SprkAccordionItemComponent', () => {
     );
   });
 
-  // TODO
+  // TODO - Remove as part of Issue 3597
   it('should add classes if additionalHeadingClasses has a value', () => {
     component.additionalHeadingClasses = 'sprk-u-man';
     fixture.detectChanges();
@@ -65,7 +65,7 @@ describe('SprkAccordionItemComponent', () => {
     );
   });
 
-  // TODO
+  // TODO - Remove as part of Issue 3597
   it('should prefer headingAdditionalClasses over additionalHeadingClasses', () => {
     component.headingAdditionalClasses = 'should-add';
     component.additionalHeadingClasses = 'should-not-add';
@@ -109,7 +109,7 @@ describe('SprkAccordionItemComponent', () => {
     expect(component.isOpen).toEqual(false);
   });
 
-  // TODO
+  // TODO - Remove as part of Issue 3597
   it('should set the heading to title', () => {
     component.title = 'This is a title';
     fixture.detectChanges();
@@ -126,7 +126,7 @@ describe('SprkAccordionItemComponent', () => {
     );
   });
 
-  // TODO
+  // TODO - Remove as part of Issue 3597
   it('should prefer heading over title', () => {
     component.heading = 'heading';
     component.title = 'title';
@@ -155,7 +155,7 @@ describe('SprkAccordionItemComponent', () => {
     expect(accordionItemElement.getAttribute('data-id')).toBeNull();
   });
 
-  // TODO remove
+  // TODO - Remove as part of Issue 3597
   it('should set the active class if isActive is true', () => {
     component.isActive = true;
     fixture.detectChanges();
@@ -257,7 +257,7 @@ describe('SprkAccordionItemComponent', () => {
     expect(accordionContentsElement.classList.toString()).toContain(testString);
   });
 
-  // TODO
+  // TODO - Remove as part of Issue 3597
   it('should add closed icon from iconTypeClosed', () => {
     component.isOpen = false;
     component.iconTypeClosed = 'exclamation';
@@ -276,7 +276,7 @@ describe('SprkAccordionItemComponent', () => {
     ).toEqual('#exclamation');
   });
 
-  // TODO
+  // TODO - Remove as part of Issue 3597
   it('should prefer iconNameClosed over iconTypeClosed', () => {
     component.isOpen = false;
     component.iconTypeClosed = 'message';
@@ -287,7 +287,7 @@ describe('SprkAccordionItemComponent', () => {
     ).toEqual('#exclamation');
   });
 
-  // TODO
+  // TODO - Remove as part of Issue 3597
   it('should add open icon from iconTypeOpen', () => {
     component.isOpen = true;
     component.iconTypeOpen = 'exclamation';
@@ -306,7 +306,7 @@ describe('SprkAccordionItemComponent', () => {
     ).toEqual('#exclamation');
   });
 
-  // TODO
+  // TODO - Remove as part of Issue 3597
   it('should prefer iconNameOpen over iconTypeOpen', () => {
     component.isOpen = true;
     component.iconTypeOpen = 'message';

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -337,4 +337,25 @@ describe('SprkAccordionItemComponent', () => {
     accordionItemTriggerElement.click();
     expect(closedEventEmitted).toEqual(true);
   });
+
+  it('should correctly add leading icon', () => {
+    component.leadingIcon = 'exclamation';
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement
+        .querySelector('svg')
+        .querySelector('use')
+        .getAttribute('xlink:href'),
+    ).toEqual('#exclamation');
+  });
+
+  it('should correctly add additional classes to the leading icon', () => {
+    const testString = 'test';
+    component.leadingIcon = 'exclamation';
+    component.leadingIconAdditionalClasses = testString;
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('svg').classList.toString(),
+    ).toContain(testString);
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -11,6 +11,7 @@ describe('SprkAccordionItemComponent', () => {
   let accordionItemTriggerElement: HTMLElement;
   let accordionHeadingElement: HTMLElement;
   let accordionDetailsElement: HTMLElement;
+  let accordionContentsElement: HTMLElement;
   let accordionSvgElement: HTMLElement;
 
   beforeEach(async(() => {
@@ -31,6 +32,7 @@ describe('SprkAccordionItemComponent', () => {
     accordionItemTriggerElement = fixture.nativeElement.querySelector('button');
     accordionHeadingElement = fixture.nativeElement.querySelector('span');
     accordionDetailsElement = fixture.nativeElement.querySelector('div');
+    accordionContentsElement = accordionDetailsElement.querySelector('div');
     accordionSvgElement = fixture.nativeElement.querySelector('svg');
   });
 
@@ -190,5 +192,20 @@ describe('SprkAccordionItemComponent', () => {
     component.iconAdditionalClasses = testString;
     fixture.detectChanges();
     expect(accordionSvgElement.classList.toString()).toContain(testString);
+  });
+
+  it('should correctly add default classes to the content container', () => {
+    fixture.detectChanges();
+
+    expect(accordionContentsElement.classList.toString()).toContain(
+      'sprk-c-Accordion__content',
+    );
+  });
+
+  it('should correctly add additional classes to the content container', () => {
+    const testString = 'test';
+    component.contentAdditionalClasses = testString;
+    fixture.detectChanges();
+    expect(accordionContentsElement.classList.toString()).toContain(testString);
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -155,6 +155,15 @@ describe('SprkAccordionItemComponent', () => {
     expect(accordionItemElement.getAttribute('data-id')).toBeNull();
   });
 
+  // TODO remove
+  it('should set the active class if isActive is true', () => {
+    component.isActive = true;
+    fixture.detectChanges();
+    expect(
+      accordionItemElement.classList.contains('sprk-c-Accordion__item--active'),
+    ).toEqual(true);
+  });
+
   it('should render with a button element', () => {
     fixture.detectChanges();
     expect(accordionItemTriggerElement).toBeTruthy();

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -156,4 +156,14 @@ describe('SprkAccordionItemComponent', () => {
       'false',
     );
   });
+
+  it('should render with correct default heading classes', () => {
+    fixture.detectChanges();
+    expect(
+      accordionHeadingElement.classList.contains('sprk-c-Accordion__heading'),
+    ).toEqual(true);
+    expect(
+      accordionHeadingElement.classList.contains('sprk-b-TypeDisplaySeven'),
+    ).toEqual(true);
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -247,4 +247,64 @@ describe('SprkAccordionItemComponent', () => {
     fixture.detectChanges();
     expect(accordionContentsElement.classList.toString()).toContain(testString);
   });
+
+  // TODO
+  it('should add closed icon from iconTypeClosed', () => {
+    component.isOpen = false;
+    component.iconTypeClosed = 'exclamation';
+    fixture.detectChanges();
+    expect(
+      accordionSvgElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#exclamation');
+  });
+
+  it('should add closed icon from iconNameClosed', () => {
+    component.isOpen = false;
+    component.iconNameClosed = 'exclamation';
+    fixture.detectChanges();
+    expect(
+      accordionSvgElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#exclamation');
+  });
+
+  // TODO
+  it('should prefer iconNameClosed over iconTypeClosed', () => {
+    component.isOpen = false;
+    component.iconTypeClosed = 'message';
+    component.iconNameClosed = 'exclamation';
+    fixture.detectChanges();
+    expect(
+      accordionSvgElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#exclamation');
+  });
+
+  // TODO
+  it('should add open icon from iconTypeOpen', () => {
+    component.isOpen = true;
+    component.iconTypeOpen = 'exclamation';
+    fixture.detectChanges();
+    expect(
+      accordionSvgElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#exclamation');
+  });
+
+  it('should add open icon from iconNameOpen', () => {
+    component.isOpen = true;
+    component.iconNameOpen = 'exclamation';
+    fixture.detectChanges();
+    expect(
+      accordionSvgElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#exclamation');
+  });
+
+  // TODO
+  it('should prefer iconNameOpen over iconTypeOpen', () => {
+    component.isOpen = true;
+    component.iconTypeOpen = 'message';
+    component.iconNameOpen = 'exclamation';
+    fixture.detectChanges();
+    expect(
+      accordionSvgElement.querySelector('use').getAttribute('xlink:href'),
+    ).toEqual('#exclamation');
+  });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -36,7 +36,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
       </button>
 
       <div [@toggleContent]="animState">
-        <div [id]="accordion_controls_id" class="sprk-c-Accordion__content">
+        <div [id]="accordion_controls_id" [ngClass]="getContentClasses()">
           <ng-content></ng-content>
         </div>
       </div>
@@ -108,6 +108,12 @@ export class SprkAccordionItemComponent implements OnInit {
    */
   @Input()
   iconAdditionalClasses: string;
+  /**
+   * Expects a space separated string of classes to be added to the accordion
+   * item content container.
+   */
+  @Input()
+  contentAdditionalClasses: string;
 
   /**
    * @ignore
@@ -209,6 +215,21 @@ export class SprkAccordionItemComponent implements OnInit {
 
     if (this.iconAdditionalClasses) {
       this.iconAdditionalClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    }
+
+    return classArray.join(' ');
+  }
+
+  /**
+   * @ignore
+   */
+  getContentClasses(): string {
+    const classArray: string[] = ['sprk-c-Accordion__content'];
+
+    if (this.contentAdditionalClasses) {
+      this.contentAdditionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -31,7 +31,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
             sprk-c-Accordion__icon
             sprk-c-Icon--xl
             sprk-c-Icon--toggle
-            {{iconStateClass}}"
+            {{ iconStateClass }}"
           [iconType]="currentIconType"
         ></sprk-icon>
       </button>
@@ -46,7 +46,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
       </div>
     </li>
   `,
-  animations: [toggleAnimations.toggleContent]
+  animations: [toggleAnimations.toggleContent],
 })
 export class SprkAccordionItemComponent implements OnInit {
   /**
@@ -173,19 +173,15 @@ export class SprkAccordionItemComponent implements OnInit {
   getClasses(): string {
     const classArray: string[] = [
       'sprk-c-Accordion__item',
-      'sprk-u-Overflow--hidden'
+      'sprk-u-Overflow--hidden',
     ];
 
     if (this.isOpen) {
       classArray.push('sprk-c-Accordion__item--open');
     }
 
-    if (this.isActive) {
-      classArray.push('sprk-c-Accordion__item--active');
-    }
-
     if (this.additionalClasses) {
-      this.additionalClasses.split(' ').forEach(className => {
+      this.additionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }
@@ -200,7 +196,7 @@ export class SprkAccordionItemComponent implements OnInit {
     const classArray: string[] = ['sprk-c-Accordion__heading'];
 
     if (this.additionalHeadingClasses) {
-      this.additionalHeadingClasses.split(' ').forEach(className => {
+      this.additionalHeadingClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -2,6 +2,8 @@ import { Component, Input, Output, OnInit, EventEmitter } from '@angular/core';
 import * as _ from 'lodash';
 import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 
+// TODO Remove title, additionalHeadingClasses, iconTypeClosed, and
+// iconTypeOpen as part of Issue XXXX
 @Component({
   selector: 'sprk-accordion-item',
   template: `
@@ -19,12 +21,12 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
       >
         <span [ngClass]="getHeadingClasses()">
           <sprk-icon
+            *ngIf="leadingIcon"
             [iconType]="leadingIcon"
             additionalClasses="
               sprk-c-Icon--filled-current-color
               sprk-c-Icon--xl
               sprk-u-mrs"
-            *ngIf="leadingIcon"
           ></sprk-icon>
           {{ heading || title }}
         </span>
@@ -45,15 +47,16 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
   animations: [toggleAnimations.toggleContent],
 })
 export class SprkAccordionItemComponent implements OnInit {
+  // TODO
   /**
    * Deprecated: use `heading` instead. The value supplied will be
-   * rendered inside the heading area of the Accordion item.
+   * rendered inside the heading area of the Accordion Item.
    */
   @Input()
   title: string;
   /**
    * The value supplied will be rendered inside the heading area of the
-   * Accordion item.
+   * Accordion Item.
    */
   @Input()
   heading: string;
@@ -75,16 +78,17 @@ export class SprkAccordionItemComponent implements OnInit {
    */
   @Input()
   additionalClasses: string;
+  // TODO
   /**
    * Deprecated - use `headingAdditionalClasses` instead. Expects a space
    * separated string of classes to be added to the heading in the Accordion
-   * item.
+   * Item.
    */
   @Input()
   additionalHeadingClasses: string;
   /**
    * Expects a space separated string of classes to be added to the heading in
-   * the Accordion item.
+   * the Accordion Item.
    */
   @Input()
   headingAdditionalClasses: string;
@@ -103,12 +107,12 @@ export class SprkAccordionItemComponent implements OnInit {
   // as part of issue XXXX
   /**
    * Deprecated - use `iconNameClosed` instead. The name of the icon to use for
-   * a closed Accordion item.
+   * a closed Accordion Item.
    */
   @Input()
   iconTypeClosed = 'chevron-up-circle';
   /**
-   * The name of the icon to use for a closed Accordion item.
+   * The name of the icon to use for a closed Accordion Item.
    */
   @Input()
   iconNameClosed;
@@ -116,41 +120,41 @@ export class SprkAccordionItemComponent implements OnInit {
   // as part of issue XXXX
   /**
    * Deprecated - use `iconNameOpen` instead. The name of the icon to use for
-   * an open Accordion item.
+   * an open Accordion Item.
    */
   @Input()
   iconTypeOpen = 'chevron-up-circle';
   /**
-   * The name of the icon to use for an open Accordion item.
+   * The name of the icon to use for an open Accordion Item.
    */
   @Input()
   iconNameOpen;
   /**
-   * The name of the icon to use before the heading in the Accordion item.
+   * The name of the icon to use before the heading in the Accordion Item.
    * This is optional.
    */
   @Input()
   leadingIcon: string;
   /**
-   * Expects a space separated string of classes to be added to the accordion
-   * item icon.
+   * Expects a space separated string of classes to be added to the Accordion
+   * Item icon.
    */
   @Input()
   iconAdditionalClasses: string;
   /**
-   * Expects a space separated string of classes to be added to the accordion
-   * item content container.
+   * Expects a space separated string of classes to be added to the Accordion
+   * Item content container.
    */
   @Input()
   contentAdditionalClasses: string;
 
   /**
-   * This event will be emitted when the accordion item is opened.
+   * This event will be emitted when the Accordion Item is opened.
    */
   @Output()
   openedEvent = new EventEmitter<any>();
   /**
-   * This event will be emitted when the accordion item is closed.
+   * This event will be emitted when the Accordion Item is closed.
    */
   @Output()
   closedEvent = new EventEmitter<any>();
@@ -182,10 +186,12 @@ export class SprkAccordionItemComponent implements OnInit {
   toggleState(): void {
     if (this.isOpen) {
       this.animState = 'open';
+      // TODO
       this.currentIconType = this.iconNameOpen || this.iconTypeOpen;
       this.iconStateClass = 'sprk-c-Icon--open';
     } else {
       this.animState = 'closed';
+      // TODO
       this.currentIconType = this.iconNameClosed || this.iconTypeClosed;
       this.iconStateClass = '';
     }
@@ -236,6 +242,7 @@ export class SprkAccordionItemComponent implements OnInit {
       'sprk-b-TypeDisplaySeven',
     ];
 
+    // TODO
     const additionalClasses =
       this.headingAdditionalClasses || this.additionalHeadingClasses;
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -193,7 +193,10 @@ export class SprkAccordionItemComponent implements OnInit {
    * @ignore
    */
   getHeadingClasses(): string {
-    const classArray: string[] = ['sprk-c-Accordion__heading'];
+    const classArray: string[] = [
+      'sprk-c-Accordion__heading',
+      'sprk-b-TypeDisplaySeven',
+    ];
 
     if (this.additionalHeadingClasses) {
       this.additionalHeadingClasses.split(' ').forEach((className) => {

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -20,7 +20,10 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
         <span [ngClass]="getHeadingClasses()">
           <sprk-icon
             [iconType]="leadingIcon"
-            additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--xl sprk-u-mrs"
+            additionalClasses="
+              sprk-c-Icon--filled-current-color
+              sprk-c-Icon--xl
+              sprk-u-mrs"
             *ngIf="leadingIcon"
           ></sprk-icon>
           {{ title }}
@@ -43,79 +46,65 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 })
 export class SprkAccordionItemComponent implements OnInit {
   /**
-   * The value supplied will be rendered
-   * inside the title area of the Accordion item.
+   * The value supplied will be rendered inside the title area of the
+   * Accordion item.
    */
   @Input()
   title: string;
   /**
-   * The value supplied will be assigned to the
-   * `data-analytics` attribute on the component.
-   * Intended for an outside
-   * library to capture data.
+   * The value supplied will be assigned to the `data-analytics` attribute
+   * on the component. Intended for an outside library to capture data.
    */
   @Input()
   analyticsString: string;
   /**
-   * The value supplied will be assigned
-   * to the `data-id` attribute on the
-   * component. This is intended to be
-   * used as a selector for automated
-   * tools. This value should be unique
-   * per page.
+   * The value supplied will be assigned to the `data-id` attribute on the
+   * component. This is intended to be used as a selector for automated tools.
+   * This value should be unique per page.
    */
   @Input()
   idString: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * component.
+   * Expects a space separated string of classes to be added to the component.
    */
   @Input()
   additionalClasses: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * heading in the Accordion item.
+   * Expects a space separated string of classes to be added to the heading in
+   * the Accordion item.
    */
   @Input()
   additionalHeadingClasses: string;
   /**
-   * The Accordion item will use this to decide
-   * if it should be open or closed on first render.
-   * (Interacting with the toggle will override this input.)
+   * The Accordion item will use this to decide if it should be open or closed
+   * on first render. (Interacting with the toggle will override this input.)
    */
   @Input()
   isOpen = false;
   /**
-   * If `true`, the active CSS class
-   * will be applied to the item.
+   * If `true`, the active CSS class will be applied to the item.
    */
   @Input()
   isActive: boolean;
   /**
-   * The name of the icon to use for
-   * a closed Accordion item.
+   * The name of the icon to use for a closed Accordion item.
    */
   @Input()
   iconTypeClosed = 'chevron-up-circle';
   /**
-   * The name of the icon to use for
-   * an open Accordion item.
+   * The name of the icon to use for an open Accordion item.
    */
   @Input()
   iconTypeOpen = 'chevron-up-circle';
   /**
-   * The name of the icon to use before
-   * the title in the Accordion item.
+   * The name of the icon to use before the title in the Accordion item.
    * This is optional.
    */
   @Input()
   leadingIcon: string;
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * component.
+   * Expects a space separated string of classes to be added to the accordion
+   * item icon.
    */
   @Input()
   iconAdditionalClasses: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -27,11 +27,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
         </span>
 
         <sprk-icon
-          additionalClasses="
-            sprk-c-Accordion__icon
-            sprk-c-Icon--xl
-            sprk-c-Icon--toggle
-            {{ iconStateClass }}"
+          [additionalClasses]="getIconClasses()"
           [iconType]="currentIconType"
         ></sprk-icon>
       </button>
@@ -116,6 +112,13 @@ export class SprkAccordionItemComponent implements OnInit {
    */
   @Input()
   leadingIcon: string;
+  /**
+   * Expects a space separated string
+   * of classes to be added to the
+   * component.
+   */
+  @Input()
+  iconAdditionalClasses: string;
 
   /**
    * @ignore
@@ -197,6 +200,26 @@ export class SprkAccordionItemComponent implements OnInit {
 
     if (this.additionalHeadingClasses) {
       this.additionalHeadingClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    }
+
+    return classArray.join(' ');
+  }
+
+  /**
+   * @ignore
+   */
+  getIconClasses(): string {
+    const classArray: string[] = [
+      'sprk-c-Accordion__icon',
+      'sprk-c-Icon--xl',
+      'sprk-c-Icon--toggle',
+      this.iconStateClass,
+    ];
+
+    if (this.iconAdditionalClasses) {
+      this.iconAdditionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -2,8 +2,8 @@ import { Component, Input, Output, OnInit, EventEmitter } from '@angular/core';
 import * as _ from 'lodash';
 import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 
-// TODO Remove title, additionalHeadingClasses, iconTypeClosed, and
-// iconTypeOpen as part of Issue 3597
+// TODO Remove title, additionalHeadingClasses, iconTypeClosed,
+// iconTypeOpen, isActive as part of Issue 3597
 @Component({
   selector: 'sprk-accordion-item',
   template: `
@@ -33,7 +33,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 
         <sprk-icon
           [additionalClasses]="getIconClasses()"
-          [iconName]="currentIconType"
+          [iconName]="currentIconName"
         ></sprk-icon>
       </button>
 
@@ -169,10 +169,11 @@ export class SprkAccordionItemComponent implements OnInit {
    * @ignore
    */
   accordion_controls_id = `accordionHeading__${this.componentID}`;
+  // TODO replace default value with iconNameClosed as part of issue 3597
   /**
    * @ignore
    */
-  public currentIconType = this.iconTypeClosed;
+  public currentIconName = this.iconTypeClosed;
   /**
    * @ignore
    */
@@ -189,12 +190,12 @@ export class SprkAccordionItemComponent implements OnInit {
     if (this.isOpen) {
       this.animState = 'open';
       // TODO - Remove iconTypeOpen as part of Issue 3597
-      this.currentIconType = this.iconNameOpen || this.iconTypeOpen;
+      this.currentIconName = this.iconNameOpen || this.iconTypeOpen;
       this.iconStateClass = 'sprk-c-Icon--open';
     } else {
       this.animState = 'closed';
       // TODO - Remove iconTypeClosed as part of Issue 3597
-      this.currentIconType = this.iconNameClosed || this.iconTypeClosed;
+      this.currentIconName = this.iconNameClosed || this.iconTypeClosed;
       this.iconStateClass = '';
     }
   }

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -23,10 +23,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
           <sprk-icon
             *ngIf="leadingIcon"
             [iconName]="leadingIcon"
-            additionalClasses="
-              sprk-c-Icon--filled-current-color
-              sprk-c-Icon--xl
-              sprk-u-mrs"
+            [additionalClasses]="getLeadingIconClasses()"
           ></sprk-icon>
           {{ heading || title }}
         </span>
@@ -133,10 +130,15 @@ export class SprkAccordionItemComponent implements OnInit {
   iconNameOpen;
   /**
    * The name of the icon to use before the heading in the Accordion Item.
-   * This is optional.
    */
   @Input()
   leadingIcon: string;
+  /**
+   * Expects a space separated string of classes to be added to the leading
+   * icon before the heading in the Accordion Item.
+   */
+  @Input()
+  leadingIconAdditionalClasses: string;
   /**
    * Expects a space separated string of classes to be added to the Accordion
    * Item icon.
@@ -275,6 +277,25 @@ export class SprkAccordionItemComponent implements OnInit {
 
     if (this.iconAdditionalClasses) {
       this.iconAdditionalClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    }
+
+    return classArray.join(' ');
+  }
+
+  /**
+   * @ignore
+   */
+  getLeadingIconClasses(): string {
+    const classArray: string[] = [
+      'sprk-c-Icon--filled-current-color',
+      'sprk-c-Icon--xl',
+      'sprk-u-mrs',
+    ];
+
+    if (this.leadingIconAdditionalClasses) {
+      this.leadingIconAdditionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -37,10 +37,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
       </button>
 
       <div [@toggleContent]="animState">
-        <div
-          [id]="accordion_controls_id"
-          class="sprk-c-Accordion__content sprk-b-TypeBodyTwo"
-        >
+        <div [id]="accordion_controls_id" class="sprk-c-Accordion__content">
           <ng-content></ng-content>
         </div>
       </div>

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -98,8 +98,10 @@ export class SprkAccordionItemComponent implements OnInit {
    */
   @Input()
   isOpen = false;
+  // TODO remove as part of issue XXXX
   /**
-   * If `true`, the active CSS class will be applied to the item.
+   * Deprecated - use additionalClasses instead. If `true`, the active class
+   * will be applied to the item.
    */
   @Input()
   isActive: boolean;
@@ -222,6 +224,10 @@ export class SprkAccordionItemComponent implements OnInit {
 
     if (this.isOpen) {
       classArray.push('sprk-c-Accordion__item--open');
+    }
+
+    if (this.isActive) {
+      classArray.push('sprk-c-Accordion__item--active');
     }
 
     if (this.additionalClasses) {

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -99,6 +99,8 @@ export class SprkAccordionItemComponent implements OnInit {
    */
   @Input()
   isActive: boolean;
+  // TODO - Remove this input and move the default value to iconNameClosed
+  // as part of issue XXXX
   /**
    * Deprecated - use `iconNameClosed` instead. The name of the icon to use for
    * a closed Accordion item.
@@ -109,7 +111,9 @@ export class SprkAccordionItemComponent implements OnInit {
    * The name of the icon to use for a closed Accordion item.
    */
   @Input()
-  iconNameClosed = 'chevron-up-circle';
+  iconNameClosed;
+  // TODO - Remove this input and move the default value to iconNameOpen
+  // as part of issue XXXX
   /**
    * Deprecated - use `iconNameOpen` instead. The name of the icon to use for
    * an open Accordion item.
@@ -120,7 +124,7 @@ export class SprkAccordionItemComponent implements OnInit {
    * The name of the icon to use for an open Accordion item.
    */
   @Input()
-  iconNameOpen = 'chevron-up-circle';
+  iconNameOpen;
   /**
    * The name of the icon to use before the heading in the Accordion item.
    * This is optional.
@@ -164,18 +168,16 @@ export class SprkAccordionItemComponent implements OnInit {
   /**
    * @ignore
    */
-  accordionState(): void {
-    this.isOpen === false
-      ? (this.animState = 'closed')
-      : (this.animState = 'open');
-
-    this.isOpen === false
-      ? (this.currentIconType = this.iconTypeClosed)
-      : (this.currentIconType = this.iconTypeOpen);
-
-    this.isOpen === false
-      ? (this.iconStateClass = '')
-      : (this.iconStateClass = 'sprk-c-Icon--open');
+  toggleState(): void {
+    if (this.isOpen) {
+      this.animState = 'open';
+      this.currentIconType = this.iconNameOpen || this.iconTypeOpen;
+      this.iconStateClass = 'sprk-c-Icon--open';
+    } else {
+      this.animState = 'closed';
+      this.currentIconType = this.iconNameClosed || this.iconTypeClosed;
+      this.iconStateClass = '';
+    }
   }
 
   /**
@@ -184,7 +186,7 @@ export class SprkAccordionItemComponent implements OnInit {
   toggleAccordion(event): void {
     event.preventDefault();
     this.isOpen = !this.isOpen;
-    this.accordionState();
+    this.toggleState();
   }
 
   /**
@@ -266,6 +268,6 @@ export class SprkAccordionItemComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.accordionState();
+    this.toggleState();
   }
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -22,7 +22,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
         <span [ngClass]="getHeadingClasses()">
           <sprk-icon
             *ngIf="leadingIcon"
-            [iconType]="leadingIcon"
+            [iconName]="leadingIcon"
             additionalClasses="
               sprk-c-Icon--filled-current-color
               sprk-c-Icon--xl
@@ -33,7 +33,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 
         <sprk-icon
           [additionalClasses]="getIconClasses()"
-          [iconType]="currentIconType"
+          [iconName]="currentIconType"
         ></sprk-icon>
       </button>
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -3,7 +3,7 @@ import * as _ from 'lodash';
 import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 
 // TODO Remove title, additionalHeadingClasses, iconTypeClosed, and
-// iconTypeOpen as part of Issue XXXX
+// iconTypeOpen as part of Issue 3597
 @Component({
   selector: 'sprk-accordion-item',
   template: `
@@ -47,7 +47,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
   animations: [toggleAnimations.toggleContent],
 })
 export class SprkAccordionItemComponent implements OnInit {
-  // TODO
+  // TODO - Remove as part of Issue 3597
   /**
    * Deprecated: use `heading` instead. The value supplied will be
    * rendered inside the heading area of the Accordion Item.
@@ -78,7 +78,7 @@ export class SprkAccordionItemComponent implements OnInit {
    */
   @Input()
   additionalClasses: string;
-  // TODO
+  // TODO - Remove as part of Issue 3597
   /**
    * Deprecated - use `headingAdditionalClasses` instead. Expects a space
    * separated string of classes to be added to the heading in the Accordion
@@ -98,7 +98,7 @@ export class SprkAccordionItemComponent implements OnInit {
    */
   @Input()
   isOpen = false;
-  // TODO remove as part of issue XXXX
+  // TODO - Remove as part of Issue 3597
   /**
    * Deprecated - use additionalClasses instead. If `true`, the active class
    * will be applied to the item.
@@ -106,7 +106,7 @@ export class SprkAccordionItemComponent implements OnInit {
   @Input()
   isActive: boolean;
   // TODO - Remove this input and move the default value to iconNameClosed
-  // as part of issue XXXX
+  // as part of issue 3597
   /**
    * Deprecated - use `iconNameClosed` instead. The name of the icon to use for
    * a closed Accordion Item.
@@ -119,7 +119,7 @@ export class SprkAccordionItemComponent implements OnInit {
   @Input()
   iconNameClosed;
   // TODO - Remove this input and move the default value to iconNameOpen
-  // as part of issue XXXX
+  // as part of issue 3597
   /**
    * Deprecated - use `iconNameOpen` instead. The name of the icon to use for
    * an open Accordion Item.
@@ -188,12 +188,12 @@ export class SprkAccordionItemComponent implements OnInit {
   toggleState(): void {
     if (this.isOpen) {
       this.animState = 'open';
-      // TODO
+      // TODO - Remove iconTypeOpen as part of Issue 3597
       this.currentIconType = this.iconNameOpen || this.iconTypeOpen;
       this.iconStateClass = 'sprk-c-Icon--open';
     } else {
       this.animState = 'closed';
-      // TODO
+      // TODO - Remove iconTypeClosed as part of Issue 3597
       this.currentIconType = this.iconNameClosed || this.iconTypeClosed;
       this.iconStateClass = '';
     }
@@ -248,7 +248,7 @@ export class SprkAccordionItemComponent implements OnInit {
       'sprk-b-TypeDisplaySeven',
     ];
 
-    // TODO
+    // TODO - Remove additionalHeadingClasses as part of Issue 3597
     const additionalClasses =
       this.headingAdditionalClasses || this.additionalHeadingClasses;
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -218,8 +218,11 @@ export class SprkAccordionItemComponent implements OnInit {
       'sprk-b-TypeDisplaySeven',
     ];
 
-    if (this.additionalHeadingClasses) {
-      this.additionalHeadingClasses.split(' ').forEach((className) => {
+    const additionalClasses =
+      this.headingAdditionalClasses || this.additionalHeadingClasses;
+
+    if (additionalClasses) {
+      additionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, Output, OnInit, EventEmitter } from '@angular/core';
 import * as _ from 'lodash';
 import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 
@@ -145,6 +145,17 @@ export class SprkAccordionItemComponent implements OnInit {
   contentAdditionalClasses: string;
 
   /**
+   * This event will be emitted when the accordion item is opened.
+   */
+  @Output()
+  openedEvent = new EventEmitter<any>();
+  /**
+   * This event will be emitted when the accordion item is closed.
+   */
+  @Output()
+  closedEvent = new EventEmitter<any>();
+
+  /**
    * @ignore
    */
   componentID = _.uniqueId();
@@ -186,6 +197,11 @@ export class SprkAccordionItemComponent implements OnInit {
   toggleAccordion(event): void {
     event.preventDefault();
     this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.openedEvent.emit();
+    } else {
+      this.closedEvent.emit();
+    }
     this.toggleState();
   }
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -97,8 +97,8 @@ export class SprkAccordionItemComponent implements OnInit {
   isOpen = false;
   // TODO - Remove as part of Issue 3597
   /**
-   * Deprecated - use additionalClasses instead. If `true`, the active class
-   * will be applied to the item.
+   * Deprecated. If `true`, the active class will be applied to the Accordion
+   * Item.
    */
   @Input()
   isActive: boolean;

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -26,7 +26,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
               sprk-u-mrs"
             *ngIf="leadingIcon"
           ></sprk-icon>
-          {{ title }}
+          {{ heading || title }}
         </span>
 
         <sprk-icon
@@ -46,11 +46,17 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 })
 export class SprkAccordionItemComponent implements OnInit {
   /**
-   * The value supplied will be rendered inside the title area of the
-   * Accordion item.
+   * Deprecated: use `heading` instead. The value supplied will be
+   * rendered inside the heading area of the Accordion item.
    */
   @Input()
   title: string;
+  /**
+   * The value supplied will be rendered inside the heading area of the
+   * Accordion item.
+   */
+  @Input()
+  heading: string;
   /**
    * The value supplied will be assigned to the `data-analytics` attribute
    * on the component. Intended for an outside library to capture data.
@@ -70,11 +76,18 @@ export class SprkAccordionItemComponent implements OnInit {
   @Input()
   additionalClasses: string;
   /**
+   * Deprecated - use `headingAdditionalClasses` instead. Expects a space
+   * separated string of classes to be added to the heading in the Accordion
+   * item.
+   */
+  @Input()
+  additionalHeadingClasses: string;
+  /**
    * Expects a space separated string of classes to be added to the heading in
    * the Accordion item.
    */
   @Input()
-  additionalHeadingClasses: string;
+  headingAdditionalClasses: string;
   /**
    * The Accordion item will use this to decide if it should be open or closed
    * on first render. (Interacting with the toggle will override this input.)
@@ -87,17 +100,29 @@ export class SprkAccordionItemComponent implements OnInit {
   @Input()
   isActive: boolean;
   /**
-   * The name of the icon to use for a closed Accordion item.
+   * Deprecated - use `iconNameClosed` instead. The name of the icon to use for
+   * a closed Accordion item.
    */
   @Input()
   iconTypeClosed = 'chevron-up-circle';
   /**
-   * The name of the icon to use for an open Accordion item.
+   * The name of the icon to use for a closed Accordion item.
+   */
+  @Input()
+  iconNameClosed = 'chevron-up-circle';
+  /**
+   * Deprecated - use `iconNameOpen` instead. The name of the icon to use for
+   * an open Accordion item.
    */
   @Input()
   iconTypeOpen = 'chevron-up-circle';
   /**
-   * The name of the icon to use before the title in the Accordion item.
+   * The name of the icon to use for an open Accordion item.
+   */
+  @Input()
+  iconNameOpen = 'chevron-up-circle';
+  /**
+   * The name of the icon to use before the heading in the Accordion item.
    * This is optional.
    */
   @Input()

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.component.spec.ts
@@ -9,7 +9,7 @@ describe('SprkAccordionComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [SprkAccordionComponent, SprkIconComponent]
+      declarations: [SprkAccordionComponent, SprkIconComponent],
     }).compileComponents();
   }));
 
@@ -26,7 +26,7 @@ describe('SprkAccordionComponent', () => {
   it('should do nothing when additionalClasses has no value', () => {
     fixture.detectChanges();
     expect(accordionElement.classList.toString()).toEqual(
-      'sprk-c-Accordion sprk-o-VerticalList'
+      'sprk-c-Accordion sprk-o-VerticalList',
     );
   });
 
@@ -34,7 +34,14 @@ describe('SprkAccordionComponent', () => {
     component.additionalClasses = 'sprk-u-man';
     fixture.detectChanges();
     expect(accordionElement.classList.toString()).toEqual(
-      'sprk-c-Accordion sprk-o-VerticalList sprk-u-man'
+      'sprk-c-Accordion sprk-o-VerticalList sprk-u-man',
     );
+  });
+
+  it('should add data-id when idString has a value', () => {
+    const testString = 'element-id';
+    component.idString = testString;
+    fixture.detectChanges();
+    expect(accordionElement.getAttribute('data-id')).toEqual(testString);
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.component.ts
@@ -6,13 +6,11 @@ import { Component, Input } from '@angular/core';
     <ul [ngClass]="getClasses()">
       <ng-content></ng-content>
     </ul>
-  `
+  `,
 })
 export class SprkAccordionComponent {
   /**
-   * Expects a space separated string
-   * of classes to be added to the
-   * component.
+   * Expects a space separated string of classes to be added to the component.
    */
   @Input()
   additionalClasses: string;
@@ -24,7 +22,7 @@ export class SprkAccordionComponent {
     const classArray: string[] = ['sprk-c-Accordion', 'sprk-o-VerticalList'];
 
     if (this.additionalClasses) {
-      this.additionalClasses.split(' ').forEach(className => {
+      this.additionalClasses.split(' ').forEach((className) => {
         classArray.push(className);
       });
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'sprk-accordion',
   template: `
-    <ul [ngClass]="getClasses()">
+    <ul [ngClass]="getClasses()" [attr.data-id]="idString">
       <ng-content></ng-content>
     </ul>
   `,
@@ -14,6 +14,13 @@ export class SprkAccordionComponent {
    */
   @Input()
   additionalClasses: string;
+  /**
+   * The value supplied will be assigned to the `data-id` attribute on the
+   * component. This is intended to be used as a selector for automated tools.
+   * This value should be unique per page.
+   */
+  @Input()
+  idString: string;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
@@ -52,7 +52,7 @@ export const defaultStory = () => ({
         idString="accordion-item-1"
         analyticsString="object.action.event"
       >
-        <p>
+        <p class="sprk-b-TypeBodyTwo">
           This is an example of accordion content.
           This is an example of accordion content.
           This is an example of accordion content.
@@ -65,7 +65,7 @@ export const defaultStory = () => ({
         idString="accordion-item-2"
         analyticsString="object.action.event"
       >
-        <p>
+        <p class="sprk-b-TypeBodyTwo">
           This is an example of accordion content.
           This is an example of accordion content.
           This is an example of accordion content.
@@ -78,7 +78,7 @@ export const defaultStory = () => ({
         idString="accordion-item-3"
         analyticsString="object.action.event"
       >
-        <p>
+        <p class="sprk-b-TypeBodyTwo">
           This is an example of accordion content.
           This is an example of accordion content.
           This is an example of accordion content.

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
@@ -47,7 +47,7 @@ export const defaultStory = () => ({
   template: `
     <sprk-accordion>
       <sprk-accordion-item
-        title="This is an accordion heading"
+        heading="This is an accordion heading"
         additionalClasses="sprk-u-mbs"
         idString="accordion-item-1"
         analyticsString="object.action.event"
@@ -61,7 +61,7 @@ export const defaultStory = () => ({
       </sprk-accordion-item>
 
       <sprk-accordion-item
-        title="This is an accordion heading"
+        heading="This is an accordion heading"
         idString="accordion-item-2"
         analyticsString="object.action.event"
       >
@@ -74,7 +74,7 @@ export const defaultStory = () => ({
       </sprk-accordion-item>
 
       <sprk-accordion-item
-        title="This is an accordion heading"
+        heading="This is an accordion heading"
         idString="accordion-item-3"
         analyticsString="object.action.event"
       >

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
@@ -11,10 +11,8 @@ export default {
   component: SprkAccordionComponent,
   decorators: [
     storyWrapper(
-      storyContent => (
-        `<div class="sprk-o-Box">${ storyContent }<div>`
-      )
-    )
+      (storyContent) => `<div class="sprk-o-Box">${storyContent}<div>`,
+    ),
   ],
   parameters: {
     subcomponents: {
@@ -51,7 +49,6 @@ export const defaultStory = () => ({
       <sprk-accordion-item
         title="This is an accordion heading"
         additionalClasses="sprk-u-mbs"
-        additionalHeadingClasses="sprk-b-TypeDisplaySeven"
         idString="accordion-item-1"
         analyticsString="object.action.event"
       >
@@ -67,7 +64,6 @@ export const defaultStory = () => ({
         title="This is an accordion heading"
         idString="accordion-item-2"
         analyticsString="object.action.event"
-        additionalHeadingClasses="sprk-b-TypeDisplaySeven"
       >
         <p>
           This is an example of accordion content.
@@ -81,7 +77,6 @@ export const defaultStory = () => ({
         title="This is an accordion heading"
         idString="accordion-item-3"
         analyticsString="object.action.event"
-        additionalHeadingClasses="sprk-b-TypeDisplaySeven"
       >
         <p>
           This is an example of accordion content.

--- a/src/pages/using-spark/components/accordion.mdx
+++ b/src/pages/using-spark/components/accordion.mdx
@@ -43,5 +43,5 @@ Use Accordion to separate supplementary (lower-priority) content into digestible
 ## Accessibility
 
 - Accessible through keyboard.
-  - `TAB` and `SHIFT-TAB` keys navigate through Accordion titles.
-  - `ENTER` key expands or collapses each section.
+  - `Tab` and `Shift+Tab` keys navigate through Accordion titles.
+  - `Enter` and `Space` keys expands or collapses each section.

--- a/src/pages/using-spark/components/accordion.mdx
+++ b/src/pages/using-spark/components/accordion.mdx
@@ -43,5 +43,5 @@ Use Accordion to separate supplementary (lower-priority) content into digestible
 ## Accessibility
 
 - Accessible through keyboard.
-  - `Tab` and `Shift+Tab` keys navigate through Accordion titles.
+  - `Tab` and `Shift` + `Tab` keys navigate through Accordion titles.
   - `Enter` and `Space` keys expands or collapses each section.


### PR DESCRIPTION
## What does this PR do?

- [x] modify component to add `sprk-b-TypeDisplaySeven` automatically and remove from story `additionalClasses`
- [x] remove `sprk-b-TypeBodyTwo` from component and add to story
- [x] add new Input `iconAdditionalClasses`
- [x] add new Input `contentAdditionalClasses`
- [x] add new Input `idString`
- [x] emit `openedEvent` when an item is opened 
- [x] emit `closedEvent` when an item is closed
- [x] deprecate `title` and add `heading`
- [x] deprecate `additionalHeadingClasses` and add `headingAdditionalClasses`
- [x] deprecate `iconTypeClosed` and replace with `iconNameClosed`
- [x] deprecate `iconTypeOpen` and replace with `iconNameOpen`
- [x] deprecate `isActive`, use `additionalClasses` instead

### Associated Issue
Fixes #3494
Issue to remove deprecated functionality: #3597 
Issue to make the component respond to changes to `isOpen`: #3568 


### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)