### PR TITLE
Fix tooltip icon to align to baseline

### DIFF
--- a/html/components/_tooltip.scss
+++ b/html/components/_tooltip.scss
@@ -1,11 +1,10 @@
 ////
 /// @group tooltip
 ////
-
 .sprk-c-Tooltip__container {
   position: relative;
   display: inline-flex;
-  vertical-align: middle;
+  vertical-align: baseline;
 }
 
 .sprk-c-Tooltip__trigger {
@@ -65,8 +64,12 @@
   &.sprk-c-Tooltip--top-left {
     top: auto;
     left: auto;
-    bottom: calc(100% + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset});
-    right: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
+    bottom: calc(
+      100% + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset}
+    );
+    right: calc(
+      50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2
+    );
 
     &::before {
       top: auto;
@@ -79,8 +82,12 @@
   &.sprk-c-Tooltip--top-right {
     top: auto;
     right: auto;
-    bottom: calc(100% + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset});
-    left: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
+    bottom: calc(
+      100% + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset}
+    );
+    left: calc(
+      50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2
+    );
 
     &::before {
       top: auto;
@@ -91,8 +98,12 @@
   }
 
   &.sprk-c-Tooltip--bottom-left {
-    top: calc(100% + #{$sprk-tooltip-caret-width} +  #{$sprk-tooltip-animation-offset});
-    right: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
+    top: calc(
+      100% + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset}
+    );
+    right: calc(
+      50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2
+    );
     bottom: auto;
     left: auto;
 
@@ -105,10 +116,14 @@
   }
 
   &.sprk-c-Tooltip--bottom-right {
-    top: calc(100% + #{$sprk-tooltip-caret-width} +  #{$sprk-tooltip-animation-offset});
+    top: calc(
+      100% + #{$sprk-tooltip-caret-width} + #{$sprk-tooltip-animation-offset}
+    );
     right: auto;
     bottom: auto;
-    left: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
+    left: calc(
+      50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2
+    );
 
     &::before {
       top: calc(-#{$sprk-tooltip-caret-width} / 2);
@@ -136,19 +151,25 @@
     top: auto;
     left: auto;
     bottom: calc(100% + #{$sprk-tooltip-caret-width});
-    right: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
+    right: calc(
+      50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2
+    );
   }
 
   &.sprk-c-Tooltip--top-right {
     top: auto;
     right: auto;
     bottom: calc(100% + #{$sprk-tooltip-caret-width});
-    left: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
+    left: calc(
+      50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2
+    );
   }
 
   &.sprk-c-Tooltip--bottom-left {
     top: calc(100% + #{$sprk-tooltip-caret-width});
-    right: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
+    right: calc(
+      50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2
+    );
     bottom: auto;
     left: auto;
   }
@@ -157,6 +178,8 @@
     top: calc(100% + #{$sprk-tooltip-caret-width});
     right: auto;
     bottom: auto;
-    left: calc(50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2);
+    left: calc(
+      50% - #{$sprk-tooltip-caret-width} - #{$sprk-tooltip-caret-offset} / 2
+    );
   }
 }


### PR DESCRIPTION
## What does this PR do?
Fixed tooltip icon in angular originally aligned to middle and now is aligned to baseline.

### Associated Issue
#3570 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [ ] Build Component in HTML
 - [ ] Build Component in Angular
 - [ ] Build Component in React

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
 

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team

### Screenshots
Baseline aligned
<img width="549" alt="Screen Shot 2020-11-06 at 2 14 37 PM" src="https://user-images.githubusercontent.com/26862826/98406718-7780fa00-203c-11eb-96f5-dc08aaa8b85e.png">

Middle aligned
<img width="534" alt="Screen Shot 2020-11-06 at 2 13 51 PM" src="https://user-images.githubusercontent.com/26862826/98406720-78199080-203c-11eb-8d6f-43ea2be08fbe.png">

