### PR TITLE
Teaser Card CTA Element

### DIFF
--- a/react/src/components/card/SprkCard.stories.js
+++ b/react/src/components/card/SprkCard.stories.js
@@ -7,7 +7,7 @@ import SprkCardTeaser from './components/SprkCardTeaser/SprkCardTeaser';
 export default {
   title: 'Components/Card',
   decorators: [
-    story => <div className="sprk-o-Box sprk-o-Box--large">{story()}</div>
+    (story) => <div className="sprk-o-Box sprk-o-Box--large">{story()}</div>,
   ],
   component: SprkCard,
   parameters: {
@@ -18,7 +18,10 @@ export default {
 };
 
 export const defaultStory = () => (
-  <SprkCard idString="card-1" additionalContentClasses="sprk-o-Stack sprk-o-Stack--large">
+  <SprkCard
+    idString="card-1"
+    additionalContentClasses="sprk-o-Stack sprk-o-Stack--large"
+  >
     Base Card Content
   </SprkCard>
 );
@@ -44,8 +47,9 @@ export const highlightedHeader = () => (
     idString="highlighted-header"
     variant="highlightedHeader"
     highlightedHeaderConfig={{
-      bodyText:
-        'Lorem ipsum dolor sit amet, doctus invenire vix te. Facilisi perpetua an pri, errem commune mea at, mei prima tantas signiferumque at. Numquam.',
+      bodyText: `Lorem ipsum dolor sit amet, doctus invenire vix te.
+         Facilisi perpetua an pri, errem commune mea at,
+         mei prima tantas signiferumque at. Numquam.`,
       title: 'Card Title',
       description: 'Description',
     }}
@@ -57,11 +61,13 @@ export const teaser = () => (
     idString="card1"
     variant="teaser"
     teaserConfig={{
-      bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+      bodyText:
+        'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
       cta: {
         ctaAnalytics: 'test',
         text: 'Learn More',
         ctaVariant: 'button',
+        ctaLinkElement: 'a',
         href: '#nogo',
       },
       media: {
@@ -83,7 +89,8 @@ export const teaserWithDifferentElementOrder = () => (
     idString="card1"
     variant="teaser"
     teaserConfig={{
-      bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+      bodyText:
+        'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
       cta: {
         ctaAnalytics: 'test',
         text: 'Learn More',
@@ -111,13 +118,14 @@ export const twoUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',
           ctaVariant: 'button',
           href: '#nogo',
-          buttonVariant: 'secondary'
+          buttonVariant: 'secondary',
         },
         media: {
           href: '#nogo',
@@ -136,7 +144,8 @@ export const twoUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',
@@ -170,7 +179,8 @@ export const threeUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',
@@ -195,7 +205,8 @@ export const threeUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',
@@ -220,7 +231,8 @@ export const threeUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',
@@ -254,7 +266,8 @@ export const fourUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',
@@ -279,7 +292,8 @@ export const fourUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',
@@ -304,7 +318,8 @@ export const fourUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',
@@ -329,7 +344,8 @@ export const fourUpCards = () => (
       variant="teaser"
       additionalClasses="sprk-o-Stack__item sprk-o-Stack__item--flex@l"
       teaserConfig={{
-        bodyText: 'Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua.',
+        bodyText: `Lorem ipsum dolor sit amet, doctus
+          invenirevix te. Facilisi perpetua.`,
         cta: {
           ctaAnalytics: 'test',
           text: 'Learn More',

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -21,6 +21,7 @@ const teaserDesigners = {
   cta: {
     text: 'Go To Designer Basics',
     ctaVariant: 'button',
+    ctaLinkElement: 'a',
     buttonVariant: 'tertiary',
     href: '/principles/design-principles',
   },
@@ -46,6 +47,7 @@ const teaserDevelopers = {
   cta: {
     text: 'Go To Developer Basics',
     ctaVariant: 'button',
+    ctaLinkElement: 'a',
     buttonVariant: 'tertiary',
     href: '/installing-spark',
   },
@@ -72,6 +74,7 @@ const teaserComponents = {
   cta: {
     text: 'Go To Components',
     ctaVariant: 'button',
+    ctaLinkElement: 'a',
     buttonVariant: 'tertiary',
     href: '/using-spark/components/button',
   },
@@ -96,6 +99,7 @@ const teaserFoundations = {
   cta: {
     text: 'Go To Foundations',
     ctaVariant: 'button',
+    ctaLinkElement: 'a',
     buttonVariant: 'tertiary',
     href: '/using-spark/foundations/color',
   },
@@ -119,6 +123,7 @@ const teaserUtils = {
   cta: {
     text: 'Go To Utilities',
     ctaVariant: 'button',
+    ctaLinkElement: 'a',
     buttonVariant: 'tertiary',
     href: '/using-spark/foundations/css-utilities',
   },
@@ -141,6 +146,7 @@ const teaserNews = {
   cta: {
     text: 'Go To News',
     ctaVariant: 'button',
+    ctaLinkElement: 'a',
     buttonVariant: 'tertiary',
     href: 'https://github.com/sparkdesignsystem/spark-design-system/releases',
   },


### PR DESCRIPTION
## What does this PR do?
- Changes the React Teaser Card story so that the CTA renders as an `a` element without `role="button"`.
- Change the 6 cards on the homepage in the same way.

This is so that the CTAs are identified as _links_, not _buttons_ for screen readers.

[More info on Screen Reader Link Navigation](https://dequeuniversity.com/screenreaders/voiceover-keyboard-shortcuts#vo-mac-navigation)

### Associated Issue
Fixes #3857 

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [X] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team
