### PR TITLE
Remove bolding on hover on links on dark backgrounds

### DIFF
--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -297,7 +297,7 @@ public class SparkDesignTokens {
     public static let sprkLinkHasIconVisitedFill = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
     public static let sprkLinkHasIconVisitedStroke = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
     public static let sprkLinkLightFontWeight = "300"
-    public static let sprkLinkLightHoverFontWeight = "500"
+    public static let sprkLinkLightHoverFontWeight = "300"
     public static let sprkLinkSimpleFontWeight = "300"
     public static let sprkMastheadAccordionActiveBackgroundColor = UIColor(red: 0.969, green: 0.969, blue: 0.969, alpha:1)
     public static let sprkMastheadAccordionActiveFontColor = UIColor(red: 0.110, green: 0.106, blue: 0.102, alpha:1)

--- a/styles/tokens/link.json
+++ b/styles/tokens/link.json
@@ -232,7 +232,7 @@
       "hover": {
         "font-weight": {
           "comment": "The font weight of Light Links on hover.",
-          "value": "{font.weight.body.one.value}",
+          "value": "{font.weight.body.two.value}",
           "file": "settings",
           "themable": true
         },


### PR DESCRIPTION
Fixes:
![light link hover](https://user-images.githubusercontent.com/4342363/113611918-29891600-961d-11eb-971b-3b3c8dc37a09.gif)
![Apr-05-2021 14-19-42](https://user-images.githubusercontent.com/4342363/113611926-2beb7000-961d-11eb-8535-a377aa534a1f.gif)
