### PR TITLE
fixes #3719 update angular huge story text label to match html/react

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/inputs/Text.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Text.stories.ts
@@ -191,7 +191,7 @@ export const invalidHugeTextInput = () => ({
         sprkInput
         variant="huge"
       />
-      <label sprkLabel>Huge Text Input</label>
+      <label sprkLabel>Text Input Label</label>
       <span sprkFieldError>
         <sprk-icon
           iconName="exclamation-filled"
@@ -229,7 +229,7 @@ export const disabledHugeTextInput = () => ({
         variant="huge"
         disabled
       />
-      <label isDisabled="true" sprkLabel>Huge Text Input</label>
+      <label isDisabled="true" sprkLabel>Text Input Label</label>
     </sprk-input-container>
   `,
 });
@@ -257,7 +257,7 @@ export const legacyHugeTextInput = () => ({
         #textInput="ngModel"
         sprkInput
       />
-      <label sprkLabel>Huge Text Input</label>
+      <label sprkLabel>Text Input Label</label>
     </sprk-huge-input-container>
   `,
 });
@@ -287,7 +287,7 @@ export const legacyInvalidHugeTextInput = () => ({
         aria-invalid="true"
         sprkInput
       />
-      <label sprkLabel>Huge Text Input</label>
+      <label sprkLabel>Text Input Label</label>
       <span sprkFieldError>
         <sprk-icon
           iconName="exclamation-filled"
@@ -324,7 +324,7 @@ export const legacyDisabledHugeTextInput = () => ({
         sprkInput
         disabled
       />
-      <label class="sprk-b-Label--disabled" sprkLabel>Huge Text Input</label>
+      <label class="sprk-b-Label--disabled" sprkLabel>Text Input Label</label>
     </sprk-huge-input-container>
   `,
 });

--- a/angular/projects/spark-angular/src/lib/components/inputs/Text.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Text.stories.ts
@@ -160,7 +160,7 @@ export const hugeTextInput = () => ({
         sprkInput
         variant="huge"
       />
-      <label sprkLabel>Huge Text Input</label>
+      <label sprkLabel>Text Input Label</label>
     </sprk-input-container>
   `,
 });


### PR DESCRIPTION
## What does this PR do?
Update huge story text label to match react and angular sb examples.

### Associated Issue
Fixes #3719

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)