### PR TITLE
Angular Icon aria-hidden

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-alert/sprk-alert.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-alert/sprk-alert.component.ts
@@ -21,7 +21,7 @@ import {
         <sprk-icon
           [iconName]="getIconName()"
           additionalClasses="sprk-c-Alert__icon sprk-c-Icon--xl sprk-c-Icon--filled sprk-c-Icon--filled-current-color"
-          aria-hidden="true"
+          ariaHidden="true"
         ></sprk-icon>
 
         <p class="sprk-c-Alert__text"><ng-content></ng-content></p>
@@ -37,7 +37,7 @@ import {
         <sprk-icon
           iconName="{{ dismissIconName }}"
           additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
-          aria-hidden="true"
+          ariaHidden="true"
         ></sprk-icon>
       </button>
     </div>

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -230,7 +230,7 @@ export const teaserIcon = () => ({
         >
           <sprk-icon
             iconName="call-team-member"
-            aria-hidden="true"
+            ariaHidden="true"
             additionalClasses="sprk-c-Icon--xl"
           ></sprk-icon>
         </a>

--- a/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.spec.ts
@@ -77,6 +77,14 @@ describe('SprkIconComponent', () => {
     expect(iconElement.getAttribute('aria-labelledby')).toEqual('test');
   });
 
+  it('should add aria-hidden', () => {
+    component.iconName = 'bell';
+    component.ariaHidden = 'true';
+    fixture.detectChanges();
+    expect(iconElement.hasAttribute('aria-hidden')).toBeTruthy();
+    expect(iconElement.getAttribute('aria-hidden')).toEqual('true');
+  });
+
   it('should add the correct classes if iconName has no value, but additionalClasses does', () => {
     component.additionalClasses = 'sprk-u-pam sprk-u-man';
     fixture.detectChanges();

--- a/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.ts
@@ -7,6 +7,7 @@ import { Component, Input } from '@angular/core';
       [ngClass]="getClasses()"
       [attr.viewBox]="viewBox"
       [attr.aria-labelledby]="ariaLabelledby"
+      [attr.aria-hidden]="ariaHidden"
       [attr.data-id]="idString"
     >
       <use [attr.xlink:href]="icon" />
@@ -43,6 +44,12 @@ export class SprkIconComponent {
    */
   @Input()
   ariaLabelledby: string;
+  /**
+   * Expects a value to assign to
+   * the `aria-hidden` attribute of the icon.
+   */
+  @Input()
+  ariaHidden: string;
   /**
    * Expects a space separated string
    * of classes to be added to the

--- a/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-tooltip/sprk-tooltip.component.ts
@@ -35,13 +35,13 @@ import { uniqueId } from 'lodash';
         <sprk-icon
           [iconType]="iconNameToUse"
           [additionalClasses]="iconAdditionalClasses"
-          aria-hidden="true"
+          ariaHidden="true"
         ></sprk-icon>
       </button>
       <span
         [ngClass]="getTooltipClasses()"
         [attr.id]="id"
-        aria-hidden="true"
+        ariaHidden="true"
         role="tooltip"
         #tooltipElement
       >


### PR DESCRIPTION
## What does this PR do?
- Adds the `ariaHidden` Input to `sprk-icon`.
- Adds a unit test to cover the new behavior.
- Updates Alert, Card, and Tooltip to use the new Input.

### Associated Issue
Fixes 2453085

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)
