### PR TITLE
update link underline color

### DIFF
--- a/styles/android/spark_design_tokens_colors.xml
+++ b/styles/android/spark_design_tokens_colors.xml
@@ -83,13 +83,13 @@
   <color name="sprk_link_color">#ff603aa1</color><!-- The default color on Links. -->
   <color name="sprk_link_underline_color">#ff603aa1</color><!-- The color of the underline on Links. -->
   <color name="sprk_link_underline_visited_color">#ff8d8d8c</color><!-- The color of the underline on visited Links. -->
-  <color name="sprk_link_border_bottom_color">#ff603aa1</color><!-- The border color of the underline on Links -->
+  <color name="sprk_link_border_bottom_color">#ff603aa1</color><!-- The border color of the underline on Links. -->
   <color name="sprk_link_hover_color">#ff2e1166</color><!-- The color of Links on hover. -->
   <color name="sprk_link_simple_color">#ff1c1b1a</color><!-- The color value of Simple Links. -->
   <color name="sprk_link_simple_hover_color">#ff1c1b1a</color><!-- The color of Simple Links on hover. -->
   <color name="sprk_link_simple_hover_underline_color">#ffc8102e</color><!-- The underline color value of Simple Links on hover. -->
   <color name="sprk_link_light_color">#ffffffff</color><!-- The color value of Light Links. -->
-  <color name="sprk_link_light_hover_color">#ffffffff</color><!-- The color of Light Links on hover -->
+  <color name="sprk_link_light_hover_color">#ffffffff</color><!-- The color of Light Links on hover. -->
   <color name="sprk_link_light_hover_underline_color">#ffffffff</color><!-- The underline color value of Light Links on hover. -->
   <color name="sprk_link_has_icon_color_icon">#ff603aa1</color><!-- The color of icons in Links containing icons. -->
   <color name="sprk_link_has_icon_hover_color_text">#ff2e1166</color><!-- The color value for Links with icons in the hover state. -->

--- a/styles/android/spark_design_tokens_colors.xml
+++ b/styles/android/spark_design_tokens_colors.xml
@@ -83,6 +83,7 @@
   <color name="sprk_link_color">#ff603aa1</color><!-- The default color on Links. -->
   <color name="sprk_link_underline_color">#ff603aa1</color><!-- The color of the underline on Links. -->
   <color name="sprk_link_underline_visited_color">#ff8d8d8c</color><!-- The color of the underline on visited Links. -->
+  <color name="sprk_link_border_bottom_color">#ff603aa1</color><!-- The border color of the underline on Links -->
   <color name="sprk_link_hover_color">#ff2e1166</color><!-- The color of Links on hover. -->
   <color name="sprk_link_simple_color">#ff1c1b1a</color><!-- The color value of Simple Links. -->
   <color name="sprk_link_simple_hover_color">#ff1c1b1a</color><!-- The color of Simple Links on hover. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -161,7 +161,7 @@
   <string name="sprk_link_transition">0.3s</string><!-- The transition timing for hover, active and focus styles on Links. -->
   <string name="sprk_link_text_decoration">none</string><!-- The text decoration on Links. -->
   <string name="sprk_link_border_bottom_style">solid</string><!-- The border style of the underline on Links. -->
-  <string name="sprk_link_border_bottom">2.00dp solid #ff8d8d8c</string><!-- The style of the underline on Links. -->
+  <string name="sprk_link_border_bottom">2.00dp solid #ff603aa1</string><!-- The style of the underline on Links. -->
   <string name="sprk_link_hover_border_bottom">2.00dp solid #ff2e1166</string><!-- The underline style of Links on hover. -->
   <string name="sprk_link_visited_border_bottom">2.00dp solid #ff8d8d8c</string><!-- The style of the underline on visited Links. -->
   <string name="sprk_link_simple_hover_border_bottom">2.00dp solid #ffc8102e</string><!-- The underline style of visited Simple Links on hover. -->

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -160,6 +160,7 @@ public class SparkDesignTokens {
     public static let sprkIconFilledFillColor = UIColor(red: 0.110, green: 0.106, blue: 0.102, alpha:1)
     public static let sprkIconStrokeColor = UIColor(red: 0.110, green: 0.106, blue: 0.102, alpha:1)
     public static let sprkLavender = UIColor(red: 0.745, green: 0.518, blue: 0.969, alpha:1)
+    public static let sprkLinkBorderBottomColor = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
     public static let sprkLinkColor = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
     public static let sprkLinkHasIconColorIcon = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
     public static let sprkLinkHasIconHoverColorText = UIColor(red: 0.180, green: 0.067, blue: 0.400, alpha:1)

--- a/styles/tokens/link.json
+++ b/styles/tokens/link.json
@@ -76,7 +76,7 @@
       },
       "bottom": {
         "comment": "The style of the underline on Links.",
-        "value": "{link.underline.width.value} {link.border.bottom-style.value} {link.underline.visited.color.value}",
+        "value": "{link.underline.width.value} {link.border.bottom-style.value} {purple.value}",
         "attributes": {
           "category": "content"
         },

--- a/styles/tokens/link.json
+++ b/styles/tokens/link.json
@@ -74,9 +74,18 @@
         "file": "settings",
         "themable": true
       },
+      "bottom-color": {
+        "comment": "The border color of the underline on Links",
+        "value": "{purple.value}",
+        "attributes": {
+          "category": "color"
+        },
+        "file": "settings",
+        "themable": true
+      },
       "bottom": {
         "comment": "The style of the underline on Links.",
-        "value": "{link.underline.width.value} {link.border.bottom-style.value} {purple.value}",
+        "value": "{link.underline.width.value} {link.border.bottom-style.value} {link.border.bottom-color.value}",
         "attributes": {
           "category": "content"
         },

--- a/styles/tokens/link.json
+++ b/styles/tokens/link.json
@@ -75,7 +75,7 @@
         "themable": true
       },
       "bottom-color": {
-        "comment": "The border color of the underline on Links",
+        "comment": "The border color of the underline on Links.",
         "value": "{purple.value}",
         "attributes": {
           "category": "color"
@@ -237,7 +237,7 @@
           "themable": true
         },
         "color": {
-          "comment": "The color of Light Links on hover",
+          "comment": "The color of Light Links on hover.",
           "value": "{white.value}",
           "attributes": {
             "category": "color"


### PR DESCRIPTION
## What does this PR do?
Updates the link underline color to be purple instead of gray.

### Associated Issue
Fixes #3791 

### Code
 - [x] Build Component in HTML
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  

### Deploy Preview Reviewed and Approved
 - [x] Design Team
 - [x] Accessibility Team