### PR TITLE
Fix alt text for Highlight Board and Teaser Card

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -144,7 +144,7 @@ export const teaser = () => ({
       title="Teaser Card Title"
       body="Lorem ipsum dolor sit amet, doctus invenirevix te. Facilisi perpetua."
       imgSrc="https://spark-assets.netlify.app/desktop.jpg"
-      imgAlt="Placeholder Image"
+      imgAlt="Learn more"
       imgHref="#nogo"
       ctaType="button"
       ctaText="Learn More"
@@ -182,6 +182,7 @@ export const twoUpCards = () => ({
          media="img"
          idString="card-two-up-1"
          imgSrc="https://spark-assets.netlify.app/desktop.jpg"
+         imgAlt="Learn more"
          body="This Lorem ipsum dolor sit amet, doctus invenire vix te.
            Facilisi perpetua an pri, errem commune mea at, mei prima tantas
            signiferumque at. Numquam."
@@ -201,6 +202,7 @@ export const twoUpCards = () => ({
           media="img"
           idString="card-two-up-2"
           imgSrc="https://spark-assets.netlify.app/desktop.jpg"
+          imgAlt="Learn more"
           body="This Lorem ipsum dolor sit amet, doctus invenire vix
             te. Facilisi perpetua an pri, errem commune mea at, mei
             prima tantas signiferumque at. Numquam."
@@ -240,6 +242,7 @@ export const threeUpCards = () => ({
          idString="card-three-up-1"
          media="img"
          imgSrc="https://spark-assets.netlify.app/desktop.jpg"
+         imgAlt="Learn more"
          body="This Lorem ipsum dolor sit amet, doctus invenire vix te.
            Facilisi perpetua an pri, errem commune mea at, mei prima
            tantas signiferumque at. Numquam."
@@ -259,6 +262,7 @@ export const threeUpCards = () => ({
           media="img"
           idString="card-three-up-2"
           imgSrc="https://spark-assets.netlify.app/desktop.jpg"
+          imgAlt="Learn more"
           body="This Lorem ipsum dolor sit amet, doctus invenire vix
             te. Facilisi perpetua an pri, errem commune mea at, mei
             prima tantas signiferumque at. Numquam."
@@ -279,6 +283,7 @@ export const threeUpCards = () => ({
           media="img"
           idString="card-three-up-3"
           imgSrc="https://spark-assets.netlify.app/desktop.jpg"
+          imgAlt="Learn more"
           body="This Lorem ipsum dolor sit amet, doctus invenire vix
             te. Facilisi perpetua an pri, errem commune mea at, mei
             prima tantas signiferumque at. Numquam."
@@ -317,6 +322,7 @@ export const fourUpCards = () => ({
          additionalCtaClasses="sprk-c-Button--secondary"
          media="img"
          idString="card-four-up-1"
+         imgAlt="Learn more"
          imgSrc="https://spark-assets.netlify.app/desktop.jpg"
          body="This Lorem ipsum dolor sit amet, doctus invenire vix te.
            Facilisi perpetua an pri, errem commune mea at, mei prima
@@ -336,6 +342,7 @@ export const fourUpCards = () => ({
           additionalCtaClasses="sprk-c-Button--secondary"
           media="img"
           idString="card-four-up-2"
+          imgAlt="Learn more"
           imgSrc="https://spark-assets.netlify.app/desktop.jpg"
           body="This Lorem ipsum dolor sit amet, doctus invenire vix
             te. Facilisi perpetua an pri, errem commune mea at, mei
@@ -355,6 +362,7 @@ export const fourUpCards = () => ({
           additionalCtaClasses="sprk-c-Button--secondary"
           media="img"
           idString="card-four-up-3"
+          imgAlt="Learn more"
           imgSrc="https://spark-assets.netlify.app/desktop.jpg"
           body="This Lorem ipsum dolor sit amet, doctus invenire vix
             te. Facilisi perpetua an pri, errem commune mea at, mei
@@ -374,6 +382,7 @@ export const fourUpCards = () => ({
           additionalCtaClasses="sprk-c-Button--secondary"
           media="img"
           idString="card-four-up-4"
+          imgAlt="Learn more"
           imgSrc="https://spark-assets.netlify.app/desktop.jpg"
           body="This Lorem ipsum dolor sit amet, doctus invenire vix
             te. Facilisi perpetua an pri, errem commune mea at, mei

--- a/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.component.ts
@@ -101,8 +101,9 @@ export class SprkHighlightBoardComponent implements OnInit {
   @Input()
   imgSrc: string;
   /**
-   * The Highlight Board will use this as
-   * the `alt` text for the main image.
+   * The `alt` text for the main image. If the image used is decorative and
+   * does not present any important content, set this property to "" so
+   * the image will be hidden from assistive technology.
    */
   @Input()
   imgAlt: string;

--- a/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
@@ -20,7 +20,11 @@ ${markdownDocumentationLinkBuilder('highlight-board')}
 - If the Buttons are being used to navigate
 to a new page, they should be \`<a>\` elements.
 If they are being used to trigger an event or action,
-then they should be \`<button>\` elements with \`aria-role=button\`.
+then they should be \`<button>\` elements.
+- If the image used is decorative and does not present any important content,
+make sure to set \`imgAlt=""\` so the image will be hidden from assistive
+technology. For more information on how and when to add \`alt\` text to images,
+see this [alt text guide](https://webaim.org/techniques/alttext/#decorative).
 `,
     docs: { iframeHeight: 600 },
   },

--- a/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-highlight-board/sprk-highlight-board.stories.ts
@@ -49,7 +49,7 @@ export const defaultStory = () => ({
       ctaText2="Developers"
       ctaHref2="#nogo"
       imgSrc="https://spark-assets.netlify.app/desktop.jpg"
-      imgAlt="placeholder"
+      imgAlt=""
       idString="highlightboard-1"
     >
     </sprk-highlight-board>
@@ -92,7 +92,7 @@ export const stacked = () => ({
       ctaText="Learn More"
       type="stacked"
       imgSrc="https://spark-assets.netlify.app/desktop.jpg"
-      imgAlt="placeholder"
+      imgAlt=""
       idString="highlightboard-4"
     >
     </sprk-highlight-board>

--- a/html/components/card.stories.js
+++ b/html/components/card.stories.js
@@ -129,7 +129,7 @@ export const teaser = () =>
       <a href="#nogo" class="sprk-o-Stack__item">
         <img
           class="sprk-c-Card__media"
-          alt="Spark placeholder image."
+          alt="Learn more"
           src="https://spark-assets.netlify.app/desktop.jpg"
         >
       </a>
@@ -186,7 +186,7 @@ export const teaserWithDifferentElementOrder = () =>
 
       <a href="#nogo" class="sprk-o-Stack__item">
         <img
-          alt="Spark placeholder image"
+          alt="Learn more"
           src="https://spark-assets.netlify.app/desktop.jpg" />
       </a>
 
@@ -244,7 +244,7 @@ export const twoUpCards = () =>
         >
           <img
             class="sprk-c-Card__media"
-            alt="Spark placeholder image."
+            alt="Learn more"
             src="https://spark-assets.netlify.app/desktop.jpg"
           >
         </a>
@@ -295,7 +295,7 @@ export const twoUpCards = () =>
       <a href="#nogo" class="sprk-o-Stack__item">
         <img
           class="sprk-c-Card__media"
-          alt="Spark placeholder image."
+          alt="Learn more"
           src="https://spark-assets.netlify.app/desktop.jpg">
       </a>
 

--- a/html/components/highlight-board.stories.js
+++ b/html/components/highlight-board.stories.js
@@ -15,7 +15,7 @@ Make sure to include keypress handlers in your JavaScript.
 - If the Buttons are being used to navigate
 to a new page, they should be \`<a>\` elements.
 If they are being used to trigger an event or action,
-then they should be \`<button>\` elements with \`aria-role=button\`.
+then they should be \`<button>\` elements.
 `,
   },
 };

--- a/html/components/highlight-board.stories.js
+++ b/html/components/highlight-board.stories.js
@@ -28,7 +28,7 @@ export const defaultStory = () => `
       <img
         class="sprk-c-HighlightBoard__image"
         src="https://spark-assets.netlify.app/desktop.jpg"
-        alt="desktop"
+        alt=""
       >
 
       <div class="
@@ -58,12 +58,12 @@ export const defaultStory = () => `
           </div>
 
           <div class="sprk-o-Stack__item sprk-c-HighlightBoard__cta">
-            <a 
+            <a
               class="
-                sprk-c-Button 
-                sprk-c-Button--full@s 
+                sprk-c-Button
+                sprk-c-Button--full@s
                 sprk-c-Button--secondary
-              " 
+              "
               href="#nogo">
               Developers
             </a>
@@ -142,7 +142,7 @@ export const stacked = () => `
   >
     <img
       class="sprk-c-HighlightBoard__image"
-      src="https://spark-assets.netlify.app/desktop.jpg" alt="desktop">
+      src="https://spark-assets.netlify.app/desktop.jpg" alt="">
 
     <div class="
       sprk-c-HighlightBoard__content

--- a/react/src/components/card/SprkCard.stories.js
+++ b/react/src/components/card/SprkCard.stories.js
@@ -73,7 +73,7 @@ export const teaser = () => (
       media: {
         href: '#nogo',
         mediaLinkElement: 'a',
-        imgAlt: 'placeholder image',
+        imgAlt: 'Learn more',
         imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
         mediaAnalyticsString: 'Card:teaser-link',
         mediaVariant: 'img',
@@ -100,7 +100,7 @@ export const teaserWithDifferentElementOrder = () => (
       media: {
         href: '#nogo',
         mediaLinkElement: 'a',
-        imgAlt: 'placeholder image',
+        imgAlt: 'Learn more',
         imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
         mediaAnalyticsString: 'Card:teaser-link',
         mediaVariant: 'img',
@@ -130,7 +130,7 @@ export const twoUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',
@@ -156,7 +156,7 @@ export const twoUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',
@@ -191,7 +191,7 @@ export const threeUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',
@@ -217,7 +217,7 @@ export const threeUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',
@@ -243,7 +243,7 @@ export const threeUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',
@@ -278,7 +278,7 @@ export const fourUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',
@@ -304,7 +304,7 @@ export const fourUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',
@@ -330,7 +330,7 @@ export const fourUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',
@@ -356,7 +356,7 @@ export const fourUpCards = () => (
         media: {
           href: '#nogo',
           mediaLinkElement: 'a',
-          imgAlt: 'placeholder image',
+          imgAlt: 'Learn more',
           imgSrc: 'https://spark-assets.netlify.app/desktop.jpg',
           mediaAnalyticsString: 'Card:teaser-link',
           mediaVariant: 'img',

--- a/react/src/components/highlight-board/SprkHighlightBoard.js
+++ b/react/src/components/highlight-board/SprkHighlightBoard.js
@@ -118,7 +118,9 @@ SprkHighlightBoard.propTypes = {
    */
   imgSrc: PropTypes.string,
   /**
-   * The `alt` text for the main image.
+   * The `alt` text for the main image. If the image used is decorative and
+   * does not present any important content, set this property to "" so
+   * the image will be hidden from assistive technology.
    */
   imgAlt: PropTypes.string,
   /**

--- a/react/src/components/highlight-board/SprkHighlightBoard.js
+++ b/react/src/components/highlight-board/SprkHighlightBoard.js
@@ -20,15 +20,8 @@ const SprkHighlightBoard = (props) => {
     variant,
     additionalClasses,
     idString,
-    analyticsString,
     ...other
   } = props;
-
-  warning(
-    (imgSrc && imgAlt) || (!imgSrc && !imgAlt),
-    `SprkHighlightBoard: If imgSrc is provided, then imgAlt is required
-    (and vice versa).`,
-  );
 
   warning(
     !(ctaText2 !== null && ctaText === null),
@@ -149,7 +142,8 @@ SprkHighlightBoard.propTypes = {
    */
   ctaAnalytics: PropTypes.string,
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as a
+   * unique selector for automated tools.
    */
   ctaIdString: PropTypes.string,
   /** The text for the second call to action. */
@@ -174,11 +168,13 @@ SprkHighlightBoard.propTypes = {
    */
   variant: PropTypes.oneOf(['noImage', 'stacked']),
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as
+   * a unique selector for automated tools.
    */
   idString: PropTypes.string,
   /**
-   * A space-separated string of classes to add to the outermost container of the component.
+   * A space-separated string of classes to add to
+   * the outermost container of the component.
    */
   additionalClasses: PropTypes.string,
 };

--- a/react/src/components/highlight-board/SprkHighlightBoard.stories.js
+++ b/react/src/components/highlight-board/SprkHighlightBoard.stories.js
@@ -14,7 +14,11 @@ ${markdownDocumentationLinkBuilder('highlight-board')}
 - If the Buttons are being used to navigate
 to a new page, they should be \`<a>\` elements.
 If they are being used to trigger an event or action,
-then they should be \`<button>\` elements with \`aria-role=button\`.
+then they should be \`<button>\` elements.
+- If the image used is decorative and does not present any important content,
+make sure to set \`imgAlt=""\` so the image will be hidden from assistive
+technology. For more information on how and when to add \`alt\` text to images,
+see this [alt text guide](https://webaim.org/techniques/alttext/#decorative).
 `,
   },
 };

--- a/react/src/components/highlight-board/SprkHighlightBoard.stories.js
+++ b/react/src/components/highlight-board/SprkHighlightBoard.stories.js
@@ -5,9 +5,7 @@ import { markdownDocumentationLinkBuilder } from '../../../../storybook-utilitie
 export default {
   title: 'Components/Highlight Board',
   component: SprkHighlightBoard,
-  decorators: [
-    story => <div className="sprk-o-Box">{story()}</div>
-  ],
+  decorators: [(story) => <div className="sprk-o-Box">{story()}</div>],
   parameters: {
     jest: ['SprkHighlightBoard'],
     info: `
@@ -24,7 +22,7 @@ then they should be \`<button>\` elements with \`aria-role=button\`.
 export const defaultStory = () => (
   <SprkHighlightBoard
     imgSrc="https://spark-assets.netlify.app/desktop.jpg"
-    imgAlt="desktop"
+    imgAlt=""
     heading="Hello, Welcome To Spark Design System"
     ctaText="Designers"
     ctaHref="#nogo"
@@ -58,7 +56,7 @@ export const stacked = () => (
   <SprkHighlightBoard
     variant="stacked"
     imgSrc="https://spark-assets.netlify.app/desktop.jpg"
-    imgAlt="desktop"
+    imgAlt=""
     heading="Hello, Welcome To Spark Design System"
     ctaText="Designers"
     ctaHref="#nogo"

--- a/react/src/components/highlight-board/SprkHighlightBoard.test.js
+++ b/react/src/components/highlight-board/SprkHighlightBoard.test.js
@@ -53,29 +53,9 @@ describe('SprkHighlightBoard:', () => {
   });
 
   it('should not allow a secondary CTA without a primary CTA', () => {
-    const wrapper = shallow(
-      <SprkHighlightBoard ctaText2="so is this" />,
-    );
+    const wrapper = shallow(<SprkHighlightBoard ctaText2="so is this" />);
     const contentDiv = wrapper.find('div.sprk-c-HighlightBoard__cta');
 
     expect(contentDiv.length).toBe(0);
-  });
-
-  it('should error if imgSrc is provided without imgAlt', () => {
-    const wrapper = shallow(<SprkHighlightBoard imgSrc="foo" />);
-    const actual = stub.getCall(0).args[0];
-
-    expect(
-      actual.includes('If imgSrc is provided, then imgAlt is required'),
-    ).toBe(true);
-  });
-
-  it('should error if imgAlt is provided without imgSrc', () => {
-    const wrapper = shallow(<SprkHighlightBoard imgAlt="foo" />);
-    const actual = stub.getCall(0).args[0];
-
-    expect(
-      actual.includes('If imgSrc is provided, then imgAlt is required'),
-    ).toBe(true);
   });
 });


### PR DESCRIPTION
## What does this PR do?
- Sets `alt=""` on the images in the Highlight Board stories. These images are presentational and should not be described to screen readers.
- Sets `alt="Learn more"` on the images in the Teaser Card stories. These images are links so they should always have alt 
text. In this case they should have text matching the CTA link, which is "Learn More". [When an image is the only content of a link, the text alternative for the image describes the unique function of the link.](https://www.w3.org/WAI/WCAG21/Techniques/html/H30)
- Removes the error message in React Highlight Board when imgAlt is not set.

### Associated Issue
Fixes #3850 

### Code
 - [X] Build Component in HTML
 - [X] Build Component in Angular
 - [X] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [X] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team
