### PR TITLE
Resolve missing SCSS module

### DIFF
--- a/src/pages/installing-spark/html-installation.mdx
+++ b/src/pages/installing-spark/html-installation.mdx
@@ -44,7 +44,7 @@ import sparkPrerender from "@sparkdesignsystem/spark/es5/sparkPrerender";
 import "@sparkdesignsystem/spark/es5/sparkPolyfills";
 
 // import the Spark CSS
-import "@sparkdesignsystem/spark-styles/spark";
+import "@sparkdesignsystem/spark-styles/_spark.scss";
 
 // initialize Spark
 sparkPrerender();


### PR DESCRIPTION
This seems to have (accidentally?) changed from the v13 docs.

Left as is, page build will fail with the following error:

```
ERROR in ./src/index.js 7:0-47
Module not found: Error: Can't resolve '@sparkdesignsystem/spark-styles/spark' in 'C:\Users\blovett\GitHub\Sorry\spark-html\src'

webpack 5.11.0 compiled with 1 error in 3956 ms

```
Reverting this import line to its v13 state allows the page to build without issue.

Windows 10 20H2 (19041), PowerShell 7.2.
