### PR TITLE
Fix uniqueIds from incrementing on toggle

### DIFF
--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -8,11 +8,16 @@ import SprkIcon from '../../../icons/SprkIcon';
 class SprkMastheadAccordionItem extends Component {
   constructor(props) {
     super(props);
-    const { defaultOpen, subNavLinks } = this.props;
+    const {
+      defaultOpen,
+      subNavLinks,
+      itemId = uniqueId('sprk_accordion_item_'),
+    } = this.props;
     this.state = {
       isOpen: defaultOpen || false,
       height: defaultOpen ? 'auto' : 0,
       subNavLinks: subNavLinks.map((link) => ({ id: uniqueId(), ...link })),
+      uniqueIdentifier: itemId,
     };
     this.toggleAccordionOpen = this.toggleAccordionOpen.bind(this);
   }
@@ -41,9 +46,13 @@ class SprkMastheadAccordionItem extends Component {
       itemId,
       ...rest
     } = this.props;
-    const { isOpen, height, subNavLinks: stateLinks } = this.state;
+    const {
+      isOpen,
+      height,
+      subNavLinks: stateLinks,
+      uniqueIdentifier,
+    } = this.state;
     const TagName = element;
-    const uniqueIdentifier = itemId || uniqueId('sprk_accordion_item_');
     return (
       <li
         className={classNames(
@@ -65,7 +74,11 @@ class SprkMastheadAccordionItem extends Component {
               aria-controls={uniqueIdentifier}
               type="button"
             >
-              <span className="sprk-b-TypeBodyOne sprk-c-MastheadAccordion__heading">
+              <span
+                className="
+                sprk-b-TypeBodyOne
+                sprk-c-MastheadAccordion__heading"
+              >
                 {text}
               </span>
               <SprkIcon
@@ -78,7 +91,10 @@ class SprkMastheadAccordionItem extends Component {
             </button>
             <AnimateHeight duration={300} height={height}>
               <ul
-                className="sprk-b-List sprk-b-List--bare sprk-c-MastheadAccordion__details"
+                className="
+                  sprk-b-List
+                  sprk-b-List--bare
+                  sprk-c-MastheadAccordion__details"
                 id={uniqueIdentifier}
               >
                 {stateLinks.map((subnavlink) => {
@@ -100,7 +116,9 @@ class SprkMastheadAccordionItem extends Component {
                             : undefined
                         }
                         className={classNames(
-                          'sprk-b-Link sprk-b-Link--plain sprk-c-Masthead__link',
+                          `sprk-b-Link
+                          sprk-b-Link--plain
+                          sprk-c-Masthead__link`,
                         )}
                         {...innerRest}
                       >
@@ -119,6 +137,7 @@ class SprkMastheadAccordionItem extends Component {
             className={classNames(
               { 'sprk-c-MastheadAccordion__summary': !isButton },
               {
+                // eslint-disable-next-line max-len
                 'sprk-c-Button sprk-c-Button--secondary sprk-c-Button--compact sprk-c-Button--full@s': isButton,
               },
             )}

--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -76,8 +76,8 @@ class SprkMastheadAccordionItem extends Component {
             >
               <span
                 className="
-                sprk-b-TypeBodyOne
-                sprk-c-MastheadAccordion__heading"
+                  sprk-b-TypeBodyOne
+                  sprk-c-MastheadAccordion__heading"
               >
                 {text}
               </span>

--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
@@ -166,6 +166,38 @@ describe('SprkMastheadAccordionItem:', () => {
     expect(wrapper.find(`#${menuItemContentId}`).length).toBe(1);
   });
 
+  it(`should not change id on toggle`, () => {
+    const wrapper = mount(
+      <SprkMastheadAccordionItem
+        text="Item 1"
+        subNavLinks={[{ text: 'Item 1' }]}
+      />,
+    );
+
+    const menuItemToggle = wrapper.find('.sprk-c-MastheadAccordion__summary');
+    menuItemToggle.simulate('click');
+
+    const menuItemContent = wrapper.find('.sprk-c-MastheadAccordion__details');
+    const menuItemContentId = menuItemContent.getDOMNode().getAttribute('id');
+    const menuItemToggleAriaControls = menuItemToggle
+      .getDOMNode()
+      .getAttribute('aria-controls');
+
+    expect(menuItemContentId).toMatch(/sprk_accordion_item_\d/);
+    expect(menuItemToggleAriaControls).toEqual(menuItemContentId);
+    expect(wrapper.find(`#${menuItemContentId}`).length).toBe(1);
+    expect(wrapper.state().isOpen).toBe(true);
+
+    menuItemToggle.simulate('click');
+
+    const postClickMenuItemContentId = menuItemContent
+      .getDOMNode()
+      .getAttribute('id');
+    expect(wrapper.state().isOpen).toBe(false);
+    expect(menuItemContentId).toMatch(postClickMenuItemContentId);
+    expect(menuItemToggleAriaControls).toEqual(postClickMenuItemContentId);
+  });
+
   it(`should add correct aria-controls and id to
   narrowNav if narrowNavId is passed`, () => {
     const testItemId = 'test12345';

--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.test.js
@@ -45,10 +45,7 @@ describe('SprkMastheadAccordionItem:', () => {
       />,
     );
     expect(
-      wrapper
-        .find('.sprk-c-Masthead__link')
-        .instance()
-        .getAttribute('href'),
+      wrapper.find('.sprk-c-Masthead__link').instance().getAttribute('href'),
     ).toBe('https://www.google.com');
   });
 
@@ -59,10 +56,7 @@ describe('SprkMastheadAccordionItem:', () => {
       />,
     );
     expect(
-      wrapper
-        .find('.sprk-c-Masthead__link')
-        .instance()
-        .getAttribute('href'),
+      wrapper.find('.sprk-c-Masthead__link').instance().getAttribute('href'),
     ).toBe('#nogo');
   });
 
@@ -73,10 +67,7 @@ describe('SprkMastheadAccordionItem:', () => {
       />,
     );
     expect(
-      wrapper
-        .find('.sprk-c-Masthead__link')
-        .instance()
-        .getAttribute('href'),
+      wrapper.find('.sprk-c-Masthead__link').instance().getAttribute('href'),
     ).toBe(null);
   });
 
@@ -90,7 +81,8 @@ describe('SprkMastheadAccordionItem:', () => {
     ).toBe(null);
   });
 
-  it('should render href as #nogo if element supplied is a and href is not supplied', () => {
+  it(`should render href as #nogo if element supplied is
+  a and href is not supplied`, () => {
     const wrapper = mount(<SprkMastheadAccordionItem element="a" />);
     expect(
       wrapper
@@ -116,6 +108,7 @@ describe('SprkMastheadAccordionItem:', () => {
     const wrapper = mount(<SprkMastheadAccordionItem isActive />);
     expect(
       wrapper.find(
+        // eslint-disable-next-line max-len
         '.sprk-c-MastheadAccordion__item.sprk-c-MastheadAccordion__item--active',
       ).length,
     ).toBe(1);
@@ -126,14 +119,16 @@ describe('SprkMastheadAccordionItem:', () => {
     expect(
       wrapper.find('.sprk-c-MastheadAccordion__item.sprk-o-Box').length,
     ).toBe(1);
-    expect(wrapper.find('span.sprk-c-MastheadAccordion__heading').length).toBe(0);
+    expect(wrapper.find('span.sprk-c-MastheadAccordion__heading').length).toBe(
+      0,
+    );
   });
 
   it('should render the right icon if leadingIcon has value', () => {
     const wrapper = mount(<SprkMastheadAccordionItem leadingIcon="settings" />);
-    expect(wrapper.find('.sprk-c-Icon > use[xlinkHref="#settings"]').length).toBe(
-      1,
-    );
+    expect(
+      wrapper.find('.sprk-c-Icon > use[xlinkHref="#settings"]').length,
+    ).toBe(1);
   });
 
   it('should add aria-expanded="true" when the item is open', () => {
@@ -148,7 +143,8 @@ describe('SprkMastheadAccordionItem:', () => {
     expect(wrapper.find('[aria-expanded="true"]').length).toBe(1);
   });
 
-  it('should add aria-controls and id to narrowNav if narrowNavId is not passed', () => {
+  it(`should add aria-controls and id to
+  narrowNav if narrowNavId is not passed`, () => {
     const wrapper = mount(
       <SprkMastheadAccordionItem
         text="Item 1"
@@ -161,31 +157,34 @@ describe('SprkMastheadAccordionItem:', () => {
 
     const menuItemContent = wrapper.find('.sprk-c-MastheadAccordion__details');
     const menuItemContentId = menuItemContent.getDOMNode().getAttribute('id');
-    const menuItemToggleAriaControls = menuItemToggle.getDOMNode().getAttribute('aria-controls');
+    const menuItemToggleAriaControls = menuItemToggle
+      .getDOMNode()
+      .getAttribute('aria-controls');
 
     expect(menuItemContentId).toMatch(/sprk_accordion_item_\d/);
     expect(menuItemToggleAriaControls).toEqual(menuItemContentId);
     expect(wrapper.find(`#${menuItemContentId}`).length).toBe(1);
   });
 
-  it('should add correct aria-controls and id to narrowNav if narrowNavId is passed', () => {
-    const testItemId = "test12345";
+  it(`should add correct aria-controls and id to
+  narrowNav if narrowNavId is passed`, () => {
+    const testItemId = 'test12345';
     const wrapper = mount(
       <SprkMastheadAccordionItem
         text="Item 1"
         itemId={testItemId}
-        subNavLinks={[{ text: 'Item 1'}]}
+        subNavLinks={[{ text: 'Item 1' }]}
       />,
     );
 
     const menuItemToggle = wrapper.find('.sprk-c-MastheadAccordion__summary');
     const menuItemContent = wrapper.find('.sprk-c-MastheadAccordion__details');
     const menuItemContentId = menuItemContent.getDOMNode().getAttribute('id');
-    const menuItemToggleAriaControls = menuItemToggle.getDOMNode().getAttribute('aria-controls');
+    const menuItemToggleAriaControls = menuItemToggle
+      .getDOMNode()
+      .getAttribute('aria-controls');
 
     expect(menuItemContentId).toEqual(testItemId);
     expect(menuItemToggleAriaControls).toEqual(testItemId);
   });
-
-
 });

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -11,10 +11,12 @@ class SprkToggle extends Component {
     super(props);
     // TODO: Remove isDefaultOpen in issue #1296
     const { isDefaultOpen, isOpen = isDefaultOpen } = this.props;
+    const { contentId = uniqueId('sprk_toggle_content_') } = this.props;
 
     this.state = {
       isOpen: isOpen || false,
       height: isOpen ? 'auto' : 0,
+      uniqueIdentifier: contentId,
     };
 
     this.toggleOpen = this.toggleOpen.bind(this);
@@ -47,9 +49,9 @@ class SprkToggle extends Component {
       onClick,
       ...other
     } = this.props;
-    const { isOpen, height } = this.state;
+    const { isOpen, height, uniqueIdentifier } = this.state;
 
-    const uniqueIdentifier = contentId || uniqueId('sprk_toggle_content_');
+    // const uniqueIdentifier = contentId || uniqueId('sprk_toggle_content_');
 
     const containerClasses = classnames('sprk-c-Toggle', additionalClasses);
 

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -51,8 +51,6 @@ class SprkToggle extends Component {
     } = this.props;
     const { isOpen, height, uniqueIdentifier } = this.state;
 
-    // const uniqueIdentifier = contentId || uniqueId('sprk_toggle_content_');
-
     const containerClasses = classnames('sprk-c-Toggle', additionalClasses);
 
     const titleClasses = classnames(

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -165,7 +165,10 @@ describe('SprkToggle:', () => {
   it(`should add classes to the title if triggerTextAdditionalClasses
   are set`, () => {
     const wrapper = mount(
-      <SprkToggle triggerText="Toggle title" triggerTextAdditionalClasses="test">
+      <SprkToggle
+        triggerText="Toggle title"
+        triggerTextAdditionalClasses="test"
+      >
         Body text
       </SprkToggle>,
     );

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -102,14 +102,14 @@ describe('SprkToggle:', () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title">Body text</SprkToggle>,
     );
-    const ButtonAriaControls = wrapper.find('button').prop('aria-controls');
+    const buttonAriaControls = wrapper.find('button').prop('aria-controls');
     const toggleContentId = wrapper
       .find('.sprk-c-Toggle__content')
       .at(1)
       .prop('id');
 
     expect(toggleContentId).toMatch(/sprk_toggle_content_\d/);
-    expect(toggleContentId).toEqual(ButtonAriaControls);
+    expect(toggleContentId).toEqual(buttonAriaControls);
     expect(wrapper.find(`div#${toggleContentId}`).length).toBe(1);
   });
 
@@ -117,14 +117,14 @@ describe('SprkToggle:', () => {
     const wrapper = mount(
       <SprkToggle triggerText="Toggle title">Body text</SprkToggle>,
     );
-    const ButtonAriaControls = wrapper.find('button').prop('aria-controls');
+    const buttonAriaControls = wrapper.find('button').prop('aria-controls');
     const toggleContentId = wrapper
       .find('.sprk-c-Toggle__content')
       .at(1)
       .prop('id');
 
     expect(toggleContentId).toMatch(/sprk_toggle_content_\d/);
-    expect(toggleContentId).toEqual(ButtonAriaControls);
+    expect(toggleContentId).toEqual(buttonAriaControls);
     expect(wrapper.find(`div#${toggleContentId}`).length).toBe(1);
     expect(wrapper.state().isOpen).toBe(false);
 
@@ -137,7 +137,7 @@ describe('SprkToggle:', () => {
 
     expect(wrapper.state().isOpen).toBe(true);
     expect(toggleContentId).toMatch(postClickToggleContentId);
-    expect(ButtonAriaControls).toEqual(postClickToggleContentId);
+    expect(buttonAriaControls).toEqual(postClickToggleContentId);
   });
 
   it(`should add classes to the content if contentAdditionalClasses

--- a/react/src/components/toggle/SprkToggle.test.js
+++ b/react/src/components/toggle/SprkToggle.test.js
@@ -113,6 +113,33 @@ describe('SprkToggle:', () => {
     expect(wrapper.find(`div#${toggleContentId}`).length).toBe(1);
   });
 
+  it('should not change id when toggled', () => {
+    const wrapper = mount(
+      <SprkToggle triggerText="Toggle title">Body text</SprkToggle>,
+    );
+    const ButtonAriaControls = wrapper.find('button').prop('aria-controls');
+    const toggleContentId = wrapper
+      .find('.sprk-c-Toggle__content')
+      .at(1)
+      .prop('id');
+
+    expect(toggleContentId).toMatch(/sprk_toggle_content_\d/);
+    expect(toggleContentId).toEqual(ButtonAriaControls);
+    expect(wrapper.find(`div#${toggleContentId}`).length).toBe(1);
+    expect(wrapper.state().isOpen).toBe(false);
+
+    wrapper.find('button').simulate('click');
+
+    const postClickToggleContentId = wrapper
+      .find('.sprk-c-Toggle__content')
+      .at(1)
+      .prop('id');
+
+    expect(wrapper.state().isOpen).toBe(true);
+    expect(toggleContentId).toMatch(postClickToggleContentId);
+    expect(ButtonAriaControls).toEqual(postClickToggleContentId);
+  });
+
   it(`should add classes to the content if contentAdditionalClasses
   are set`, () => {
     const wrapper = mount(


### PR DESCRIPTION
## What does this PR do?
Updates the uniqueIds in SprkToggle and SprkMastheadAccordionItem to be unique if there are multiple on the same page, but not increment on toggle.

### Associated Issue
Fixes #3598 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)

### Screenshots
Example of multiple toggles on the same page with different ids.
![image](https://user-images.githubusercontent.com/15703773/97623361-eab2bc80-19fb-11eb-95a3-b29aca6a4eb7.png)

