### PR TITLE
Add Dropdown Updates

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.spec.ts
@@ -112,6 +112,27 @@ describe('SprkDropdownComponent', () => {
     ).toEqual(1);
   });
 
+  it('should emit open and closed events when dropdown is opened or closed', (done) => {
+    let openEventEmitted = false;
+    let closedEventEmitted = false;
+
+    dropdownComponent.openedEvent.subscribe((g) => {
+      openEventEmitted = true;
+      done();
+    });
+    dropdownComponent.closedEvent.subscribe((g) => {
+      closedEventEmitted = true;
+      done();
+    });
+
+    dropdownTriggerElement.click();
+    expect(openEventEmitted).toEqual(true);
+    expect(closedEventEmitted).toEqual(false);
+
+    dropdownTriggerElement.click();
+    expect(closedEventEmitted).toEqual(true);
+  });
+
   it('should add the correct classes if additionalClasses are supplied', () => {
     wrapperComponent.additionalClasses = 'sprk-u-pam sprk-u-man';
     dropdownElement = fixture.nativeElement.querySelector('.sprk-c-Dropdown');

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.spec.ts
@@ -721,6 +721,49 @@ describe('SprkDropdownComponent', () => {
     expect(paragraphs.length).toEqual(2);
   });
 
+  it('should not render empty paragraphs for choices using routerLink', () => {
+    fixture.detectChanges();
+    wrapperComponent.variant = 'informational';
+    wrapperComponent.choices = [
+      {
+        content: {
+          title: 'Choice Title',
+          infoLine1: 'Information about this choice',
+          infoLine2: 'More Information',
+        },
+        routerLink: '/router-test',
+        value: 'Choice Title 1',
+        active: false,
+      },
+    ];
+    fixture.detectChanges();
+    dropdownTriggerElement.click();
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('.sprk-c-Dropdown'),
+    ).not.toBeNull();
+    let paragraphs = fixture.nativeElement.querySelectorAll('p');
+    expect(paragraphs.length).toEqual(3);
+
+    wrapperComponent.choices = [
+      {
+        content: {
+          title: 'Choice Title',
+          infoLine1: 'Information about this choice',
+        },
+        value: 'Choice Title 1',
+        routerLink: '/router-test',
+        active: false,
+      },
+    ];
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('.sprk-c-Dropdown'),
+    ).not.toBeNull();
+    paragraphs = fixture.nativeElement.querySelectorAll('p');
+    expect(paragraphs.length).toEqual(2);
+  });
+
   it('should apply selector Input to aria-label and title', () => {
     wrapperComponent.selector = 'test';
     fixture.detectChanges();

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -160,8 +160,12 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
                 [attr.aria-label]="choice.content.title"
               >
                 <p sprkText variant="bodyOne">{{ choice.content.title }}</p>
-                <p sprkText variant="bodyTwo">{{ choice.content.infoLine1 }}</p>
-                <p sprkText variant="bodyTwo">{{ choice.content.infoLine2 }}</p>
+                <p sprkText variant="bodyTwo" *ngIf="choice.content.infoLine1">
+                  {{ choice.content.infoLine1 }}
+                </p>
+                <p sprkText variant="bodyTwo" *ngIf="choice.content.infoLine2">
+                  {{ choice.content.infoLine2 }}
+                </p>
               </a>
             </ng-template>
           </li>

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -139,7 +139,7 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
                 }"
                 [attr.aria-label]="choice.content.title"
               >
-                <p class="sprk-b-TypeBodyOne">{{ choice.content.title }}</p>
+                <p sprkText variant="bodyOne">{{ choice.content.title }}</p>
                 <p sprkText variant="bodyTwo" *ngIf="choice.content.infoLine1">
                   {{ choice.content.infoLine1 }}
                 </p>
@@ -159,9 +159,9 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
                 }"
                 [attr.aria-label]="choice.content.title"
               >
-                <p class="sprk-b-TypeBodyOne">{{ choice.content.title }}</p>
-                <p>{{ choice.content.infoLine1 }}</p>
-                <p>{{ choice.content.infoLine2 }}</p>
+                <p sprkText variant="bodyOne">{{ choice.content.title }}</p>
+                <p sprkText variant="bodyTwo">{{ choice.content.infoLine1 }}</p>
+                <p sprkText variant="bodyTwo">{{ choice.content.infoLine2 }}</p>
               </a>
             </ng-template>
           </li>

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -367,7 +367,7 @@ export class SprkDropdownComponent implements OnChanges {
     event.preventDefault();
     this.isOpen = !this.isOpen;
     if (this.isOpen) {
-      this.openedEvent.emit(event);
+      this.openedEvent.emit();
     } else {
       this.closedEvent.emit();
     }

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -326,6 +326,20 @@ export class SprkDropdownComponent implements OnChanges {
    */
   @Output()
   choiceMade: EventEmitter<string> = new EventEmitter();
+
+  /**
+   * This event will be emitted
+   * when the Dropdown is opened.
+   */
+  @Output()
+  openedEvent: EventEmitter<any> = new EventEmitter();
+  /**
+   * This event will be emitted
+   * when the Dropdown is closed.
+   */
+  @Output()
+  closedEvent: EventEmitter<any> = new EventEmitter();
+
   /**
    * @ignore
    */
@@ -352,6 +366,11 @@ export class SprkDropdownComponent implements OnChanges {
   toggle(event): void {
     event.preventDefault();
     this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.openedEvent.emit(event);
+    } else {
+      this.closedEvent.emit();
+    }
   }
 
   @HostListener('document:click', ['$event'])

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.spec.ts
@@ -405,7 +405,49 @@ describe('SprkMastheadSelectorComponent', () => {
     expect(paragraphs.length).toEqual(2);
   });
 
-  it('should set dropdown title to heading', () => {
+  it('should not render empty paragraphs for choices using routerLink', () => {
+    fixture.detectChanges();
+    wrapperComponent.choices = [
+      {
+        content: {
+          title: 'Choice Title',
+          infoLine1: 'Information about this choice',
+          infoLine2: 'More Information',
+        },
+        routerLink: '/router-test',
+        value: 'Choice Title 1',
+        active: false,
+      },
+    ];
+    fixture.detectChanges();
+    mastheadSelectorTriggerElement.click();
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('.sprk-c-Dropdown'),
+    ).not.toBeNull();
+    let paragraphs = fixture.nativeElement.querySelectorAll('p');
+    expect(paragraphs.length).toEqual(3);
+
+    wrapperComponent.choices = [
+      {
+        content: {
+          title: 'Choice Title',
+          infoLine1: 'Information about this choice',
+        },
+        routerLink: '/router-test',
+        value: 'Choice Title 1',
+        active: false,
+      },
+    ];
+    fixture.detectChanges();
+    expect(
+      fixture.nativeElement.querySelector('.sprk-c-Dropdown'),
+    ).not.toBeNull();
+    paragraphs = fixture.nativeElement.querySelectorAll('p');
+    expect(paragraphs.length).toEqual(2);
+  });
+
+  it('should set selector title to heading', () => {
     wrapperComponent.heading = 'test';
     fixture.detectChanges();
     mastheadSelectorTriggerElement.click();

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.spec.ts
@@ -73,6 +73,27 @@ describe('SprkMastheadSelectorComponent', () => {
     expect(mastheadSelectorComponent).toBeTruthy();
   });
 
+  it('should emit open and closed events when selector is opened or closed', (done) => {
+    let openEventEmitted = false;
+    let closedEventEmitted = false;
+
+    mastheadSelectorComponent.openedEvent.subscribe((g) => {
+      openEventEmitted = true;
+      done();
+    });
+    mastheadSelectorComponent.closedEvent.subscribe((g) => {
+      closedEventEmitted = true;
+      done();
+    });
+
+    mastheadSelectorTriggerElement.click();
+    expect(openEventEmitted).toEqual(true);
+    expect(closedEventEmitted).toEqual(false);
+
+    mastheadSelectorTriggerElement.click();
+    expect(closedEventEmitted).toEqual(true);
+  });
+
   it('should have the correct base classes on Masthead Selector content', () => {
     mastheadSelectorTriggerElement.click();
     fixture.detectChanges();

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.ts
@@ -231,6 +231,19 @@ export class SprkMastheadSelectorComponent implements OnChanges {
   choiceMade: EventEmitter<string> = new EventEmitter();
 
   /**
+   * This event will be emitted
+   * when the Masthead Selector is opened.
+   */
+  @Output()
+  openedEvent: EventEmitter<any> = new EventEmitter();
+  /**
+   * This event will be emitted
+   * when the Masthead Selector is closed.
+   */
+  @Output()
+  closedEvent: EventEmitter<any> = new EventEmitter();
+
+  /**
    * @ignore
    */
   isOpen = false;
@@ -254,6 +267,11 @@ export class SprkMastheadSelectorComponent implements OnChanges {
   toggle(event): void {
     event.preventDefault();
     this.isOpen = !this.isOpen;
+    if (this.isOpen) {
+      this.openedEvent.emit();
+    } else {
+      this.closedEvent.emit();
+    }
   }
 
   @HostListener('document:click', ['$event'])

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.ts
@@ -133,7 +133,7 @@ import { ISprkMastheadSelectorChoice } from '../sprk-masthead-selector/sprk-mast
                 }"
                 [attr.aria-label]="choice.content.title"
               >
-                <p class="sprk-b-TypeBodyOne">{{ choice.content.title }}</p>
+                <p sprkText variant="bodyOne">{{ choice.content.title }}</p>
                 <p sprkText variant="bodyTwo" *ngIf="choice.content.infoLine1">
                   {{ choice.content.infoLine1 }}
                 </p>
@@ -153,7 +153,7 @@ import { ISprkMastheadSelectorChoice } from '../sprk-masthead-selector/sprk-mast
                 }"
                 [attr.aria-label]="choice.content.title"
               >
-                <p class="sprk-b-TypeBodyOne">{{ choice.content.title }}</p>
+                <p sprkText variant="bodyOne">{{ choice.content.title }}</p>
                 <p sprkText variant="bodyTwo" *ngIf="choice.content.infoLine1">
                   {{ choice.content.infoLine1 }}
                 </p>

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.component.ts
@@ -173,13 +173,13 @@ export class SprkMastheadSelectorComponent implements OnChanges {
   /**
    * The value supplied will be visually hidden
    * inside the trigger. Useful
-   * for when title is empty,
-   * and only `triggerIconType` is supplied.
+   * for when heading is empty,
+   * and only `triggerIconName` is supplied.
    */
   @Input()
   screenReaderText: string;
   /**
-   * This value will be assigned to the masthead selector
+   * This value will be assigned to the Masthead Selector
    * placeholder text and the dropdown heading.
    */
   @Input()
@@ -210,7 +210,9 @@ export class SprkMastheadSelectorComponent implements OnChanges {
   @Input()
   choices: ISprkMastheadSelectorChoice[];
   /**
-   * Renders the icon to the right of the trigger text.
+   * The name of the icon that
+   * renders the icon to the right
+   * of the trigger text.
    */
   @Input()
   triggerIconName: string;
@@ -221,7 +223,7 @@ export class SprkMastheadSelectorComponent implements OnChanges {
   triggerText: string;
   /**
    * The event that is
-   * emitted from the Dropdown when a choice
+   * emitted from the Masthead Selector when a choice
    * is clicked. The event contains the value
    * of the choice that was clicked.
    */
@@ -316,7 +318,7 @@ export class SprkMastheadSelectorComponent implements OnChanges {
   }
 
   /**
-   * Update trigger text with default choice value
+   * Update trigger text with default choice value.
    */
   protected _updateTriggerTextWithDefaultValue(): void {
     const defaultChoice = this._lookupDefaultChoice();
@@ -332,7 +334,7 @@ export class SprkMastheadSelectorComponent implements OnChanges {
   }
 
   /**
-   * Lookup choice with specified `isDefault: true` field
+   * Lookup choice with specified `isDefault: true` field.
    */
   protected _lookupDefaultChoice(): ISprkMastheadSelectorChoice | null {
     return this.choices.find((choice) => choice.isDefault) || null;

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.interfaces.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead-selector/sprk-masthead-selector.interfaces.ts
@@ -1,7 +1,7 @@
 /**
  * This choice object is used to
  * construct a selectable
- * choice item in the masthead selector.
+ * choice item in the Masthead Selector.
  */
 export interface ISprkMastheadSelectorChoice {
   /**
@@ -72,7 +72,7 @@ export interface ISprkMastheadSelectorChoice {
     infoLine1: string;
     /**
      * Value is rendered in a paragraph tag
-     * underneath the `infoLine1` paragraph.
+     * underneath the `infoLine2` paragraph.
      * Use to give extra information about the choice item.
      */
     infoLine2?: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.interfaces.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.interfaces.ts
@@ -1,5 +1,5 @@
 import { ISprkMastheadSelectorChoice } from './sprk-masthead-selector/sprk-masthead-selector.interfaces';
-
+import { ISprkDropdownChoice } from '../sprk-dropdown/sprk-dropdown.interfaces';
 /**
  * Used to create the "Big Navigation"
  * in the extended variant of the Masthead.
@@ -35,7 +35,7 @@ export interface ISprkBigNavLink {
    * Optional sub-navigation for the link.
    * Renders a dropdown under the main link.
    */
-  subNav?: ISprkMastheadSelectorChoice;
+  subNav?: ISprkDropdownChoice;
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?
Adds outputs for dropdown/masthead selector being open/closed. Adds correct TS interface for the other sprk-dropdowns still left in masthead big-nav. Adds dropdown/masthead selector tests for choices with routerLink. Adds sprkText directives to the all paragraphs in dropdown/masthead selector, was previously added to some but not all. Adds routerLink ngIf test to selector. Fixes general typos in dropdown/masthead selector.

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.


### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
<img width="748" alt="Screen Shot 2021-02-15 at 7 58 22 AM" src="https://user-images.githubusercontent.com/2117593/107969448-06bb7900-6f6d-11eb-938b-04d31ceb228e.png">
<img width="744" alt="Screen Shot 2021-02-15 at 7 57 15 AM" src="https://user-images.githubusercontent.com/2117593/107969455-091dd300-6f6d-11eb-98f8-1c0e605be1f4.png">

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension, yes but I noticed an unrelated issue that I logged here, https://github.com/sparkdesignsystem/spark-design-system/issues/3864
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)
