### PR TITLE
Remove unecessary secondary variant on SprkLink

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -263,10 +263,7 @@ const IndexPage = () => (
           </SprkStackItem>
 
           <SprkStackItem>
-            <SprkLink
-              href="https://github.com/sparkdesignsystem/spark-design-system/blob/main/CONTRIBUTING.md"
-              variant="secondary"
-            >
+            <SprkLink href="https://github.com/sparkdesignsystem/spark-design-system/blob/main/CONTRIBUTING.md">
               Learn More
             </SprkLink>
           </SprkStackItem>


### PR DESCRIPTION
Fixes console error for undefined prop value on spark doc site.