### PR TITLE
React Disabled Password bug

### DIFF
--- a/react/src/base/inputs/SprkRevealInput/SprkRevealInput.js
+++ b/react/src/base/inputs/SprkRevealInput/SprkRevealInput.js
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import uniqueId from 'lodash/uniqueId';
+import classNames from 'classnames';
 import SprkTextInput from '../SprkTextInput/SprkTextInput';
 
 class SprkRevealInput extends Component {
@@ -14,16 +15,21 @@ class SprkRevealInput extends Component {
   }
 
   toggleReveal() {
-    this.setState(prevState => ({
+    this.setState((prevState) => ({
       isRevealed: !prevState.isRevealed,
     }));
   }
 
   render() {
     const { isRevealed, revealControlId } = this.state;
-    const { toggleLabel, ...rest } = this.props;
+    const { toggleLabel, disabled, ...rest } = this.props;
+
     return (
-      <SprkTextInput type={isRevealed ? 'text' : 'password'} {...rest}>
+      <SprkTextInput
+        type={isRevealed ? 'text' : 'password'}
+        disabled={disabled}
+        {...rest}
+      >
         <div
           className="
           sprk-b-Checkbox
@@ -35,10 +41,14 @@ class SprkRevealInput extends Component {
             id={revealControlId}
             type="checkbox"
             onClick={this.toggleReveal}
+            disabled={disabled}
           />
           <label
             htmlFor={revealControlId}
-            className="sprk-b-Label sprk-b-Label--inline sprk-b-Checkbox__label"
+            className={classNames(
+              'sprk-b-Label sprk-b-Label--inline sprk-b-Checkbox__label',
+              { 'sprk-b-Label--disabled': disabled },
+            )}
           >
             {toggleLabel}
           </label>
@@ -50,11 +60,13 @@ class SprkRevealInput extends Component {
 
 SprkRevealInput.propTypes = {
   /**
-   * A space-separated string of classes to add to the outermost container of the component.
+   * A space-separated string of classes to add to the outermost container
+   *  of the component.
    */
   additionalClasses: PropTypes.string,
   /**
-   * Assigned to the `data-analytics` attribute serving as a unique selector for outside libraries to capture data.
+   * Assigned to the `data-analytics` attribute serving as a unique selector
+   * for outside libraries to capture data.
    */
   analyticsString: PropTypes.string,
   /**
@@ -75,7 +87,8 @@ SprkRevealInput.propTypes = {
    */
   hiddenLabel: PropTypes.bool,
   /**
-   * Assigned to the `data-id` attribute serving as a unique selector for automated tools.
+   * Assigned to the `data-id` attribute serving as a unique selector for
+   * automated tools.
    */
   idString: PropTypes.string,
   /**
@@ -102,12 +115,16 @@ SprkRevealInput.propTypes = {
    * component in the valid or the error state.
    */
   valid: PropTypes.bool,
+  /**
+   * 	If true, will render the component in the disabled state.
+   */
+  disabled: PropTypes.bool,
 };
 
 SprkRevealInput.defaultProps = {
   additionalClasses: '',
   analyticsString: '',
-  formatter: value => value,
+  formatter: (value) => value,
   helperText: '',
   hiddenLabel: false,
   idString: '',


### PR DESCRIPTION
## What does this PR do?
Adds a new `disabled` prop to `SprkRevealInput` that is passed on to the input, the checkbox, and the Show Password label. This is not a breaking change because `disabled` was already being used in the story and passed to the input through `...rest`.

### Code
 - [X] Build Component in React
 - [X] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [X] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team