### PR TITLE
Fix extended masthead from pushing down content on hover

### DIFF
--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -194,6 +194,7 @@
   <string name="sprk_masthead_accordion_item_text_align">left</string><!-- The text alignment of the items in the navigation links when masthead is on narrow viewports. -->
   <string name="sprk_masthead_accordion_item_background">transparent</string><!-- The background of the items in the navigation links when masthead is on narrow viewports. -->
   <string name="sprk_big_nav_link_hover_border_bottom">transparent</string><!-- The border-bottom of the links in the big nav item when the big nav item is hovered in the Masthead Extended. -->
+  <string name="sprk_big_nav_item_border_bottom">0.125rem solid transparent</string><!-- The border bottom of the big navigation items in the Masthead Extended. -->
   <string name="sprk_big_nav_item_active_border_bottom">0.125rem solid #ffc8102e</string><!-- The border bottom of the active big navigation items in the Masthead Extended. -->
   <string name="sprk_big_nav_item_open_border_bottom">0.125rem solid #ffc8102e</string><!-- The border bottom of open big navigation items in the Masthead Extended. -->
   <string name="sprk_menu_icon_transition">transform 0.3s ease-in-out, opacity 0.2s ease-in-out</string><!-- The transition on the menu icon that turns the menu icon into an 'X'. -->

--- a/styles/components/_masthead.scss
+++ b/styles/components/_masthead.scss
@@ -238,6 +238,7 @@
   position: relative;
   text-align: center;
   white-space: nowrap;
+  border-bottom: $sprk-big-nav-item-border-bottom;
 
   &:active,
   &:focus,

--- a/styles/tokens/masthead.json
+++ b/styles/tokens/masthead.json
@@ -551,6 +551,15 @@
         "themable": true
       },
       "item": {
+        "border-bottom": {
+          "comment": "The border bottom of the big navigation items in the Masthead Extended.",
+          "value": "0.125rem solid transparent",
+          "attributes": {
+            "category": "content"
+          },
+          "file": "settings",
+          "themable": true
+        },
         "active-border-bottom": {
           "comment": "The border bottom of the active big navigation items in the Masthead Extended.",
           "value": "0.125rem solid {red.value}",


### PR DESCRIPTION
## What does this PR do?
<img width="1250" alt="Screen Shot 2021-02-16 at 4 48 06 PM" src="https://user-images.githubusercontent.com/4342363/108125701-d829c500-7076-11eb-8d95-2468dcd4a05d.png">

## 🤷🏽‍♂️ What was wrong?
- These big navigational item links were the culprit.
- Some items have link type `--plain` and some have `--simple` which was bad
- On hover, these links have a red border bottom underline. Usually, these links have a transparent border bottom with the same size so things don't move around on hover
  - `--plain` removes the border.
- There's a hover color change on its parent <li> (via `sprk-c-Masthead__link--big-nav`), but it didn't have that transparent border bottom default to prevent things from moving around.

### ✨ ✅ Final result
- `sprk-c-Masthead__link--big-nav` now has a default transparent border so it takes up the same amount of space after hover/active etc.
- Resulting in a new style attribute, added to design tokens, and updated internal files. (no edited story files.

### Associated Issue
Fixes #3856 

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - no changes

### Deploy Preview Reviewed and Approved
 - no changes, this is more about where the style is applied in code.
