### PR TITLE
Masthead logo area - Make top and bottom padding match 8px [ALL PACKAGES]

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -15,11 +15,6 @@ import { SprkMastheadSelectorModule } from './sprk-masthead-selector/sprk-masthe
 export default {
   title: 'Components/Masthead',
   component: SprkMastheadComponent,
-  decorators: [
-    storyWrapper(
-      (storyContent) => `<div class="sprk-o-Box">${storyContent}<div>`,
-    ),
-  ],
   parameters: {
     subcomponents: {
       SprkMastheadAccordionComponent,

--- a/react/src/components/masthead/SprkMasthead.stories.js
+++ b/react/src/components/masthead/SprkMasthead.stories.js
@@ -175,7 +175,7 @@ const utilityItems = [
     element="a"
     href="#nogo"
     variant="secondary"
-    additionalClasses="sprk-u-Right--zero sprk-u-mrm sprk-c-Button--compact"
+    additionalClasses="sprk-u-Right--zero sprk-c-Button--compact"
   >
     Sign In
   </SprkButton>,

--- a/styles/android/spark_design_tokens_dimens.xml
+++ b/styles/android/spark_design_tokens_dimens.xml
@@ -163,7 +163,7 @@
   <dimen name="sprk_masthead_content_item_padding_top">8.00dp</dimen><!-- The padding top around the content items in the content section of the Masthead. -->
   <dimen name="sprk_masthead_content_item_padding_top_wide">8.00dp</dimen><!-- The padding top around the content items in the content section of the Masthead in wide viewports. -->
   <dimen name="sprk_masthead_content_item_padding_bottom">8.00dp</dimen><!-- The padding bottom around the content items in the content section of the Masthead. -->
-  <dimen name="sprk_masthead_content_item_padding_bottom_wide">16.00dp</dimen><!-- The padding bottom around the content items in the content section of the Masthead in wide viewports. -->
+  <dimen name="sprk_masthead_content_item_padding_bottom_wide">8.00dp</dimen><!-- The padding bottom around the content items in the content section of the Masthead in wide viewports. -->
   <dimen name="sprk_masthead_content_item_padding_right">8.00dp</dimen><!-- The padding right around the content items in the content section of the Masthead. -->
   <dimen name="sprk_masthead_content_item_padding_right_wide">16.00dp</dimen><!-- The padding right around the content items in the content section of the Masthead in wide viewports. -->
   <dimen name="sprk_masthead_content_item_padding_left">8.00dp</dimen><!-- The padding left around the content items in the content section of the Masthead. -->

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -557,7 +557,7 @@ public class SparkDesignTokens {
     public static let sprkMastheadBreakpoint = CGFloat(864.00)
     public static let sprkMastheadColumnWidth = CGFloat(1424.00)
     public static let sprkMastheadContentItemPaddingBottom = CGFloat(8.00)
-    public static let sprkMastheadContentItemPaddingBottomWide = CGFloat(16.00)
+    public static let sprkMastheadContentItemPaddingBottomWide = CGFloat(8.00)
     public static let sprkMastheadContentItemPaddingLeft = CGFloat(8.00)
     public static let sprkMastheadContentItemPaddingLeftWide = CGFloat(16.00)
     public static let sprkMastheadContentItemPaddingRight = CGFloat(8.00)

--- a/styles/tokens/masthead.json
+++ b/styles/tokens/masthead.json
@@ -74,7 +74,7 @@
         },
         "item-padding-bottom-wide": {
           "comment": "The padding bottom around the content items in the content section of the Masthead in wide viewports.",
-          "value": "{space.m.value}",
+          "value": "{space.s.value}",
           "attributes": {
             "category": "size"
           },


### PR DESCRIPTION
## What does this PR do?
Before:
<img width="394" alt="Screen Shot 2021-05-06 at 1 20 56 PM" src="https://user-images.githubusercontent.com/4342363/117340187-a1419f00-ae6e-11eb-8909-e27ed7667112.png">
- Bottom padding is 16px and it made it look uneven
- It's also not vertically centered within the masthead

After:
<img width="294" alt="Screen Shot 2021-05-06 at 1 21 23 PM" src="https://user-images.githubusercontent.com/4342363/117340199-a43c8f80-ae6e-11eb-803c-fee488ec803a.png">
- Bottom padding is now matching the top, which is 8px


Misc:
- Removed unnecessary box class around masthead storybook
- Remove unecessary right padding on compact button so all packages match
- 
### Associated Issue
Fixes 2465094

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Documentation
 - no documentation change

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
- No changes in accessibility

### Deploy Preview Reviewed and Approved
 - [x] Design Team


### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
