### PR TITLE
Quickfix: WCAG messaging on validation guide

### DIFF
--- a/src/pages/using-spark/guides/validation-messaging.mdx
+++ b/src/pages/using-spark/guides/validation-messaging.mdx
@@ -27,7 +27,7 @@ Giving validation feedback is an emotional process. Support users with this proc
 
 <img
   srcSet={validationAnatomySet}
-  class="sprk-u-pam sprk-u-pbh sprk-u-Width-100"
+  class="sprk-u-Measure sprk-u-pam sprk-u-pbh sprk-u-Width-100"
   src={validationAnatomy}
   alt="Anatomy of Input validation with numbers pointing to each part: placement, timing, and language."
 />
@@ -103,4 +103,4 @@ Use error messaging to clarify any system errors and additional constraints to t
   - *Contains a number.*
   - *Contains a special character.*
 
-> The guides are not all-inclusive in regard to accessibility considerations. Refer to: [WCAG 2.1 guidelines](https://www.w3.org/TR/WCAG21/) for additional insights.
+> The guides are not all-inclusive in regard to accessibility considerations. Refer to the [Web Content Accessibility Guidelines (WCAG 2.1, Level AA)](https://www.w3.org/TR/WCAG21/) for additional insights.


### PR DESCRIPTION
## What does this PR do?
- Olya noticed that we should specify that we're following Level AA accessibility guidelines. Add that detail to the disclaimer at the bottom.
- Also fixed the image to have a limited width on larger viewports.


![image](https://user-images.githubusercontent.com/4342363/112015525-46442a80-8b02-11eb-8d9d-84fcdcc68105.png)

**This is changing just a few words**

