### PR TITLE
Input Icon Alt Text

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/inputs/Date.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Date.stories.ts
@@ -107,6 +107,7 @@ export const invalidDateInput = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/DatePicker.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/DatePicker.stories.ts
@@ -79,6 +79,8 @@ export const defaultStory = () => ({
           iconName="calendar"
           additionalClasses="sprk-c-Icon--stroke-current-color"
           sprk-input-icon
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="datepicker"
@@ -120,6 +122,8 @@ export const invalidDatePicker = () => ({
           iconName="calendar"
           additionalClasses="sprk-c-Icon--stroke-current-color"
           sprk-input-icon
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="invalid-datepicker"
@@ -139,6 +143,8 @@ export const invalidDatePicker = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -171,6 +177,8 @@ export const disabledDatePicker = () => ({
           iconName="calendar"
           additionalClasses="sprk-c-Icon--stroke-current-color"
           sprk-input-icon
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="disabled-datepicker"
@@ -212,6 +220,8 @@ export const legacyStory = () => ({
         iconType="calendar"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-datepicker"
@@ -253,6 +263,8 @@ export const legacyInvalidDatePicker = () => ({
         iconType="calendar"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-invalid-datepicker"
@@ -272,6 +284,8 @@ export const legacyInvalidDatePicker = () => ({
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -304,6 +318,8 @@ export const legacyDisabledDatePicker = () => ({
         iconType="calendar"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-disabled-datepicker"

--- a/angular/projects/spark-angular/src/lib/components/inputs/DatePicker.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/DatePicker.stories.ts
@@ -80,7 +80,6 @@ export const defaultStory = () => ({
           additionalClasses="sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <input
           id="datepicker"
@@ -123,7 +122,6 @@ export const invalidDatePicker = () => ({
           additionalClasses="sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <input
           id="invalid-datepicker"
@@ -144,7 +142,6 @@ export const invalidDatePicker = () => ({
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -178,7 +175,6 @@ export const disabledDatePicker = () => ({
           additionalClasses="sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <input
           id="disabled-datepicker"
@@ -221,7 +217,6 @@ export const legacyStory = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-datepicker"
@@ -264,7 +259,6 @@ export const legacyInvalidDatePicker = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-invalid-datepicker"
@@ -285,7 +279,6 @@ export const legacyInvalidDatePicker = () => ({
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -319,7 +312,6 @@ export const legacyDisabledDatePicker = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-disabled-datepicker"

--- a/angular/projects/spark-angular/src/lib/components/inputs/HelperText.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/HelperText.stories.ts
@@ -119,6 +119,7 @@ export const invalidHelperText = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/Monetary.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Monetary.stories.ts
@@ -126,6 +126,7 @@ export const invalidMonetaryInput = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -239,6 +240,7 @@ export const legacyInvalidMonetaryInput = () => ({
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/Password.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Password.stories.ts
@@ -144,6 +144,7 @@ export const invalidPasswordInput = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -266,6 +267,7 @@ export const legacyInvalidPasswordInput = () => ({
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/Percentage.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Percentage.stories.ts
@@ -69,7 +69,6 @@ export const percentageInput = () => ({
           additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <input
           id="percentage"
@@ -108,7 +107,6 @@ export const invalidPercentageInput = () => ({
           additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <input
           id="invalid-percentage"
@@ -125,7 +123,6 @@ export const invalidPercentageInput = () => ({
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -159,7 +156,6 @@ export const disabledPercentageInput = () => ({
           additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <input
           id="disabled-percentage"
@@ -195,7 +191,6 @@ export const legacyStory = () => ({
         additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-percentage"
@@ -229,7 +224,6 @@ export const legacyInvalidPercentageInput = () => ({
         additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-invalid-percentage"
@@ -245,7 +239,6 @@ export const legacyInvalidPercentageInput = () => ({
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -281,7 +274,6 @@ export const legacyDisabledPercentageInput = () => ({
         additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-disabled-percentage"

--- a/angular/projects/spark-angular/src/lib/components/inputs/Percentage.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Percentage.stories.ts
@@ -68,6 +68,8 @@ export const percentageInput = () => ({
           iconName="percent"
           additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
           sprk-input-icon
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="percentage"
@@ -99,13 +101,14 @@ export const invalidPercentageInput = () => ({
       <div class="
         sprk-b-InputContainer__icon-container
         sprk-b-InputContainer__icon-container--narrow"
-      >      
+      >
         <label for="invalid-percentage" sprkLabel>Percentage</label>
         <sprk-icon
           iconName="percent"
           additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
-          aria-invalid="true"
           sprk-input-icon
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="invalid-percentage"
@@ -114,12 +117,15 @@ export const invalidPercentageInput = () => ({
           name="percentage"
           type="tel"
           sprkInput
+          aria-invalid="true"
         />
       </div>
       <span sprkFieldError id="percentage-error">
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -152,6 +158,8 @@ export const disabledPercentageInput = () => ({
           iconName="percent"
           additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
           sprk-input-icon
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="disabled-percentage"
@@ -186,6 +194,8 @@ export const legacyStory = () => ({
         iconType="percent"
         additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-percentage"
@@ -217,14 +227,16 @@ export const legacyInvalidPercentageInput = () => ({
       <sprk-icon
         iconType="percent"
         additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
-        aria-invalid="true"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-invalid-percentage"
         aria-describedby="legacy-percentage-error"
         class="sprk-b-InputContainer__input--has-icon-right sprk-b-TextInput--error"
         name="percentage"
+        aria-invalid="true"
         type="tel"
         sprkInput
       />
@@ -232,6 +244,8 @@ export const legacyInvalidPercentageInput = () => ({
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -266,6 +280,8 @@ export const legacyDisabledPercentageInput = () => ({
         iconType="percent"
         additionalClasses="sprk-b-InputContainer__icon sprk-b-InputContainer__icon--right"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-disabled-percentage"

--- a/angular/projects/spark-angular/src/lib/components/inputs/Phone.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Phone.stories.ts
@@ -110,6 +110,7 @@ export const invalidPhoneInput = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/SSN.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/SSN.stories.ts
@@ -151,6 +151,7 @@ export const invalidSSNInput = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/Search.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Search.stories.ts
@@ -73,7 +73,6 @@ export const searchInput = () => ({
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
-
         ></sprk-icon>
         <input
           id="search"
@@ -120,7 +119,6 @@ export const invalidSearchInput = () => ({
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
-
         ></sprk-icon>
         <input
           id="invalid-search"

--- a/angular/projects/spark-angular/src/lib/components/inputs/Search.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Search.stories.ts
@@ -72,6 +72,7 @@ export const searchInput = () => ({
           iconName="search"
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
+          ariaHidden="true"
         ></sprk-icon>
         <input
           id="search"

--- a/angular/projects/spark-angular/src/lib/components/inputs/Search.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Search.stories.ts
@@ -73,6 +73,7 @@ export const searchInput = () => ({
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="search"
@@ -118,6 +119,8 @@ export const invalidSearchInput = () => ({
           iconName="search"
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="invalid-search"
@@ -137,6 +140,8 @@ export const invalidSearchInput = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -174,6 +179,8 @@ export const disabledSearchInput = () => ({
           iconName="search"
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <input
           id="disabled-search"
@@ -218,6 +225,8 @@ export const legacyStory = () => ({
         iconType="search"
         additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-search"
@@ -260,6 +269,8 @@ export const legacyInvalidSearchInput = () => ({
         iconType="search"
         additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-invalid-search"
@@ -278,6 +289,8 @@ export const legacyInvalidSearchInput = () => ({
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -312,6 +325,8 @@ export const legacyDisabledSearchInput = () => ({
         iconType="search"
         additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
+        ariaHidden="true"
+        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-disabled-search"

--- a/angular/projects/spark-angular/src/lib/components/inputs/Search.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Search.stories.ts
@@ -73,7 +73,7 @@ export const searchInput = () => ({
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
+
         ></sprk-icon>
         <input
           id="search"
@@ -120,7 +120,7 @@ export const invalidSearchInput = () => ({
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
+
         ></sprk-icon>
         <input
           id="invalid-search"
@@ -141,7 +141,6 @@ export const invalidSearchInput = () => ({
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -180,7 +179,6 @@ export const disabledSearchInput = () => ({
           additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
           sprk-input-icon
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <input
           id="disabled-search"
@@ -226,7 +224,6 @@ export const legacyStory = () => ({
         additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-search"
@@ -270,7 +267,6 @@ export const legacyInvalidSearchInput = () => ({
         additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-invalid-search"
@@ -290,7 +286,6 @@ export const legacyInvalidSearchInput = () => ({
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="false"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -326,7 +321,6 @@ export const legacyDisabledSearchInput = () => ({
         additionalClasses="sprk-b-InlineSearch__icon sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color"
         sprk-input-icon
         ariaHidden="true"
-        focusable="false"
       ></sprk-icon>
       <input
         id="legacy-disabled-search"

--- a/angular/projects/spark-angular/src/lib/components/inputs/Select.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Select.stories.ts
@@ -85,7 +85,6 @@ export const selectBox = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
     </sprk-input-container>
   `,
@@ -130,14 +129,12 @@ export const invalidSelectBox = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
       <span sprkFieldError id="select-error">
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -182,7 +179,6 @@ export const disabledSelectBox = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
     </sprk-input-container>
   `,
@@ -230,7 +226,6 @@ export const hugeSelectBox = () => ({
         additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
     </sprk-input-container>
   `,
@@ -281,14 +276,12 @@ export const invalidHugeSelectBox = () => ({
         additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
       <span sprkFieldError id="huge-select-error">
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -340,7 +333,6 @@ export const disabledHugeSelectBox = () => ({
         additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
     </sprk-input-container>
   `,
@@ -387,7 +379,6 @@ export const legacyHugeSelectBox = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
     </sprk-huge-input-container>
   `,
@@ -437,14 +428,12 @@ export const legacyInvalidHugeSelectBox = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
       <span sprkFieldError id="legacy-huge-select-error">
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
           ariaHidden="true"
-          focusable="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -495,7 +484,6 @@ export const legacyDisabledHugeSelectBox = () => ({
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
         ariaHidden="true"
-        focusable="true"
       ></sprk-icon>
     </sprk-huge-input-container>
   `,

--- a/angular/projects/spark-angular/src/lib/components/inputs/Select.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Select.stories.ts
@@ -84,6 +84,8 @@ export const selectBox = () => ({
         iconName="chevron-down"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
     </sprk-input-container>
   `,
@@ -127,11 +129,15 @@ export const invalidSelectBox = () => ({
         iconName="chevron-down"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
       <span sprkFieldError id="select-error">
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -175,6 +181,8 @@ export const disabledSelectBox = () => ({
         iconName="chevron-down"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
     </sprk-input-container>
   `,
@@ -221,6 +229,8 @@ export const hugeSelectBox = () => ({
         iconName="chevron-down"
         additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
     </sprk-input-container>
   `,
@@ -270,11 +280,15 @@ export const invalidHugeSelectBox = () => ({
         iconName="chevron-down"
         additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
       <span sprkFieldError id="huge-select-error">
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -325,6 +339,8 @@ export const disabledHugeSelectBox = () => ({
         iconName="chevron-down"
         additionalClasses="sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
     </sprk-input-container>
   `,
@@ -370,6 +386,8 @@ export const legacyHugeSelectBox = () => ({
         iconType="chevron-down"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
     </sprk-huge-input-container>
   `,
@@ -418,11 +436,15 @@ export const legacyInvalidHugeSelectBox = () => ({
         iconType="chevron-down"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
       <span sprkFieldError id="legacy-huge-select-error">
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
+          focusable="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -472,6 +494,8 @@ export const legacyDisabledHugeSelectBox = () => ({
         iconType="chevron-down"
         additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color sprk-b-SelectContainer__icon"
         sprk-select-icon
+        ariaHidden="true"
+        focusable="true"
       ></sprk-icon>
     </sprk-huge-input-container>
   `,

--- a/angular/projects/spark-angular/src/lib/components/inputs/Text.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Text.stories.ts
@@ -103,6 +103,7 @@ export const invalidTextInput = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -203,6 +204,7 @@ export const invalidHugeTextInput = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>
@@ -303,6 +305,7 @@ export const legacyInvalidHugeTextInput = () => ({
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/Textarea.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/Textarea.stories.ts
@@ -99,6 +99,7 @@ export const invalidTextarea = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/sprk-checkbox-item/sprk-checkbox.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/sprk-checkbox-item/sprk-checkbox.stories.ts
@@ -324,6 +324,7 @@ export const invalidCheckbox = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">
           There is an error on this field.
@@ -689,6 +690,7 @@ export const hugeInvalid = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">
           There is an error on this field.
@@ -1489,6 +1491,7 @@ export const legacyInvalidStory = () => ({
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/inputs/sprk-radio-item/sprk-radio.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/sprk-radio-item/sprk-radio.stories.ts
@@ -325,6 +325,7 @@ export const invalidRadioButton = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">
           There is an error on this field.
@@ -690,6 +691,7 @@ export const hugeInvalid = () => ({
         <sprk-icon
           iconName="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">
           There is an error on this field.
@@ -1476,6 +1478,7 @@ export const legacyInvalidRadio = () => ({
         <sprk-icon
           iconType="exclamation-filled"
           additionalClasses="sprk-b-ErrorIcon"
+          ariaHidden="true"
         ></sprk-icon>
         <div class="sprk-b-ErrorText">There is an error on this field.</div>
       </span>

--- a/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.spec.ts
@@ -85,6 +85,14 @@ describe('SprkIconComponent', () => {
     expect(iconElement.getAttribute('aria-hidden')).toEqual('true');
   });
 
+  it('should add focusable', () => {
+    component.iconName = 'bell';
+    component.focusable = 'true';
+    fixture.detectChanges();
+    expect(iconElement.hasAttribute('focusable')).toBeTruthy();
+    expect(iconElement.getAttribute('focusable')).toEqual('true');
+  });
+
   it('should add the correct classes if iconName has no value, but additionalClasses does', () => {
     component.additionalClasses = 'sprk-u-pam sprk-u-man';
     fixture.detectChanges();

--- a/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.spec.ts
@@ -85,9 +85,16 @@ describe('SprkIconComponent', () => {
     expect(iconElement.getAttribute('aria-hidden')).toEqual('true');
   });
 
-  it('should add focusable', () => {
+  it('should add focusable=false by default', () => {
     component.iconName = 'bell';
-    component.focusable = 'true';
+    fixture.detectChanges();
+    expect(iconElement.hasAttribute('focusable')).toBeTruthy();
+    expect(iconElement.getAttribute('focusable')).toEqual('false');
+  });
+
+  it('should add focusableAttr', () => {
+    component.iconName = 'bell';
+    component.focusableAttr = true;
     fixture.detectChanges();
     expect(iconElement.hasAttribute('focusable')).toBeTruthy();
     expect(iconElement.getAttribute('focusable')).toEqual('true');

--- a/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.ts
@@ -8,6 +8,7 @@ import { Component, Input } from '@angular/core';
       [attr.viewBox]="viewBox"
       [attr.aria-labelledby]="ariaLabelledby"
       [attr.aria-hidden]="ariaHidden"
+      [attr.focusable]="focusable"
       [attr.data-id]="idString"
     >
       <use [attr.xlink:href]="icon" />
@@ -50,6 +51,12 @@ export class SprkIconComponent {
    */
   @Input()
   ariaHidden: string;
+  /**
+   * Expects a value to assign to
+   * the `focusable` attribute of the icon.
+   */
+  @Input()
+  focusable: string;
   /**
    * Expects a space separated string
    * of classes to be added to the

--- a/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-icon/sprk-icon.component.ts
@@ -8,7 +8,7 @@ import { Component, Input } from '@angular/core';
       [attr.viewBox]="viewBox"
       [attr.aria-labelledby]="ariaLabelledby"
       [attr.aria-hidden]="ariaHidden"
-      [attr.focusable]="focusable"
+      [attr.focusable]="focusableAttr"
       [attr.data-id]="idString"
     >
       <use [attr.xlink:href]="icon" />
@@ -53,10 +53,12 @@ export class SprkIconComponent {
   ariaHidden: string;
   /**
    * Expects a value to assign to
-   * the `focusable` attribute of the icon.
+   * the `focusable` attribute of the icon. This is a
+   * deprecated SVG attribute that is only included for
+   * IE 11 compatibility.
    */
   @Input()
-  focusable: string;
+  focusableAttr: boolean = false;
   /**
    * Expects a space separated string
    * of classes to be added to the

--- a/html/base/inputs/Checkbox.stories.js
+++ b/html/base/inputs/Checkbox.stories.js
@@ -16,7 +16,7 @@ use the tabindex attribute to change this.
 - Change the value of the aria-checked attribute
 dynamically when the checkbox is activated.
 
-###### Ensure all related checkboxes are grouped together using 
+###### Ensure all related checkboxes are grouped together using
 one of the following methods:
 
 - Fieldset and legend tags
@@ -288,6 +288,8 @@ export const invalidCheckbox = () => {
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>
@@ -700,6 +702,8 @@ export const hugeInvalid = () => {
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/Date.stories.js
+++ b/html/base/inputs/Date.stories.js
@@ -90,6 +90,8 @@ export const invalidDateInput = () => `
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/DatePicker.stories.js
+++ b/html/base/inputs/DatePicker.stories.js
@@ -52,11 +52,13 @@ export const defaultStory = () => {
       <div class="sprk-b-TextInputIconContainer">
         <svg
           class="
-            sprk-c-Icon 
-            sprk-c-Icon--filled-current-color 
+            sprk-c-Icon
+            sprk-c-Icon--filled-current-color
             sprk-c-Icon--stroke-current-color
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#calendar" />
         </svg>
@@ -110,11 +112,13 @@ export const invalidDatePicker = () => {
       <div class="sprk-b-TextInputIconContainer">
         <svg
           class="
-            sprk-c-Icon 
-            sprk-c-Icon--filled-current-color 
+            sprk-c-Icon
+            sprk-c-Icon--filled-current-color
             sprk-c-Icon--stroke-current-color
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#calendar" />
         </svg>
@@ -142,6 +146,8 @@ export const invalidDatePicker = () => {
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>
@@ -180,11 +186,13 @@ export const disabledDatePicker = () => {
       <div class="sprk-b-TextInputIconContainer">
         <svg
           class="
-            sprk-c-Icon 
-            sprk-c-Icon--filled-current-color 
+            sprk-c-Icon
+            sprk-c-Icon--filled-current-color
             sprk-c-Icon--stroke-current-color
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#calendar" />
         </svg>

--- a/html/base/inputs/HelperText.stories.js
+++ b/html/base/inputs/HelperText.stories.js
@@ -78,6 +78,8 @@ export const invalidHelperText = () =>
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/Monetary.stories.js
+++ b/html/base/inputs/Monetary.stories.js
@@ -107,6 +107,8 @@ export const invalidMonetaryInput = () => `
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/Password.stories.js
+++ b/html/base/inputs/Password.stories.js
@@ -125,6 +125,8 @@ export const invalidPasswordInput = () => `
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/Percentage.stories.js
+++ b/html/base/inputs/Percentage.stories.js
@@ -37,6 +37,8 @@ export const percentageInput = () => `
             sprk-b-InputContainer__icon--right
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#percent" />
         </svg>
@@ -91,6 +93,8 @@ export const invalidPercentageInput = () => `
             sprk-b-InputContainer__icon--right
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#percent" />
         </svg>
@@ -118,6 +122,8 @@ export const invalidPercentageInput = () => `
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>
@@ -157,6 +163,8 @@ export const disabledPercentageInput = () => `
             sprk-b-InputContainer__icon--right
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#percent" />
         </svg>

--- a/html/base/inputs/Phone.stories.js
+++ b/html/base/inputs/Phone.stories.js
@@ -90,6 +90,8 @@ export const invalidPhoneInput = () => `
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/Radio.stories.js
+++ b/html/base/inputs/Radio.stories.js
@@ -273,6 +273,8 @@ export const invalidRadioButton = () => {
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>
@@ -675,6 +677,8 @@ export const hugeInvalid = () => {
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/SSN.stories.js
+++ b/html/base/inputs/SSN.stories.js
@@ -133,6 +133,8 @@ export const invalidSSNInput = () => `
         <svg
          class="sprk-c-Icon sprk-b-ErrorIcon"
          viewBox="0 0 64 64"
+         aria-hidden="true"
+         focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/Search.stories.js
+++ b/html/base/inputs/Search.stories.js
@@ -24,11 +24,13 @@ export const searchInput = () => `
       <div class="sprk-b-TextInputIconContainer">
         <svg
           class="
-            sprk-c-Icon 
-            sprk-c-Icon--filled-current-color 
+            sprk-c-Icon
+            sprk-c-Icon--filled-current-color
             sprk-c-Icon--stroke-current-color
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#search" />
         </svg>
@@ -70,8 +72,8 @@ export const invalidSearchInput = () => `
       <div class="sprk-b-TextInputIconContainer">
         <svg
           class="
-            sprk-c-Icon 
-            sprk-c-Icon--filled-current-color 
+            sprk-c-Icon
+            sprk-c-Icon--filled-current-color
             sprk-c-Icon--stroke-current-color
           "
           viewBox="0 0 64 64"
@@ -132,8 +134,8 @@ export const disabledSearchInput = () => `
       <div class="sprk-b-TextInputIconContainer">
         <svg
           class="
-            sprk-c-Icon 
-            sprk-c-Icon--filled-current-color 
+            sprk-c-Icon
+            sprk-c-Icon--filled-current-color
             sprk-c-Icon--stroke-current-color
           "
           viewBox="0 0 64 64"

--- a/html/base/inputs/Search.stories.js
+++ b/html/base/inputs/Search.stories.js
@@ -77,6 +77,8 @@ export const invalidSearchInput = () => `
             sprk-c-Icon--stroke-current-color
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#search" />
         </svg>
@@ -104,6 +106,8 @@ export const invalidSearchInput = () => `
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>
@@ -139,6 +143,8 @@ export const disabledSearchInput = () => `
             sprk-c-Icon--stroke-current-color
           "
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#search" />
         </svg>

--- a/html/base/inputs/Select.stories.js
+++ b/html/base/inputs/Select.stories.js
@@ -48,6 +48,8 @@ export const selectBox = () => `
           sprk-b-SelectContainer__icon
         "
         viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#chevron-down" />
       </svg>
@@ -98,6 +100,8 @@ export const invalidSelectBox = () => `
           sprk-b-SelectContainer__icon
         "
         viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#chevron-down" />
       </svg>
@@ -109,6 +113,8 @@ export const invalidSelectBox = () => `
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>
@@ -158,6 +164,8 @@ export const disabledSelectBox = () => `
           sprk-b-SelectContainer__icon
         "
         viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#chevron-down" />
       </svg>
@@ -218,6 +226,8 @@ export const hugeSelectBox = () => {
           sprk-b-SelectContainer__icon
         "
         viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#chevron-down" />
       </svg>
@@ -283,6 +293,8 @@ export const invalidHugeSelectBox = () => {
           sprk-b-SelectContainer__icon
         "
         viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#chevron-down" />
       </svg>
@@ -294,6 +306,8 @@ export const invalidHugeSelectBox = () => {
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>
@@ -358,6 +372,8 @@ export const disabledHugeSelectBox = () => {
           sprk-b-SelectContainer__icon
         "
         viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#chevron-down" />
       </svg>

--- a/html/base/inputs/Text.stories.js
+++ b/html/base/inputs/Text.stories.js
@@ -61,6 +61,7 @@ export const invalidTextInput = () => `
         class="sprk-c-Icon sprk-b-ErrorIcon"
         viewBox="0 0 64 64"
         aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#exclamation-filled" />
       </svg>
@@ -167,6 +168,7 @@ export const invalidHugeTextInput = () => {
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
           aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/base/inputs/Textarea.stories.js
+++ b/html/base/inputs/Textarea.stories.js
@@ -64,6 +64,8 @@ export const invalidTextarea = () =>
         <svg
          class="sprk-c-Icon sprk-b-ErrorIcon"
          viewBox="0 0 64 64"
+         aria-hidden="true"
+         focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/components/autocomplete.stories.js
+++ b/html/components/autocomplete.stories.js
@@ -347,6 +347,8 @@ export const defaultInvalid = () => {
         <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>
@@ -761,6 +763,8 @@ export const hugeInvalid = () => {
       <svg
           class="sprk-c-Icon sprk-b-ErrorIcon"
           viewBox="0 0 64 64"
+          aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#exclamation-filled" />
         </svg>

--- a/html/components/autocomplete.stories.js
+++ b/html/components/autocomplete.stories.js
@@ -112,6 +112,7 @@ export const defaultStory = () => {
           "
           viewBox="0 0 64 64"
           aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#search" />
         </svg>
@@ -247,6 +248,7 @@ export const defaultInvalid = () => {
           "
           viewBox="0 0 64 64"
           aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#search" />
         </svg>
@@ -391,6 +393,7 @@ export const defaultDisabled = () => {
           "
           viewBox="0 0 64 64"
           aria-hidden="true"
+          focusable="false"
         >
           <use xlink:href="#search" />
         </svg>
@@ -518,7 +521,9 @@ export const hugeStory = () => {
           sprk-c-Icon--filled-current-color
           sprk-c-Icon--stroke-current-color
         "
-        viewBox="0 0 64 64" aria-hidden="true"
+        viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#search" />
       </svg>
@@ -652,7 +657,9 @@ export const hugeInvalid = () => {
           sprk-c-Icon--filled-current-color
           sprk-c-Icon--stroke-current-color
         "
-        viewBox="0 0 64 64" aria-hidden="true"
+        viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#search" />
       </svg>
@@ -797,7 +804,9 @@ export const hugeDisabled = () => {
           sprk-c-Icon--filled-current-color
           sprk-c-Icon--stroke-current-color
         "
-        viewBox="0 0 64 64" aria-hidden="true"
+        viewBox="0 0 64 64"
+        aria-hidden="true"
+        focusable="false"
       >
         <use xlink:href="#search" />
       </svg>

--- a/react/src/base/inputs/Search.stories.js
+++ b/react/src/base/inputs/Search.stories.js
@@ -4,15 +4,10 @@ import { markdownDocumentationLinkBuilder } from '../../../../storybook-utilitie
 
 export default {
   title: 'Components/Input/Search',
-  decorators: [
-    story => <div className="sprk-o-Box">{story()}</div>
-  ],
+  decorators: [(story) => <div className="sprk-o-Box">{story()}</div>],
   component: SprkTextInput,
   parameters: {
-    jest: [
-      'SprkErrorContainer',
-      'SprkInputIconCheck',
-    ],
+    jest: ['SprkErrorContainer', 'SprkInputIconCheck'],
     info: `${markdownDocumentationLinkBuilder('input')}`,
   },
 };
@@ -24,15 +19,14 @@ export const searchInput = () => (
     hiddenLabel
     name="InlineSearch"
     placeholder="Search"
+    iconAriaHidden="true"
   />
 );
 
 searchInput.story = {
   name: 'Default',
   parameters: {
-    jest: [
-      'SprkTextInput',
-    ]
+    jest: ['SprkTextInput'],
   },
 };
 
@@ -51,9 +45,7 @@ export const invalidSearchInput = () => (
 invalidSearchInput.story = {
   name: 'Invalid',
   parameters: {
-    jest: [
-      'SprkTextInput',
-    ]
+    jest: ['SprkTextInput'],
   },
 };
 
@@ -71,8 +63,6 @@ export const disabledSearchInput = () => (
 disabledSearchInput.story = {
   name: 'Disabled',
   parameters: {
-    jest: [
-      'SprkTextInput',
-    ]
+    jest: ['SprkTextInput'],
   },
 };

--- a/react/src/base/inputs/Search.stories.js
+++ b/react/src/base/inputs/Search.stories.js
@@ -19,7 +19,6 @@ export const searchInput = () => (
     hiddenLabel
     name="InlineSearch"
     placeholder="Search"
-    iconAriaHidden="true"
   />
 );
 

--- a/react/src/base/inputs/SprkTextInput/SprkTextInput.js
+++ b/react/src/base/inputs/SprkTextInput/SprkTextInput.js
@@ -37,6 +37,7 @@ class SprkTextInput extends Component {
       valid,
       value,
       ariaDescribedBy,
+      iconAriaHidden,
       ...rest
     } = this.props;
     const { id, errorContainerId } = this.state;
@@ -52,6 +53,7 @@ class SprkTextInput extends Component {
           textIcon={textIcon}
           narrowWidth={narrowWidth}
           iconRight={iconRight}
+          ariaHidden={iconAriaHidden}
         >
           <SprkLabelLocationCheck
             type={type}
@@ -172,6 +174,10 @@ SprkTextInput.propTypes = {
    * attribute on the Input.
    */
   ariaDescribedBy: PropTypes.string,
+  /**
+   * 	The value of aria-hidden on the icon inside the input element.
+   */
+  iconAriaHidden: PropTypes.bool,
 };
 
 SprkTextInput.defaultProps = {
@@ -191,6 +197,7 @@ SprkTextInput.defaultProps = {
   textIcon: false,
   valid: true,
   disabled: false,
+  // iconAriaHidden: false,
 };
 
 export default SprkTextInput;

--- a/react/src/base/inputs/SprkTextInput/SprkTextInput.js
+++ b/react/src/base/inputs/SprkTextInput/SprkTextInput.js
@@ -37,7 +37,6 @@ class SprkTextInput extends Component {
       valid,
       value,
       ariaDescribedBy,
-      iconAriaHidden,
       ...rest
     } = this.props;
     const { id, errorContainerId } = this.state;
@@ -53,7 +52,6 @@ class SprkTextInput extends Component {
           textIcon={textIcon}
           narrowWidth={narrowWidth}
           iconRight={iconRight}
-          ariaHidden={iconAriaHidden}
         >
           <SprkLabelLocationCheck
             type={type}
@@ -174,10 +172,6 @@ SprkTextInput.propTypes = {
    * attribute on the Input.
    */
   ariaDescribedBy: PropTypes.string,
-  /**
-   * 	The value of aria-hidden on the icon inside the input element.
-   */
-  iconAriaHidden: PropTypes.bool,
 };
 
 SprkTextInput.defaultProps = {
@@ -197,7 +191,6 @@ SprkTextInput.defaultProps = {
   textIcon: false,
   valid: true,
   disabled: false,
-  // iconAriaHidden: false,
 };
 
 export default SprkTextInput;

--- a/react/src/base/inputs/components/SprkInputIconCheck/SprkInputIconCheck.js
+++ b/react/src/base/inputs/components/SprkInputIconCheck/SprkInputIconCheck.js
@@ -9,6 +9,7 @@ const SprkInputIconCheck = ({
   textIcon,
   narrowWidth,
   iconRight,
+  ariaHidden,
 }) => {
   if (leadingIcon || textIcon) {
     return (
@@ -27,6 +28,7 @@ const SprkInputIconCheck = ({
               'sprk-c-Icon--stroke-current-color sprk-c-Icon--filled-current-color': true,
               'sprk-b-InputContainer__icon--right': iconRight,
             })}
+            aria-hidden={ariaHidden}
           />
         )}
         {children}
@@ -41,6 +43,7 @@ SprkInputIconCheck.propTypes = {
   textIcon: propTypes.bool,
   narrowWidth: propTypes.bool,
   iconRight: propTypes.bool,
+  ariaHidden: propTypes.bool,
 };
 
 export default SprkInputIconCheck;

--- a/react/src/base/inputs/components/SprkInputIconCheck/SprkInputIconCheck.js
+++ b/react/src/base/inputs/components/SprkInputIconCheck/SprkInputIconCheck.js
@@ -9,7 +9,6 @@ const SprkInputIconCheck = ({
   textIcon,
   narrowWidth,
   iconRight,
-  ariaHidden,
 }) => {
   if (leadingIcon || textIcon) {
     return (
@@ -28,7 +27,6 @@ const SprkInputIconCheck = ({
               'sprk-c-Icon--stroke-current-color sprk-c-Icon--filled-current-color': true,
               'sprk-b-InputContainer__icon--right': iconRight,
             })}
-            aria-hidden={ariaHidden}
           />
         )}
         {children}
@@ -43,7 +41,6 @@ SprkInputIconCheck.propTypes = {
   textIcon: propTypes.bool,
   narrowWidth: propTypes.bool,
   iconRight: propTypes.bool,
-  ariaHidden: propTypes.bool,
 };
 
 export default SprkInputIconCheck;


### PR DESCRIPTION
## What does this PR do?
- Adds `aria-hidden="true"` and `focusable="false"` to all input icons and error container icons in HTML and Angular.
- Autocomplete, Search, Percentage, Date Picker, and Select. (Monetary is not an SVG).

### Associated Issue
Fixes 2303668

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [x] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [x] Accessibility Team
