### PR TITLE
Autocomplete Click Fix

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.spec.ts
@@ -3,7 +3,7 @@ import { SprkAutocompleteComponent } from './sprk-autocomplete.component';
 import { SprkAutocompleteResultsDirective } from './directives/sprk-autocomplete-results/sprk-autocomplete-results.directive';
 import { SprkAutocompleteResultDirective } from './directives/sprk-autocomplete-result/sprk-autocomplete-result.directive';
 import { SprkAutocompleteInputContainerDirective } from './directives/sprk-autocomplete-input-container/sprk-autocomplete-input-container.directive';
-import { Component } from '@angular/core';
+import { Component, ElementRef } from '@angular/core';
 import { SprkInputDirective } from '../../directives/inputs/sprk-input/sprk-input.directive';
 
 @Component({
@@ -819,6 +819,33 @@ describe('SprkAutocompleteComponent', () => {
     expect(component.hideResults).toBeCalledTimes(0);
     expect(component.showResults).toBeCalledTimes(0);
   });
+
+  // it('should set the click event on the list items when the results are changed', (done) => {
+  //   let called = false;
+  //   let value = -1;
+
+  //   component.isOpen = true;
+  //   component.itemSelectedEvent.subscribe((itemId) => {
+  //     called = true;
+  //     value = itemId;
+  //     done();
+  //   });
+
+  //   const newResult = new SprkAutocompleteResultDirective(component.results.nativeElement);
+  //   newResult.id = 'item5';
+
+  //   component.resultItems.reset([...component.resultItems.toArray(), newResult]);
+
+  //   fixture.detectChanges();
+
+  //   component.resultItems
+  //     .toArray()[4]
+  //     .ref.nativeElement.dispatchEvent(new Event('click'));
+
+  //   expect(called).toEqual(true);
+  //   expect(value).toEqual('item5');
+  //   done();
+  // });
 
   it('should set the click event on the list items if itemSelectedEvent is set', (done) => {
     let called = false;

--- a/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.spec.ts
@@ -24,11 +24,40 @@ import { SprkInputDirective } from '../../directives/inputs/sprk-input/sprk-inpu
 })
 class WrappedAutocompleteComponent {}
 
+@Component({
+  selector: 'sprk-dynamic-test',
+  template: `
+    <sprk-autocomplete isOpen="true" itemSelectedEvent="itemSelectedEvent">
+      <div sprkAutocompleteInputContainer>
+        <input sprkInput />
+      </div>
+      <ul sprkAutocompleteResults>
+        <li
+          sprkAutocompleteResult
+          *ngFor="let item of list; let i = index"
+          id="{{ item.id }}"
+        ></li>
+      </ul>
+    </sprk-autocomplete>
+  `,
+})
+class DynamicComponent {
+  public itemSelectedEvent;
+  public list = ['item1', 'item2', 'item3', 'item4'];
+  public newList = ['item1', 'item2', 'item3', 'item4', 'item5'];
+  changeMe(): void {
+    this.list = this.newList;
+  }
+}
+
 describe('SprkAutocompleteComponent', () => {
   let component: SprkAutocompleteComponent;
   let fixture: ComponentFixture<WrappedAutocompleteComponent>;
   let resultsElement;
   let inputElement;
+
+  let dynamicTestComponent;
+  let dynamicTestFixture;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -39,6 +68,7 @@ describe('SprkAutocompleteComponent', () => {
         SprkAutocompleteResultsDirective,
         SprkAutocompleteResultDirective,
         SprkInputDirective,
+        DynamicComponent,
       ],
     }).compileComponents();
   }));
@@ -56,6 +86,10 @@ describe('SprkAutocompleteComponent', () => {
     inputElement = component.input.ref;
 
     fixture.detectChanges();
+
+    // Dynamic Test Component
+    dynamicTestFixture = TestBed.createComponent(DynamicComponent);
+    dynamicTestComponent = dynamicTestFixture.componentInstance;
   });
 
   afterEach(() => {
@@ -820,33 +854,6 @@ describe('SprkAutocompleteComponent', () => {
     expect(component.showResults).toBeCalledTimes(0);
   });
 
-  // it('should set the click event on the list items when the results are changed', (done) => {
-  //   let called = false;
-  //   let value = -1;
-
-  //   component.isOpen = true;
-  //   component.itemSelectedEvent.subscribe((itemId) => {
-  //     called = true;
-  //     value = itemId;
-  //     done();
-  //   });
-
-  //   const newResult = new SprkAutocompleteResultDirective(component.results.nativeElement);
-  //   newResult.id = 'item5';
-
-  //   component.resultItems.reset([...component.resultItems.toArray(), newResult]);
-
-  //   fixture.detectChanges();
-
-  //   component.resultItems
-  //     .toArray()[4]
-  //     .ref.nativeElement.dispatchEvent(new Event('click'));
-
-  //   expect(called).toEqual(true);
-  //   expect(value).toEqual('item5');
-  //   done();
-  // });
-
   it('should set the click event on the list items if itemSelectedEvent is set', (done) => {
     let called = false;
     let value = -1;
@@ -940,5 +947,40 @@ describe('SprkAutocompleteComponent', () => {
     expect(component.input.ref.nativeElement.getAttribute('style')).toEqual(
       null,
     );
+  });
+
+  it('should set the click event on the list items when the results are changed', (done) => {
+    let called = false;
+    let value = -1;
+
+    // dynamicTestComponent.itemSelectedEvent.subscribe((itemId) => {
+    //   called = true;
+    //   value = itemId;
+    //   done();
+    // });
+
+    dynamicTestFixture.detectChanges();
+    const dynamicTestElement = dynamicTestFixture.nativeElement;
+    const changeButton = dynamicTestElement.querySelector('.changeButton');
+
+    changeButton.click();
+    dynamicTestFixture.detectChanges();
+
+    // let newElement = document.createElement('li');
+
+    // const newResult = new SprkAutocompleteResultDirective(newElement);
+    // newResult.id = 'item5';
+
+    // component.resultItems.reset([...component.resultItems.toArray(), newResult]);
+
+    fixture.detectChanges();
+
+    // component.resultItems
+    //   .toArray()[4]
+    //   .ref.nativeElement.dispatchEvent(new Event('click'));
+
+    // expect(called).toEqual(true);
+    // expect(value).toEqual('item5');
+    done();
   });
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.ts
@@ -275,6 +275,17 @@ export class SprkAutocompleteComponent
   }
 
   /**
+   * If itemSelectedEvent is specified, also set that as the click event on each result
+   */
+  bindClickEvents(): void {
+    if (this.itemSelectedEvent) {
+      this.resultItems.forEach((element) => {
+        element.clickedEvent = this.itemSelectedEvent;
+      });
+    }
+  }
+
+  /**
    * @ignore
    * Track the index of the currently-highlighted Autocomplete result item.
    */
@@ -292,34 +303,11 @@ export class SprkAutocompleteComponent
       }
     }
 
-    // if itemSelectedEvent is specified, also set that as the click event on each result
-    // if (this.itemSelectedEvent) {
-    //   this.resultItems.forEach((element) => {
-    //     element.clickedEvent = this.itemSelectedEvent;
-    //   });
-    // }
-  }
+    this.bindClickEvents();
 
-  ngAfterContentChecked() {
-    const currentResultsCount = this.resultItems.length;
-    const newResultsCount = this.results.nativeElement.getElementsByClassName(
-      'sprk-c-Autocomplete__result',
-    ).length;
-
-    /**
-     * This is working, but it's running a LOT. Any time anything in the component is CHECKED,
-     * not even necessarily if something has changed. We only want to do this if the number of
-     * list items has changed.
-     *
-     * Or what if we checked the number of observers and only did it if the count is 0?
-     */
-
-    // if itemSelectedEvent is specified, also set that as the click event on each result
-    if (this.itemSelectedEvent) {
-      this.resultItems.forEach((element) => {
-        element.clickedEvent = this.itemSelectedEvent;
-      });
-    }
+    this.resultItems.changes.subscribe((_) => {
+      this.bindClickEvents();
+    });
   }
 
   /**

--- a/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.ts
@@ -293,6 +293,28 @@ export class SprkAutocompleteComponent
     }
 
     // if itemSelectedEvent is specified, also set that as the click event on each result
+    // if (this.itemSelectedEvent) {
+    //   this.resultItems.forEach((element) => {
+    //     element.clickedEvent = this.itemSelectedEvent;
+    //   });
+    // }
+  }
+
+  ngAfterContentChecked() {
+    const currentResultsCount = this.resultItems.length;
+    const newResultsCount = this.results.nativeElement.getElementsByClassName(
+      'sprk-c-Autocomplete__result',
+    ).length;
+
+    /**
+     * This is working, but it's running a LOT. Any time anything in the component is CHECKED,
+     * not even necessarily if something has changed. We only want to do this if the number of
+     * list items has changed.
+     *
+     * Or what if we checked the number of observers and only did it if the count is 0?
+     */
+
+    // if itemSelectedEvent is specified, also set that as the click event on each result
     if (this.itemSelectedEvent) {
       this.resultItems.forEach((element) => {
         element.clickedEvent = this.itemSelectedEvent;

--- a/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-autocomplete/sprk-autocomplete.component.ts
@@ -275,12 +275,14 @@ export class SprkAutocompleteComponent
   }
 
   /**
-   * If itemSelectedEvent is specified, also set that as the click event on each result
+   * If itemSelectedEvent is specified, also set that as the click event on each result.
+   * This should be called automatically whenever the results list is changed.
    */
   bindClickEvents(): void {
     if (this.itemSelectedEvent) {
-      this.resultItems.forEach((element) => {
-        element.clickedEvent = this.itemSelectedEvent;
+      // bind the click event on each individual result item.
+      this.resultItems.forEach((autocompleteResultDirective) => {
+        autocompleteResultDirective.clickedEvent = this.itemSelectedEvent;
       });
     }
   }
@@ -303,8 +305,12 @@ export class SprkAutocompleteComponent
       }
     }
 
+    // If there are any result items in the component when it initializes,
+    // set up their click events.
     this.bindClickEvents();
 
+    // If the result items change at runtime (by a filter, etc),
+    // redo the click events.
     this.resultItems.changes.subscribe((_) => {
       this.bindClickEvents();
     });


### PR DESCRIPTION
## What does this PR do?
Adds subscription logic so click events are reset if result items are dynamically added or removed.

```javascript
this.resultItems.changes.subscribe((_) => {
  this.bindClickEvents();
});
```

## Why?
Currently `sprk-autocomplete` sets up the click event on each of its child result items in `ngAfterContentInit`. Autocomplete results are often dynamically added/removed/changed at runtime (due to filtering). When items are dynamically added/removed, their click events were not being correctly set up, since `ngAfterContentInit` doesn't run when those items are changed.

## Code Coverage
![image](https://user-images.githubusercontent.com/1424560/121202628-6fdc3a80-c843-11eb-9f19-216034b60f43.png)

