### PR TITLE
Fix no-set-state-on-update eslint error

### DIFF
--- a/react/src/base/inputs/components/SprkInputElement/SprkInputElement.js
+++ b/react/src/base/inputs/components/SprkInputElement/SprkInputElement.js
@@ -19,12 +19,11 @@ class SprkInputElement extends Component {
     }
 
     this.calculateAriaDescribedBy = this.calculateAriaDescribedBy.bind(this);
+    this.setAriaDescribedBy = this.setAriaDescribedBy.bind(this);
   }
 
   componentDidMount() {
-    this.setState({
-      calculatedAriaDescribedBy: this.calculateAriaDescribedBy(),
-    });
+    this.setAriaDescribedBy();
   }
 
   componentDidUpdate(prevProps) {
@@ -34,10 +33,14 @@ class SprkInputElement extends Component {
       errorContainerId !== prevProps.errorContainerId ||
       ariaDescribedBy !== prevProps.ariaDescribedBy
     ) {
-      this.setState({
-        calculatedAriaDescribedBy: this.calculateAriaDescribedBy(),
-      });
+      this.setAriaDescribedBy();
     }
+  }
+
+  setAriaDescribedBy() {
+    this.setState({
+      calculatedAriaDescribedBy: this.calculateAriaDescribedBy(),
+    });
   }
 
   calculateAriaDescribedBy() {
@@ -172,6 +175,12 @@ SprkInputElement.propTypes = {
    * attribute on the Input.
    */
   ariaDescribedBy: propTypes.string,
+  children: propTypes.node,
+  disabled: propTypes.bool,
+  hiddenLabel: propTypes.bool,
+  forwardedRef: propTypes.shape(),
+  value: propTypes.string,
+  defaultValue: propTypes.string,
 };
 
 export default SprkInputElement;


### PR DESCRIPTION
## What does this PR do?
Adds an additional function to handle updating the state of `ariaDescribedBy` in the SprkInputElement.

### Associated Issue
Fixes #3851 

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)