### PR TITLE
update icon color for simple links in masthead on hover

### DIFF
--- a/html/components/_masthead.scss
+++ b/html/components/_masthead.scss
@@ -172,6 +172,12 @@
   }
 }
 
+.sprk-c-Masthead__link.sprk-b-Link--simple:hover {
+  .sprk-c-Icon {
+    color: $sprk-masthead-simple-link-icon-hover-color;
+  }
+}
+
 // Selector has 100% default width
 // then grows to size of content on larger views
 .sprk-c-Masthead__selector {

--- a/html/settings/_settings.scss
+++ b/html/settings/_settings.scss
@@ -1951,6 +1951,8 @@ $sprk-masthead-content-item-padding-left-wide: $sprk-space-m !default;
 $sprk-masthead-link-color: $sprk-black !default;
 /// The color of Masthead Icon Links on hover.
 $sprk-masthead-link-icon-hover-color: $sprk-purple !default;
+/// The color of Simple Masthead Icon Links on hover.
+$sprk-masthead-simple-link-icon-hover-color: $sprk-black !default;
 /// The visited state color of Masthead links.
 $sprk-masthead-link-visited-color: $sprk-black !default;
 /// The font weight for Masthead links.


### PR DESCRIPTION
## What does this PR do?
Updates the icon color for links in Masthead that are 'simple' links and have an icon.

### Associated Issue
Fixes #3576 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team