### PR TITLE
Adjust footer link font weight

### DIFF
--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -66,7 +66,7 @@
   <string name="sprk_dropdown_border_style">solid</string><!-- The border style of the Dropdown. -->
   <string name="sprk_dropdown_border">1.00dp solid #fff7f7f7</string><!-- The border of the Dropdown. -->
   <string name="sprk_dropdown_shadow">0 0 40px 2px rgba(0, 0, 0, 0.1)</string><!-- The box shadow of the Dropdown. -->
-  <string name="sprk_footer_link_font_weight">normal</string><!-- Link font-weight on the Footer. -->
+  <string name="sprk_footer_link_font_weight">300</string><!-- Link font-weight on the Footer. -->
   <string name="sprk_footer_trigger_font_weight">normal</string><!-- Toggle trigger font-weight on the Footer. -->
   <string name="sprk_footer_trigger_hover_text_decoration">underline</string><!-- Toggle trigger hover text decoration on the Footer. -->
   <string name="sprk_footer_toggle_transition">0.3s</string><!-- Toggle transition timing on the Footer. -->

--- a/styles/tokens/footer.json
+++ b/styles/tokens/footer.json
@@ -30,7 +30,7 @@
       },
       "font-weight": {
         "comment": "Link font-weight on the Footer.",
-        "value": "normal",
+        "value": "300",
         "attributes": {
           "category": "content"
         },


### PR DESCRIPTION
Modifies the `font-weight` of Footer Links to be the same in the default and hover/focus states so that the text will not change size when it is interacted with.