### PR TITLE
Add property names to host bindings

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-card/directives/sprk-card-content/sprk-card-content.directive.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/directives/sprk-card-content/sprk-card-content.directive.ts
@@ -16,7 +16,7 @@ export class SprkCardContentDirective {
   @Input()
   idString: string;
 
-  @HostBinding('class.sprk-c-Card__content') true;
+  @HostBinding('class.sprk-c-Card__content') cardContentClass = true;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/directives/sprk-card-header/sprk-card-header.directive.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/directives/sprk-card-header/sprk-card-header.directive.ts
@@ -16,7 +16,7 @@ export class SprkCardHeaderDirective {
   @Input()
   idString: string;
 
-  @HostBinding('class.sprk-c-Card__header') true;
+  @HostBinding('class.sprk-c-Card__header') cardHeaderClass = true;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/directives/sprk-card-media/sprk-card-media.directive.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/directives/sprk-card-media/sprk-card-media.directive.ts
@@ -16,7 +16,7 @@ export class SprkCardMediaDirective {
   @Input()
   idString: string;
 
-  @HostBinding('class.sprk-c-Card__media') true;
+  @HostBinding('class.sprk-c-Card__media') cardMediaClass = true;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-promo/directives/sprk-promo-content/sprk-promo-content.directive.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-promo/directives/sprk-promo-content/sprk-promo-content.directive.ts
@@ -16,7 +16,7 @@ export class SprkPromoContentDirective {
   @Input()
   idString: string;
 
-  @HostBinding('class.sprk-c-Promo__content') true;
+  @HostBinding('class.sprk-c-Promo__content') promoContentClass = true;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-promo/directives/sprk-promo-heading/sprk-promo-heading.directive.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-promo/directives/sprk-promo-heading/sprk-promo-heading.directive.ts
@@ -16,5 +16,5 @@ export class SprkPromoHeadingDirective {
   @Input()
   idString: string;
 
-  @HostBinding('class.sprk-c-Promo__title') true;
+  @HostBinding('class.sprk-c-Promo__title') promoTitleClass = true;
 }

--- a/angular/projects/spark-angular/src/lib/components/sprk-promo/directives/sprk-promo-media/sprk-promo-media.directive.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-promo/directives/sprk-promo-media/sprk-promo-media.directive.ts
@@ -23,7 +23,7 @@ export class SprkPromoMediaDirective {
   @Input()
   isFlag: string;
 
-  @HostBinding('class.sprk-c-Promo__image') true;
+  @HostBinding('class.sprk-c-Promo__image') promoImageClass = true;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/components/sprk-promo/directives/sprk-promo-subheading/sprk-promo-subheading.directive.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-promo/directives/sprk-promo-subheading/sprk-promo-subheading.directive.ts
@@ -16,7 +16,7 @@ export class SprkPromoSubheadingDirective {
   @Input()
   idString: string;
 
-  @HostBinding('class.sprk-c-Promo__subtitle') true;
+  @HostBinding('class.sprk-c-Promo__subtitle') promoSubtitleClass = true;
 
   /**
    * @ignore

--- a/angular/projects/spark-angular/src/lib/directives/sprk-box/sprk-box.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-box/sprk-box.directive.ts
@@ -42,7 +42,7 @@ export class SprkBoxDirective {
     | 'miscC'
     | 'miscD';
 
-  @HostBinding('class.sprk-o-Box') true;
+  @HostBinding('class.sprk-o-Box') boxClass = true;
 
   @HostBinding('class.sprk-o-Box--flush')
   get flush() {

--- a/angular/projects/spark-angular/src/lib/directives/sprk-button/sprk-button.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-button/sprk-button.directive.ts
@@ -51,7 +51,7 @@ export class SprkButtonDirective implements OnInit, OnChanges, AfterViewInit {
   @Input() variant: 'primary' | 'secondary' | 'tertiary' = 'primary';
 
   // Always set the button class on the element
-  @HostBinding('class.sprk-c-Button') true;
+  @HostBinding('class.sprk-c-Button') buttonClass = true;
 
   /**
    * The value supplied will be assigned

--- a/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-centered-column/sprk-centered-column.directive.ts
@@ -4,7 +4,7 @@ import { Directive, Input, HostBinding } from '@angular/core';
   selector: '[sprkCenteredColumn]',
 })
 export class SprkCenteredColumnDirective {
-  @HostBinding('class.sprk-o-CenteredColumn') true;
+  @HostBinding('class.sprk-o-CenteredColumn') centeredColumnClass = true;
 
   /**
    * The value supplied will be assigned

--- a/angular/projects/spark-angular/src/lib/directives/sprk-divider/sprk-divider.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-divider/sprk-divider.directive.ts
@@ -4,7 +4,7 @@ import { Directive, Input, HostBinding } from '@angular/core';
   selector: '[sprkDivider]',
 })
 export class SprkDividerDirective {
-  @HostBinding('class.sprk-c-Divider') true;
+  @HostBinding('class.sprk-c-Divider') dividerClass = true;
 
   /**
    * The value supplied will be assigned


### PR DESCRIPTION
## What does this PR do?
In Angular 10 (and TypeScript 3) `@HostBinding('class.example') true;` was interpreted such that `true` was the value and thus the HostBinding was applied properly. In Angular 11 (and TypeScript 4), `true` is instead interpreted as the property name, with no value, meaning a falsey value, and the HostBinding does not get applied. This change, backwards compatible with all previous versions, should fix these issues in newer versions of Angular and TypeScript.

### Associated Issue
n/a

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team
