### PR TITLE
Radio headers

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/inputs/sprk-radio-item/sprk-radio.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/sprk-radio-item/sprk-radio.stories.ts
@@ -115,7 +115,7 @@ export const defaultStory = () => ({
             for="radio-1"
             sprkRadioLabel
           >
-            Item 1
+            Radio Item 1
           </label>
        </sprk-radio-item>
        <sprk-radio-item>
@@ -133,7 +133,7 @@ export const defaultStory = () => ({
            for="radio-2"
            sprkRadioLabel
          >
-          Item 2
+          Radio Item 2
          </label>
        </sprk-radio-item>
        <sprk-radio-item>
@@ -151,7 +151,7 @@ export const defaultStory = () => ({
            for="radio-3"
            sprkRadioLabel
          >
-           Item 3
+           Radio Item 3
          </label>
        </sprk-radio-item>
      </fieldset>

--- a/angular/projects/spark-angular/src/lib/components/inputs/sprk-radio-item/sprk-radio.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/inputs/sprk-radio-item/sprk-radio.stories.ts
@@ -197,7 +197,7 @@ export const defaultHelperText = () => ({
             for="invalid-radio-1"
             sprkRadioLabel
           >
-            Item 1
+            Radio Item 1
           </label>
         </sprk-radio-item>
         <sprk-radio-item>
@@ -215,7 +215,7 @@ export const defaultHelperText = () => ({
             for="invalid-radio-2"
             sprkRadioLabel
           >
-            Item 2
+            Radio Item 2
           </label>
         </sprk-radio-item>
         <sprk-radio-item>
@@ -233,7 +233,7 @@ export const defaultHelperText = () => ({
             for="invalid-radio-3"
             sprkRadioLabel
           >
-            Item 3
+            Radio Item 3
           </label>
         </sprk-radio-item>
       </fieldset>
@@ -281,7 +281,7 @@ export const invalidRadioButton = () => ({
             for="invalid-radio-1"
             sprkRadioLabel
           >
-            Item 1
+            Radio Item 1
           </label>
         </sprk-radio-item>
         <sprk-radio-item>
@@ -299,7 +299,7 @@ export const invalidRadioButton = () => ({
             for="invalid-radio-2"
             sprkRadioLabel
           >
-            Item 2
+            Radio Item 2
           </label>
         </sprk-radio-item>
         <sprk-radio-item>
@@ -317,7 +317,7 @@ export const invalidRadioButton = () => ({
             for="invalid-radio-3"
             sprkRadioLabel
           >
-            Item 3
+            Radio Item 3
           </label>
         </sprk-radio-item>
       </fieldset>
@@ -376,7 +376,7 @@ export const disabledRadioButton = () => ({
             sprkRadioLabel
             isDisabled="true"
           >
-            Item 1
+            Radio Item 1
           </label>
       </sprk-radio-item>
       <sprk-radio-item>
@@ -396,7 +396,7 @@ export const disabledRadioButton = () => ({
             sprkRadioLabel
             isDisabled="true"
           >
-            Item 2
+            Radio Item 2
           </label>
       </sprk-radio-item>
       <sprk-radio-item>
@@ -416,7 +416,7 @@ export const disabledRadioButton = () => ({
             sprkRadioLabel
             isDisabled="true"
           >
-            Item 3
+            Radio Item 3
           </label>
         </sprk-radio-item>
       </fieldset>
@@ -464,7 +464,7 @@ export const huge = () => ({
             sprkRadioLabel
             variant="huge"
           >
-            Item 1
+            Radio Item 1
           </label>
        </sprk-radio-item>
        <sprk-radio-item variant="huge">
@@ -484,7 +484,7 @@ export const huge = () => ({
            sprkRadioLabel
            variant="huge"
          >
-            Item 2
+            Radio Item 2
          </label>
        </sprk-radio-item>
        <sprk-radio-item variant="huge">
@@ -504,7 +504,7 @@ export const huge = () => ({
             sprkRadioLabel
             variant="huge"
           >
-            Item 3
+            Radio Item 3
           </label>
        </sprk-radio-item>
      </fieldset>
@@ -552,7 +552,7 @@ export const hugeHelperText = () => ({
             sprkRadioLabel
             variant="huge"
           >
-            Item 1
+            Radio Item 1
           </label>
         </sprk-radio-item>
         <sprk-radio-item variant="huge">
@@ -572,7 +572,7 @@ export const hugeHelperText = () => ({
             sprkRadioLabel
             variant="huge"
           >
-            Item 2
+            Radio Item 2
           </label>
         </sprk-radio-item>
         <sprk-radio-item variant="huge">
@@ -592,7 +592,7 @@ export const hugeHelperText = () => ({
             sprkRadioLabel
             variant="huge"
           >
-            Item 3
+            Radio Item 3
           </label>
         </sprk-radio-item>
       </fieldset>
@@ -642,7 +642,7 @@ export const hugeInvalid = () => ({
             sprkRadioLabel
             variant="huge"
           >
-            Item 1
+            Radio Item 1
           </label>
         </sprk-radio-item>
         <sprk-radio-item variant="huge">
@@ -662,7 +662,7 @@ export const hugeInvalid = () => ({
             sprkRadioLabel
             variant="huge"
           >
-            Item 2
+            Radio Item 2
           </label>
         </sprk-radio-item>
         <sprk-radio-item variant="huge">
@@ -682,7 +682,7 @@ export const hugeInvalid = () => ({
             sprkRadioLabel
             variant="huge"
           >
-            Item 3
+            Radio Item 3
           </label>
         </sprk-radio-item>
       </fieldset>
@@ -743,7 +743,7 @@ export const hugeDisabled = () => ({
             isDisabled="true"
             variant="huge"
           >
-            Item 1
+            Radio Item 1
           </label>
         </sprk-radio-item>
         <sprk-radio-item variant="huge">
@@ -765,7 +765,7 @@ export const hugeDisabled = () => ({
             isDisabled="true"
             variant="huge"
           >
-            Item 2
+            Radio Item 2
           </label>
         </sprk-radio-item>
         <sprk-radio-item variant="huge">
@@ -787,7 +787,7 @@ export const hugeDisabled = () => ({
             isDisabled="true"
             variant="huge"
           >
-            Item 3
+            Radio Item 3
           </label>
         </sprk-radio-item>
      </fieldset>
@@ -837,7 +837,7 @@ export const hugeLayoutTwo = () => ({
               sprkRadioLabel
               variant="huge"
             >
-              Item 1
+              Radio Item 1
             </label>
           </sprk-radio-item>
         </div>
@@ -859,7 +859,7 @@ export const hugeLayoutTwo = () => ({
               sprkRadioLabel
               variant="huge"
             >
-              Item 2
+              Radio Item 2
             </label>
           </sprk-radio-item>
         </div>
@@ -914,7 +914,7 @@ export const hugeLayoutFour = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 1
+                  Radio Item 1
                 </label>
               </sprk-radio-item>
             </div>
@@ -936,7 +936,7 @@ export const hugeLayoutFour = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 2
+                  Radio Item 2
                 </label>
               </sprk-radio-item>
             </div>
@@ -962,7 +962,7 @@ export const hugeLayoutFour = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 3
+                  Radio Item 3
                 </label>
               </sprk-radio-item>
             </div>
@@ -984,7 +984,7 @@ export const hugeLayoutFour = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 4
+                  Radio Item 4
                 </label>
               </sprk-radio-item>
             </div>
@@ -1041,7 +1041,7 @@ export const hugeLayoutFive = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 1
+                  Radio Item 1
                 </label>
               </sprk-radio-item>
             </div>
@@ -1063,7 +1063,7 @@ export const hugeLayoutFive = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 2
+                  Radio Item 2
                 </label>
               </sprk-radio-item>
             </div>
@@ -1089,7 +1089,7 @@ export const hugeLayoutFive = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 3
+                  Radio Item 3
                 </label>
               </sprk-radio-item>
             </div>
@@ -1111,7 +1111,7 @@ export const hugeLayoutFive = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 4
+                  Radio Item 4
                 </label>
               </sprk-radio-item>
             </div>
@@ -1137,7 +1137,7 @@ export const hugeLayoutFive = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 5
+                  Radio Item 5
                 </label>
               </sprk-radio-item>
             </div>
@@ -1194,7 +1194,7 @@ export const hugeLayoutSix = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 1
+                  Radio Item 1
                 </label>
               </sprk-radio-item>
             </div>
@@ -1216,7 +1216,7 @@ export const hugeLayoutSix = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 2
+                  Radio Item 2
                 </label>
               </sprk-radio-item>
             </div>
@@ -1242,7 +1242,7 @@ export const hugeLayoutSix = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 3
+                  Radio Item 3
                 </label>
               </sprk-radio-item>
             </div>
@@ -1264,7 +1264,7 @@ export const hugeLayoutSix = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 4
+                  Radio Item 4
                 </label>
               </sprk-radio-item>
             </div>
@@ -1290,7 +1290,7 @@ export const hugeLayoutSix = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 5
+                  Radio Item 5
                 </label>
               </sprk-radio-item>
             </div>
@@ -1312,7 +1312,7 @@ export const hugeLayoutSix = () => ({
                   sprkRadioLabel
                   variant="huge"
                 >
-                  Item 6
+                  Radio Item 6
                 </label>
               </sprk-radio-item>
             </div>
@@ -1360,7 +1360,7 @@ export const legacyRadio = () => ({
           for="radio-1"
           sprkSelectionLabel
         >
-          Item 1
+          Radio Item 1
         </label>
       </sprk-selection-item-container>
       <sprk-selection-item-container>
@@ -1378,7 +1378,7 @@ export const legacyRadio = () => ({
           for="radio-2"
           sprkSelectionLabel
         >
-          Item 2
+          Radio Item 2
         </label>
       </sprk-selection-item-container>
       <sprk-selection-item-container>
@@ -1396,7 +1396,7 @@ export const legacyRadio = () => ({
           for="radio-3"
           sprkSelectionLabel
         >
-          Item 3
+          Radio Item 3
         </label>
       </sprk-selection-item-container>
     </sprk-selection-container>
@@ -1435,7 +1435,7 @@ export const legacyInvalidRadio = () => ({
           for="radio-1"
           sprkSelectionLabel
         >
-          Item 1
+          Radio Item 1
         </label>
       </sprk-selection-item-container>
       <sprk-selection-item-container>
@@ -1453,7 +1453,7 @@ export const legacyInvalidRadio = () => ({
           for="radio-2"
           sprkSelectionLabel
         >
-          Item 2
+          Radio Item 2
         </label>
       </sprk-selection-item-container>
       <sprk-selection-item-container>
@@ -1471,7 +1471,7 @@ export const legacyInvalidRadio = () => ({
           for="radio-3"
           sprkSelectionLabel
         >
-          Item 3
+          Radio Item 3
         </label>
       </sprk-selection-item-container>
       <span sprkFieldError>
@@ -1521,7 +1521,7 @@ export const legacyDisabledRadio = () => ({
           for="radio-1"
           sprkSelectionLabel
         >
-          Item 1
+          Radio Item 1
         </label>
       </sprk-selection-item-container>
       <sprk-selection-item-container>
@@ -1541,7 +1541,7 @@ export const legacyDisabledRadio = () => ({
           for="radio-2"
           sprkSelectionLabel
         >
-          Item 2
+          Radio Item 2
         </label>
       </sprk-selection-item-container>
       <sprk-selection-item-container>
@@ -1561,7 +1561,7 @@ export const legacyDisabledRadio = () => ({
           for="radio-3"
           sprkSelectionLabel
         >
-          Item 3
+          Radio Item 3
         </label>
       </sprk-selection-item-container>
     </sprk-selection-container>

--- a/html/base/inputs/Radio.stories.js
+++ b/html/base/inputs/Radio.stories.js
@@ -21,7 +21,7 @@ export const defaultStory = () => {
   return `
     <div class="sprk-b-InputContainer">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
 

--- a/html/base/inputs/Radio.stories.js
+++ b/html/base/inputs/Radio.stories.js
@@ -111,7 +111,7 @@ export const defaultHelperText = () => {
   return `
     <div class="sprk-b-InputContainer">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
         <div
@@ -199,7 +199,7 @@ export const invalidRadioButton = () => {
   return `
     <div class="sprk-b-InputContainer">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
 
@@ -406,7 +406,7 @@ export const huge = () => {
   return `
     <div class="sprk-b-InputContainer sprk-b-InputContainer--huge">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
 
@@ -497,7 +497,7 @@ export const hugeHelperText = () => {
   return `
     <div class="sprk-b-InputContainer sprk-b-InputContainer--huge">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
         <div
@@ -597,7 +597,7 @@ export const hugeInvalid = () => {
   return `
     <div class="sprk-b-InputContainer sprk-b-InputContainer--huge">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
         <div
@@ -814,7 +814,7 @@ export const hugeLayoutTwo = () => {
   return `
     <div class="sprk-b-InputContainer sprk-b-InputContainer--huge">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
 
@@ -899,7 +899,7 @@ export const hugeLayoutFour = () => {
   return `
     <div class="sprk-b-InputContainer sprk-b-InputContainer--huge">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
 
@@ -1048,7 +1048,7 @@ export const hugeLayoutFive = () => {
   return `
     <div class="sprk-b-InputContainer sprk-b-InputContainer--huge">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
         <div class="sprk-o-Stack sprk-o-Stack--medium">
@@ -1231,7 +1231,7 @@ export const hugeLayoutSix = () => {
   return `
     <div class="sprk-b-InputContainer sprk-b-InputContainer--huge">
       <fieldset class="sprk-b-Fieldset">
-        <legend class="sprk-b-Legend">
+        <legend class="sprk-b-Legend sprk-b-Label">
           Radio Group Label
         </legend>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spark-design-system-gatsby",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spark-design-system-gatsby",
-  "version": "3.1.0",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/react/src/base/inputs/SprkRadio.stories.js
+++ b/react/src/base/inputs/SprkRadio.stories.js
@@ -47,7 +47,7 @@ and <code>SprkRadioItem</code> components.
 export const defaultStory = () => (
   <SprkRadioGroup>
     <SprkFieldset>
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkRadioItem name="radio">Radio Item 1</SprkRadioItem>
       <SprkRadioItem name="radio">Radio Item 2</SprkRadioItem>
       <SprkRadioItem name="radio">Radio Item 3</SprkRadioItem>

--- a/react/src/base/inputs/SprkRadio.stories.js
+++ b/react/src/base/inputs/SprkRadio.stories.js
@@ -65,7 +65,7 @@ defaultStory.story = {
 export const defaultHelperText = () => (
   <SprkRadioGroup>
     <SprkFieldset>
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkRadioItem name="radio">Radio Item 1</SprkRadioItem>
       <SprkRadioItem name="radio">Radio Item 2</SprkRadioItem>
       <SprkRadioItem name="radio">Radio Item 3</SprkRadioItem>
@@ -87,7 +87,7 @@ defaultHelperText.story = {
 export const invalidRadioButton = () => (
   <SprkRadioGroup>
     <SprkFieldset ariaDescribedBy="invalid-radio">
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkRadioItem name="radio">Radio Item 1</SprkRadioItem>
       <SprkRadioItem name="radio">Radio Item 2</SprkRadioItem>
       <SprkRadioItem name="radio">Radio Item 3</SprkRadioItem>
@@ -113,7 +113,7 @@ invalidRadioButton.story = {
 export const disabledRadioButton = () => (
   <SprkRadioGroup>
     <SprkFieldset>
-      <SprkLegend isDisabled>Group Label Name</SprkLegend>
+      <SprkLegend isDisabled>Radio Group Label</SprkLegend>
       <SprkRadioItem name="radio" isDisabled>
         Radio Item 1
       </SprkRadioItem>
@@ -137,7 +137,7 @@ disabledRadioButton.story = {
 export const huge = () => (
   <SprkRadioGroup variant="huge">
     <SprkFieldset>
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkRadioItem name="radio" variant="huge">
         Radio Item 1
       </SprkRadioItem>
@@ -161,7 +161,7 @@ huge.story = {
 export const hugeHelperText = () => (
   <SprkRadioGroup variant="huge">
     <SprkFieldset ariaDescribedBy="huge-radio-helper-text">
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkRadioItem name="radio" variant="huge">
         Radio Item 1
       </SprkRadioItem>
@@ -188,7 +188,7 @@ hugeHelperText.story = {
 export const hugeInvalid = () => (
   <SprkRadioGroup variant="huge">
     <SprkFieldset ariaDescribedBy="invalid-huge-radio">
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkRadioItem name="radio" variant="huge">
         Radio Item 1
       </SprkRadioItem>
@@ -220,7 +220,7 @@ hugeInvalid.story = {
 export const hugeDisabled = () => (
   <SprkRadioGroup variant="huge">
     <SprkFieldset>
-      <SprkLegend isDisabled>Group Label Name</SprkLegend>
+      <SprkLegend isDisabled>Radio Group Label</SprkLegend>
       <SprkRadioItem name="radio" variant="huge" isDisabled>
         Radio Item 1
       </SprkRadioItem>
@@ -244,7 +244,7 @@ hugeDisabled.story = {
 export const hugeLayoutTwo = () => (
   <SprkRadioGroup variant="huge">
     <SprkFieldset>
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkStack itemSpacing="medium">
         <SprkStackItem>
           <SprkStack splitAt="small" itemSpacing="medium">
@@ -275,7 +275,7 @@ hugeLayoutTwo.story = {
 export const hugeLayoutFour = () => (
   <SprkRadioGroup variant="huge">
     <SprkFieldset>
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkStack itemSpacing="medium">
         <SprkStackItem>
           <SprkStack splitAt="small" itemSpacing="medium">
@@ -319,7 +319,7 @@ hugeLayoutFour.story = {
 export const hugeLayoutFive = () => (
   <SprkRadioGroup variant="huge">
     <SprkFieldset>
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkStack itemSpacing="medium">
         <SprkStackItem>
           <SprkStack splitAt="small" itemSpacing="medium">
@@ -381,7 +381,7 @@ hugeLayoutFive.story = {
 export const hugeLayoutSix = () => (
   <SprkRadioGroup variant="huge">
     <SprkFieldset>
-      <SprkLegend>Group Label Name</SprkLegend>
+      <SprkLegend>Radio Group Label</SprkLegend>
       <SprkStack itemSpacing="medium">
         <SprkStackItem>
           <SprkStack splitAt="small" itemSpacing="medium">


### PR DESCRIPTION
## What does this PR do?
Updates to the Radio Group headers to make their text and style consistent across storybooks. Additionally, text for each Radio item updated for consistency as well.

### Associated Issue
2275405