### PR TITLE
Remove usage of utils from Spark components

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -44,7 +44,7 @@ describe('SprkAccordionItemComponent', () => {
     component.additionalClasses = 'sprk-u-man';
     fixture.detectChanges();
     expect(accordionItemElement.classList.toString()).toContain(
-      'sprk-c-Accordion__item sprk-u-Overflow--hidden sprk-u-man',
+      'sprk-c-Accordion__item sprk-u-man',
     );
   });
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -220,10 +220,7 @@ export class SprkAccordionItemComponent implements OnInit {
    * @ignore
    */
   getClasses(): string {
-    const classArray: string[] = [
-      'sprk-c-Accordion__item',
-      'sprk-u-Overflow--hidden',
-    ];
+    const classArray: string[] = ['sprk-c-Accordion__item'];
 
     if (this.isOpen) {
       classArray.push('sprk-c-Accordion__item--open');

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -291,7 +291,8 @@ export class SprkAccordionItemComponent implements OnInit {
     const classArray: string[] = [
       'sprk-c-Icon--filled-current-color',
       'sprk-c-Icon--xl',
-      'sprk-u-mrs',
+      'sprk-c-Accordion__icon',
+      'sprk-c-Accordion__icon--leading',
     ];
 
     if (this.leadingIconAdditionalClasses) {

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.stories.ts
@@ -55,7 +55,6 @@ export const defaultStory = () => ({
     <sprk-accordion>
       <sprk-accordion-item
         heading="This is an accordion heading"
-        additionalClasses="sprk-u-mbs"
         idString="accordion-item-1"
         analyticsString="object.action.event"
       >

--- a/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-award/sprk-award.component.ts
@@ -14,7 +14,7 @@ import { Component, Input } from '@angular/core';
           sprk-o-Stack__item
           sprk-b-TypeDisplayFive
           sprk-b-Measure sprk-b-Measure--narrow
-          sprk-u-TextAlign--center
+          sprk-b-Type--center
           sprk-o-Stack__item--center-column
         "
       >

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -102,7 +102,7 @@ export const highlightedHeader = () => ({
           sprkHeading
           sprkStackItem
           variant="displaySeven"
-          class="sprk-u-Color--white"
+          class="sprk-c-Card__highlighted-heading"
         >
           Description
         </h3>
@@ -111,7 +111,7 @@ export const highlightedHeader = () => ({
           sprkHeading
           sprkStackItem
           variant="displayFive"
-          class="sprk-u-Color--white"
+          class="sprk-c-Card__highlighted-heading"
         >
           Card Title
         </h4>

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -219,7 +219,7 @@ export const teaserIcon = () => ({
           sprkStackItem
           aria-label="Title"
           analyticsString="teaser-icon-media"
-          class="sprk-u-AbsoluteCenter"
+          class="sprk-o-Stack sprk-o-Stack--center-all"
         >
           <sprk-icon
             iconName="call-team-member"

--- a/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-card/sprk-card.stories.ts
@@ -210,7 +210,7 @@ export const teaserIcon = () => ({
         sprkCardContent
         itemSpacing="large"
         sprkStackItem
-        additionalClasses="sprk-u-TextAlign--center"
+        additionalClasses="sprk-b-Type--center"
       >
         <a
           sprkLink

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -36,9 +36,11 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
         <span class="sprk-u-ScreenReaderText">{{ screenReaderText }}</span>
         <sprk-icon
           [iconName]="triggerIconName || triggerIconType"
-          additionalClasses="sprk-u-mls sprk-c-Icon--filled-current-color sprk-c-Icon--stroke-current-color {{
-            iconAdditionalClasses || additionalIconClasses
-          }}"
+          additionalClasses="
+            sprk-c-Dropdown__trigger-icon
+            sprk-c-Icon--filled-current-color
+            sprk-c-Icon--stroke-current-color
+            {{ iconAdditionalClasses || additionalIconClasses }}"
         ></sprk-icon>
       </a>
 
@@ -78,7 +80,7 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
               additionalClasses="
                 sprk-c-Icon--filled-current-color
                 sprk-c-Icon--stroke-current-color
-                sprk-u-mls
+                sprk-c-Dropdown__trigger-icon
                 sprk-c-Icon--toggle
                 {{ iconAdditionalClasses || additionalIconClasses }}
               "

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.component.ts
@@ -60,7 +60,7 @@ import { ISprkDropdownChoice } from './sprk-dropdown.interfaces';
             sprkLink
             *ngIf="selector && (!title || !heading)"
             variant="plain"
-            class="sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column sprk-u-Width-100"
+            class="sprk-o-Stack sprk-o-Stack--split@xxs sprk-o-Stack--center-column"
             (click)="toggle($event)"
             [attr.aria-label]="selector"
             href="#"

--- a/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-dropdown/sprk-dropdown.stories.ts
@@ -105,7 +105,7 @@ export const informational = () => ({
     ]"
     >
       <div
-        class="sprk-c-Dropdown__footer sprk-u-TextAlign--center"
+        class="sprk-c-Dropdown__footer sprk-b-Type--center"
         sprkDropdownFooter
       >
         <a

--- a/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.component.ts
@@ -219,7 +219,8 @@ import {
         </div>
 
         <span
-          class="sprk-c-Divider sprk-u-mvn sprk-u-mhm"
+          sprkDivider
+          class="sprk-c-Footer__divider"
           data-id="divider-1"
         ></span>
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.component.ts
@@ -23,7 +23,13 @@ import {
         >
           <div
             *ngIf="globalLinks"
-            class="sprk-o-Stack__item sprk-o-Stack__item--three-tenths@m sprk-o-Stack sprk-o-Stack--misc-b sprk-o-Box sprk-u-prh"
+            class="
+              sprk-o-Stack__item
+              sprk-o-Stack__item--three-tenths@m
+              sprk-o-Stack
+              sprk-o-Stack--misc-b
+              sprk-c-Footer__global-links
+            "
           >
             <h3
               class="sprk-o-Stack__item sprk-b-TypeBodyOne sprk-c-Footer__text"
@@ -99,7 +105,13 @@ import {
             >
               <div
                 *ngFor="let item of localLinks"
-                class="sprk-o-Stack__item sprk-o-Stack__item--third@m sprk-o-Box sprk-u-PaddingRight--a sprk-o-Stack sprk-o-Stack--large"
+                class="
+                  sprk-o-Stack__item
+                  sprk-o-Stack__item--third@m
+                  sprk-c-Footer__local-links
+                  sprk-o-Stack
+                  sprk-o-Stack--large
+                "
               >
                 <h3
                   class="sprk-o-Stack__item sprk-b-TypeBodyOne sprk-c-Footer__text"
@@ -225,7 +237,12 @@ import {
         ></span>
 
         <div
-          class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--misc-b sprk-o-Box sprk-u-PaddingTop--b"
+          class="
+            sprk-o-Stack__item
+            sprk-o-Stack
+            sprk-o-Stack--misc-b
+            sprk-c-Footer__awards
+          "
         >
           <div
             *ngIf="awards"
@@ -238,7 +255,13 @@ import {
             </h3>
 
             <div
-              class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack--split@s sprk-u-mbm"
+              class="
+                sprk-o-Stack__item
+                sprk-o-Stack
+                sprk-o-Stack--medium
+                sprk-o-Stack--split@s
+                sprk-c-Footer__awards-media
+              "
             >
               <div class="sprk-o-Stack__item" *ngFor="let award of awards">
                 <a

--- a/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.module.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.module.ts
@@ -7,6 +7,7 @@ import { SprkIconModule } from '../sprk-icon/sprk-icon.module';
 import { SprkLinkDirectiveModule } from '../../directives/sprk-link/sprk-link.module';
 import { SprkStackModule } from '../sprk-stack/sprk-stack.module';
 import { SprkToggleModule } from '../sprk-toggle/sprk-toggle.module';
+import { SprkDividerDirectiveModule } from '../../directives/sprk-divider/sprk-divider.module';
 import { SprkFooterComponent } from './sprk-footer.component';
 
 @NgModule({
@@ -19,6 +20,7 @@ import { SprkFooterComponent } from './sprk-footer.component';
     SprkLinkDirectiveModule,
     SprkTextModule,
     RouterModule,
+    SprkDividerDirectiveModule,
   ],
   declarations: [SprkFooterComponent],
   exports: [
@@ -27,6 +29,7 @@ import { SprkFooterComponent } from './sprk-footer.component';
     SprkLinkDirectiveModule,
     SprkTextModule,
     SprkFooterComponent,
+    SprkDividerDirectiveModule,
   ],
 })
 export class SprkFooterModule {}

--- a/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-footer/sprk-footer.stories.ts
@@ -115,10 +115,6 @@ export const defaultStory = () => ({
               href: '#nogo'
             },
             {
-              text: 'About That',
-              href: '#nogo'
-            },
-            {
               text: 'Disclosures and Other Things',
               href: '#nogo',
               analyticsString: 'Link to Sub Item 1'
@@ -223,7 +219,7 @@ export const defaultStory = () => ({
         }
       ]"
 
-      awardsHeading="Awards"
+      awardsHeading="Awards Heading Title"
       [awards]="[
         {
           href: '#nogo',

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/components/sprk-masthead-accordion-item/sprk-masthead-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/components/sprk-masthead-accordion-item/sprk-masthead-accordion-item.component.ts
@@ -19,7 +19,13 @@ import { toggleAnimations } from '../../../sprk-toggle/sprk-toggle-animations';
           <span [ngClass]="getHeadingClasses()">
             <sprk-icon
               [iconName]="leadingIcon"
-              additionalClasses="sprk-c-Icon--filled-current-color sprk-c-Icon--xl sprk-c-Icon--toggle sprk-u-mrs"
+              additionalClasses="
+                sprk-c-MastheadAccordion__icon
+                sprk-c-MastheadAccordion__icon--leading
+                sprk-c-Icon--filled-current-color
+                sprk-c-Icon--xl
+                sprk-c-Icon--toggle
+              "
               *ngIf="leadingIcon"
             ></sprk-icon>
             {{ heading }}

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/components/sprk-masthead-selector/sprk-masthead-selector.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/components/sprk-masthead-selector/sprk-masthead-selector.component.ts
@@ -39,7 +39,7 @@ import { ISprkMastheadSelectorChoice } from '../sprk-masthead-selector/sprk-mast
           <span class="sprk-u-ScreenReaderText">{{ screenReaderText }}</span>
           <sprk-icon
             [iconName]="triggerIconName"
-            additionalClasses="sprk-Stack__item sprk-u-mhs"
+            additionalClasses="sprk-Stack__item sprk-c-Masthead__selector-icon"
           ></sprk-icon>
         </a>
       </div>

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -672,7 +672,7 @@ export const extended = () => ({
               triggerIconName="user"
               triggerAdditionalClasses="sprk-b-Link--plain sprk-c-Masthead__link"
               iconAdditionalClasses="sprk-c-Icon--xl"
-              additionalClasses="sprk-u-Right--zero sprk-u-mrm"
+              additionalClasses="sprk-c-Masthead__dropdown"
               screenReaderText="User Account"
             >
             </sprk-dropdown>

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -526,7 +526,8 @@ export const defaultStory = () => ({
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                 ></sprk-icon>
                 (555) 555-5555
@@ -548,7 +549,8 @@ export const defaultStory = () => ({
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                 ></sprk-icon>
                 Talk To Us
@@ -921,7 +923,8 @@ export const extended = () => ({
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                 ></sprk-icon>
                 (555) 555-5555
@@ -943,7 +946,8 @@ export const extended = () => ({
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                 ></sprk-icon>
                 Talk To Us
@@ -965,7 +969,8 @@ export const extended = () => ({
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                 ></sprk-icon>
                 Settings
@@ -1431,7 +1436,8 @@ export const extendedWithExampleContent = () => ({
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                 ></sprk-icon>
                 (555) 555-5555
@@ -1453,7 +1459,8 @@ export const extendedWithExampleContent = () => ({
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                 ></sprk-icon>
                 Talk To Us
@@ -1475,7 +1482,8 @@ export const extendedWithExampleContent = () => ({
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                 ></sprk-icon>
                 Settings

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -623,7 +623,7 @@ export const extended = () => ({
       >
         <div sprkStackItem class="sprk-o-Stack__item--flex@xxs">
           <sprk-stack additionalClasses="sprk-o-Stack--center-column sprk-o-Stack--center-row">
-            <div sprkStackItem class="sprk-u-Position--relative">
+            <div sprkStackItem class="sprk-c-Masthead__selector-container">
               <sprk-masthead-selector
                 triggerText="Choose One"
                 heading="Choose One"
@@ -1135,7 +1135,7 @@ export const extendedWithExampleContent = () => ({
       >
         <div sprkStackItem class="sprk-o-Stack__item--flex@xxs">
           <sprk-stack additionalClasses="sprk-o-Stack--center-column sprk-o-Stack--center-row">
-            <div sprkStackItem class="sprk-u-Position--relative">
+            <div sprkStackItem class="sprk-c-Masthead__selector-container">
               <sprk-masthead-selector
                 triggerText="Choose One"
                 heading="Choose One"
@@ -1184,7 +1184,7 @@ export const extendedWithExampleContent = () => ({
               triggerIconName="user"
               triggerAdditionalClasses="sprk-b-Link--plain sprk-c-Masthead__link"
               iconAdditionalClasses="sprk-c-Icon--xl"
-              additionalClasses="sprk-u-Right--zero sprk-u-mrm"
+              additionalClasses="sprk-c-Masthead__dropdown"
               screenReaderText="User Account"
             >
             </sprk-dropdown>

--- a/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-masthead/sprk-masthead.stories.ts
@@ -710,7 +710,7 @@ export const extended = () => ({
               <sprk-dropdown
                 [choices]="item2NavBarDropdownChoices"
                 triggerAdditionalClasses="sprk-b-Link--simple sprk-c-Masthead__link sprk-c-Masthead__link--nav-bar"
-                additionalClasses="sprk-u-TextAlign--left"
+                additionalClasses="sprk-b-Type--left"
                 triggerIconName="chevron-down"
                 analyticsString="nav-bar-item-2"
                 triggerText="Item Two"
@@ -739,7 +739,7 @@ export const extended = () => ({
               <sprk-dropdown
                 [choices]="item2NavBarDropdownChoices"
                 triggerAdditionalClasses="sprk-b-Link--simple sprk-c-Masthead__link sprk-c-Masthead__link--nav-bar"
-                additionalClasses="sprk-u-TextAlign--left"
+                additionalClasses="sprk-b-Type--left"
                 triggerIconName="chevron-down"
                 analyticsString="nav-bar-item-4"
                 triggerText="Item Four"
@@ -1223,7 +1223,7 @@ export const extendedWithExampleContent = () => ({
               <sprk-dropdown
                 [choices]="item2NavBarDropdownChoices"
                 triggerAdditionalClasses="sprk-b-Link--simple sprk-c-Masthead__link sprk-c-Masthead__link--nav-bar"
-                additionalClasses="sprk-u-TextAlign--left"
+                additionalClasses="sprk-b-Type--left"
                 triggerIconName="chevron-down"
                 analyticsString="nav-bar-item-2"
                 triggerText="Item Two"
@@ -1252,7 +1252,7 @@ export const extendedWithExampleContent = () => ({
               <sprk-dropdown
                 [choices]="item2NavBarDropdownChoices"
                 triggerAdditionalClasses="sprk-b-Link--simple sprk-c-Masthead__link sprk-c-Masthead__link--nav-bar"
-                additionalClasses="sprk-u-TextAlign--left"
+                additionalClasses="sprk-b-Type--left"
                 triggerIconName="chevron-down"
                 analyticsString="nav-bar-item-4"
                 triggerText="Item Four"

--- a/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.stories.ts
@@ -40,7 +40,15 @@ for an example.
       },
     },
   },
+<<<<<<< HEAD
 } as Meta;
+=======
+};
+
+const modules = {
+  imports: [SprkStackModule, SprkStackItemModule, SprkTextModule],
+};
+>>>>>>> stack story updates
 
 export const defaultStory = () => ({
   template: `
@@ -69,7 +77,7 @@ export const stackSplit = () => ({
   `,
 });
 
-stackSplit.storyName = 'Stack/Split - Spaced Item';
+stackSplit.storyName = 'Stack/Split - Spaced Items';
 
 defaultStory.parameters = {
   jest: ['sprk-stack.component', 'sprk-stack-item.directive'],
@@ -315,108 +323,108 @@ stackSplitLayoutThreeTenths.parameters = {
 export const stackSplitLayoutMixed = () => ({
   template: `
     <sprk-stack splitAt="tiny">
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           fourth
         </p>
-      </sprk-stack>
+      </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--half@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           half
         </p>
-      </sprk-stack>
+      </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           fourth
         </p>
-      </sprk-stack>
+      </div>
     </sprk-stack>
 
     <sprk-stack splitAt="tiny">
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           sixth
         </p>
-      </sprk-stack>
+      </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           sixth
         </p>
-      </sprk-stack>
+      </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           sixth
         </p>
-      </sprk-stack>
+      </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           flex
         </p>
-      </sprk-stack>
+      </div>
     </sprk-stack>
 
     <sprk-stack splitAt="tiny">
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           two-fifths
         </p>
-      </sprk-stack>
+      </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           fifth
         </p>
       </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           fifth
         </p>
-      </sprk-stack>
+      </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           fifth
         </p>
-      </sprk-stack>
+      </div>
     </sprk-stack>
 
     <sprk-stack splitAt="tiny">
@@ -425,54 +433,54 @@ export const stackSplitLayoutMixed = () => ({
         class="sprk-o-Stack__item--half@xs"
       >
         <sprk-stack splitAt="tiny">
-          <sprk-stack
-            isStackItem="true"
-            additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
+          <div
+            sprkStackItem
+            class="sprk-o-Stack sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
           >
             <p sprkStackItem class="sprk-b-TypeBodyOne">
               Nested Item (flex)
             </p>
-          </sprk-stack>
+          </div>
 
-          <sprk-stack
-            isStackItem="true"
-            additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
+          <div
+            sprkStackItem
+            class="sprk-o-Stack sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
           >
             <p sprkStackItem class="sprk-b-TypeBodyOne">
               Nested Item (flex)
             </p>
-          </sprk-stack>
+          </div>
         </sprk-stack>
       </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--half@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           half
         </p>
-      </sprk-stack>
+      </div>
     </sprk-stack>
 
     <sprk-stack splitAt="tiny">
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           two-fifths
         </p>
-      </sprk-stack>
+      </div>
 
-      <sprk-stack
-        isStackItem="true"
-        additionalClasses="sprk-o-Stack__item--three-fifths@xs sprk-o-Stack--center-all"
+      <div
+        sprkStackItem
+        class="sprk-o-Stack sprk-o-Stack__item--three-fifths@xs sprk-o-Stack--center-all"
       >
         <p sprkStackItem class="sprk-b-TypeBodyOne">
           three-fifths
         </p>
-      </sprk-stack>
+      </div>
     </sprk-stack>
   `,
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.stories.ts
@@ -40,15 +40,7 @@ for an example.
       },
     },
   },
-<<<<<<< HEAD
 } as Meta;
-=======
-};
-
-const modules = {
-  imports: [SprkStackModule, SprkStackItemModule, SprkTextModule],
-};
->>>>>>> stack story updates
 
 export const defaultStory = () => ({
   template: `

--- a/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.stories.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-stack/sprk-stack.stories.ts
@@ -315,100 +315,108 @@ stackSplitLayoutThreeTenths.parameters = {
 export const stackSplitLayoutMixed = () => ({
   template: `
     <sprk-stack splitAt="tiny">
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--fourth@xs sprk-u-AbsoluteCenter"
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           fourth
         </p>
-      </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--half@xs sprk-u-AbsoluteCenter"
+      </sprk-stack>
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           half
         </p>
-      </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--fourth@xs sprk-u-AbsoluteCenter"
+      </sprk-stack>
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           fourth
         </p>
-      </div>
+      </sprk-stack>
     </sprk-stack>
 
     <sprk-stack splitAt="tiny">
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--sixth@xs sprk-u-AbsoluteCenter"
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           sixth
         </p>
-      </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--sixth@xs sprk-u-AbsoluteCenter"
+      </sprk-stack>
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           sixth
         </p>
-      </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--sixth@xs sprk-u-AbsoluteCenter"
+      </sprk-stack>
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           sixth
         </p>
-      </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--flex@xs sprk-u-AbsoluteCenter"
+      </sprk-stack>
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           flex
         </p>
-      </div>
+      </sprk-stack>
     </sprk-stack>
 
     <sprk-stack splitAt="tiny">
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--two-fifths@xs sprk-u-AbsoluteCenter"
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           two-fifths
         </p>
-      </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--fifth@xs sprk-u-AbsoluteCenter"
+      </sprk-stack>
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           fifth
         </p>
       </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--fifth@xs sprk-u-AbsoluteCenter"
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           fifth
         </p>
-      </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--fifth@xs sprk-u-AbsoluteCenter"
+      </sprk-stack>
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           fifth
         </p>
-      </div>
+      </sprk-stack>
     </sprk-stack>
 
     <sprk-stack splitAt="tiny">
@@ -417,51 +425,54 @@ export const stackSplitLayoutMixed = () => ({
         class="sprk-o-Stack__item--half@xs"
       >
         <sprk-stack splitAt="tiny">
-          <div
-            sprkStackItem
-            class="sprk-o-Stack__item--flex@xs sprk-u-AbsoluteCenter"
+          <sprk-stack
+            isStackItem="true"
+            additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
           >
-            <p class="sprk-b-TypeBodyOne">
+            <p sprkStackItem class="sprk-b-TypeBodyOne">
               Nested Item (flex)
             </p>
-          </div>
-          <div
-            sprkStackItem
-            class="sprk-o-Stack__item--flex@xs sprk-u-AbsoluteCenter"
+          </sprk-stack>
+
+          <sprk-stack
+            isStackItem="true"
+            additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
           >
-            <p class="sprk-b-TypeBodyOne">
+            <p sprkStackItem class="sprk-b-TypeBodyOne">
               Nested Item (flex)
             </p>
-          </div>
+          </sprk-stack>
         </sprk-stack>
       </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--half@xs sprk-u-AbsoluteCenter"
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           half
         </p>
-      </div>
+      </sprk-stack>
     </sprk-stack>
 
     <sprk-stack splitAt="tiny">
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--two-fifths@xs sprk-u-AbsoluteCenter"
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           two-fifths
         </p>
-      </div>
-      <div
-        sprkStackItem
-        class="sprk-o-Stack__item--three-fifths@xs sprk-u-AbsoluteCenter"
+      </sprk-stack>
+
+      <sprk-stack
+        isStackItem="true"
+        additionalClasses="sprk-o-Stack__item--three-fifths@xs sprk-o-Stack--center-all"
       >
-        <p class="sprk-b-TypeBodyOne">
+        <p sprkStackItem class="sprk-b-TypeBodyOne">
           three-fifths
         </p>
-      </div>
+      </sprk-stack>
     </sprk-stack>
   `,
 });

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -179,7 +179,7 @@ describe('SprkToggleComponent', () => {
     component.titleFontClass = 'test-1 test-2';
     fixture.detectChanges();
     expect(triggerElement.classList.toString()).toContain(
-      'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
+      'sprk-c-Toggle__trigger sprk-b-Type--crop-none test-1 test-2',
     );
   });
 
@@ -187,7 +187,7 @@ describe('SprkToggleComponent', () => {
     component.triggerTextAdditionalClasses = 'test-1 test-2';
     fixture.detectChanges();
     expect(triggerElement.classList.toString()).toContain(
-      'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
+      'sprk-c-Toggle__trigger sprk-b-Type--crop-none test-1 test-2',
     );
   });
 
@@ -197,7 +197,7 @@ describe('SprkToggleComponent', () => {
     component.titleFontClass = 'test-3 test-4';
     fixture.detectChanges();
     expect(triggerElement.classList.toString()).toContain(
-      'sprk-c-Toggle__trigger sprk-u-TextCrop--none test-1 test-2',
+      'sprk-c-Toggle__trigger sprk-b-Type--crop-none test-1 test-2',
     );
   });
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -71,7 +71,9 @@ describe('SprkToggleComponent', () => {
     fixture.detectChanges();
     expect(
       element.querySelector('button .sprk-c-Icon').classList.toString(),
-    ).toEqual('sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle');
+    ).toEqual(
+      'sprk-c-Icon sprk-c-Icon--xl sprk-c-Toggle__trigger-icon sprk-c-Icon--toggle',
+    );
   });
 
   // TODO: Remove `iconClass` in issue #1305

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.spec.ts
@@ -35,7 +35,7 @@ describe('SprkToggleComponent', () => {
   it('clicking should show body text', () => {
     element.querySelector('button').click();
     fixture.detectChanges();
-    expect(element.querySelector('div.sprk-u-pts.sprk-u-pbs')).toBeTruthy();
+    expect(element.querySelector('div.sprk-c-Toggle__content')).toBeTruthy();
   });
 
   it('should set the data-analytics attribute given a value in the analyticsString Input', () => {
@@ -54,7 +54,7 @@ describe('SprkToggleComponent', () => {
     expect(
       element.querySelector('button .sprk-c-Icon').classList.toString(),
     ).toEqual(
-      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle sprk-c-Icon--open',
+      'sprk-c-Icon sprk-c-Icon--xl sprk-c-Toggle__trigger-icon sprk-c-Icon--toggle sprk-c-Icon--open',
     );
   });
 
@@ -65,7 +65,7 @@ describe('SprkToggleComponent', () => {
     expect(
       triggerElement.querySelector('.sprk-c-Icon').classList.toString(),
     ).toEqual(
-      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle sprk-c-Icon--open',
+      'sprk-c-Icon sprk-c-Icon--xl sprk-c-Toggle__trigger-icon sprk-c-Icon--toggle sprk-c-Icon--open',
     );
     element.querySelector('button').click();
     fixture.detectChanges();
@@ -81,7 +81,7 @@ describe('SprkToggleComponent', () => {
     expect(
       element.querySelector('button .sprk-c-Icon').classList.toString(),
     ).toEqual(
-      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle test',
+      'sprk-c-Icon sprk-c-Icon--xl sprk-c-Toggle__trigger-icon sprk-c-Icon--toggle test',
     );
   });
 
@@ -91,7 +91,7 @@ describe('SprkToggleComponent', () => {
     expect(
       element.querySelector('button .sprk-c-Icon').classList.toString(),
     ).toEqual(
-      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle test',
+      'sprk-c-Icon sprk-c-Icon--xl sprk-c-Toggle__trigger-icon sprk-c-Icon--toggle test',
     );
   });
 
@@ -103,7 +103,7 @@ describe('SprkToggleComponent', () => {
     expect(
       element.querySelector('button .sprk-c-Icon').classList.toString(),
     ).toEqual(
-      'sprk-c-Icon sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle should-add',
+      'sprk-c-Icon sprk-c-Icon--xl sprk-c-Toggle__trigger-icon sprk-c-Icon--toggle should-add',
     );
   });
 
@@ -171,7 +171,7 @@ describe('SprkToggleComponent', () => {
     fixture.detectChanges();
     expect(
       element.querySelector('.sprk-c-Toggle__content').classList.toString(),
-    ).toContain('sprk-u-pts sprk-u-pbs sprk-c-Toggle__content test-1 test-2');
+    ).toContain('sprk-c-Toggle__content test-1 test-2');
   });
 
   // TODO: Remove `titleFontClass` in issue #1305

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -197,7 +197,7 @@ export class SprkToggleComponent implements AfterContentInit {
     const additionalClasses =
       this.triggerTextAdditionalClasses || this.titleFontClass;
     const classArray: string[] = [
-      'sprk-c-Toggle__trigger sprk-u-TextCrop--none',
+      'sprk-c-Toggle__trigger sprk-b-Type--crop-none',
       additionalClasses,
     ];
     return classArray.join(' ');

--- a/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-toggle/sprk-toggle.component.ts
@@ -210,7 +210,7 @@ export class SprkToggleComponent implements AfterContentInit {
     // TODO: Remove `iconClass` in issue #1305
     const additionalClasses = this.iconAdditionalClasses || this.iconClass;
     const classArray: string[] = [
-      'sprk-c-Icon--xl sprk-u-mrs sprk-c-Icon--toggle',
+      'sprk-c-Icon--xl sprk-c-Toggle__trigger-icon sprk-c-Icon--toggle',
       this.iconStateClass,
     ];
     if (additionalClasses) {
@@ -226,7 +226,7 @@ export class SprkToggleComponent implements AfterContentInit {
    */
   getContentClasses(): string {
     const classArray: string[] = [
-      'sprk-u-pts sprk-u-pbs sprk-c-Toggle__content',
+      'sprk-c-Toggle__content',
     ];
     if (this.contentAdditionalClasses) {
       this.contentAdditionalClasses.split(' ').forEach((className) => {

--- a/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-link/sprk-link.stories.ts
@@ -132,7 +132,8 @@ export const iconWithTextLink = () => ({
         additionalClasses="
           sprk-c-Icon--l
           sprk-c-Icon--filled-current-color
-          sprk-u-mrs"
+          sprk-b-Link__icon
+        "
       >
       </sprk-icon>
       Back
@@ -226,7 +227,8 @@ export const disabledIconWithTextLink = () => ({
         additionalClasses="
           sprk-c-Icon--xl
           sprk-c-Icon--filled-current-color
-          sprk-u-mrs"
+          sprk-b-Link__icon
+        "
       >
       </sprk-icon>
       Back

--- a/html/base/link.stories.js
+++ b/html/base/link.stories.js
@@ -79,7 +79,7 @@ export const iconWithTextLink = () =>
         class="
           sprk-c-Icon
           sprk-c-Icon--xl
-          sprk-u-mrs
+          sprk-b-Link__icon
           sprk-c-Icon--filled-current-color
         "
         viewBox="0 0 100 100"
@@ -153,7 +153,7 @@ export const disabledIconWithTextLink = () =>
         class="
           sprk-c-Icon
           sprk-c-Icon--xl
-          sprk-u-mrs
+          sprk-b-Link__icon
           sprk-c-Icon--filled-current-color
         "
         viewBox="0 0 100 100"

--- a/html/components/alert.stories.js
+++ b/html/components/alert.stories.js
@@ -24,8 +24,10 @@ export const info = () => {
   return `
     <div
       class="sprk-c-Alert sprk-c-Alert--info"
-      role="alert" data-sprk-alert="container"
-      data-id="alert-info-1" data-analytics="object.action.event"
+      role="alert"
+      data-sprk-alert="container"
+      data-id="alert-info-1"
+      data-analytics="object.action.event"
     >
       <div class="sprk-c-Alert__content">
         <svg

--- a/html/components/alerts.js
+++ b/html/components/alerts.js
@@ -1,7 +1,7 @@
 import getElements from '../utilities/getElements';
 
 const dismissAlert = (alert) => {
-  alert.classList.add('sprk-u-Display--none');
+  alert.classList.add('sprk-c-Alert--is-hidden');
 };
 
 const bindUIEvents = (element) => {

--- a/html/components/autocomplete.js
+++ b/html/components/autocomplete.js
@@ -26,7 +26,7 @@ const hideList = (autocompleteContainer, inputEl) => {
       listEl.querySelectorAll('[data-sprk-autocomplete="result"]'),
       activeClass,
     );
-    listEl.classList.add('sprk-u-Display--none');
+    listEl.classList.add('sprk-c-Autocomplete__results--is-hidden');
     inputEl.removeAttribute('aria-activedescendant');
     inputEl.parentNode.setAttribute('aria-expanded', false);
   }

--- a/html/components/autocomplete.stories.js
+++ b/html/components/autocomplete.stories.js
@@ -56,12 +56,12 @@ In order to keep the Spark Autocomplete flexible enough to use in a wide
     - Update the contents of the associated \`aria-live\` element.
   - Showing the list
     - Set \`aria-expanded\` to \`true\` on the input container.
-    - Remove \`sprk-u-Display--none\` from the results list.
+    - Remove \`sprk-c-Autocomplete__results--is-hidden\` from the results list.
   - Hiding the list
     - Remove \`aria-selected\` from the active list item.
     - Remove \`aria-activedescendant\` from the input.
     - Set \`aria-expanded\` to false on the input container.
-    - Add \`sprk-u-Display--none\` to the results list.
+    - Add \`sprk-c-Autocomplete__results--is-hidden\` to the results list.
   - Selecting an item in the list by clicking it or pressing the Enter key.
     - The highlighted item is identified by the value of
     \`aria-activedescendant\` on the input.
@@ -272,7 +272,7 @@ export const defaultInvalid = () => {
 
       <ul
         data-sprk-autocomplete="results"
-        class="sprk-c-Autocomplete__results sprk-u-Display--none"
+        class="sprk-c-Autocomplete__results sprk-c-Autocomplete__results--is-hidden"
         role="listbox"
         aria-labelledby="autocomplete-label"
       >
@@ -417,7 +417,7 @@ export const defaultDisabled = () => {
 
       <ul
         data-sprk-autocomplete="results"
-        class="sprk-c-Autocomplete__results sprk-u-Display--none"
+        class="sprk-c-Autocomplete__results sprk-c-Autocomplete__results--is-hidden"
         role="listbox"
         aria-labelledby="autocomplete-label"
       >
@@ -686,7 +686,7 @@ export const hugeInvalid = () => {
     </div>
 
     <ul
-      class="sprk-c-Autocomplete__results sprk-u-Display--none"
+      class="sprk-c-Autocomplete__results sprk-c-Autocomplete__results--is-hidden"
       role="listbox"
       aria-labelledby="autocomplete-huge-label-invalid"
       data-sprk-autocomplete="results"
@@ -835,7 +835,7 @@ export const hugeDisabled = () => {
     </div>
 
     <ul
-      class="sprk-c-Autocomplete__results sprk-u-Display--none"
+      class="sprk-c-Autocomplete__results sprk-c-Autocomplete__results--is-hidden"
       role="listbox"
       aria-labelledby="input-label-huge"
       data-sprk-autocomplete="results"

--- a/html/components/award.stories.js
+++ b/html/components/award.stories.js
@@ -81,7 +81,12 @@ export const defaultStory = () => {
         data-sprk-toggle="trigger"
       >
           <svg
-            class="sprk-c-Icon sprk-c-Icon--xl sprk-c-Icon--toggle sprk-c-Toggle__trigger-icon"
+            class="
+              sprk-c-Icon
+              sprk-c-Icon--xl
+              sprk-c-Icon--toggle
+              sprk-c-Toggle__trigger-icon
+            "
             data-sprk-toggle="icon"
             viewBox="0 0 64 64"
           >
@@ -90,8 +95,8 @@ export const defaultStory = () => {
           My Disclaimer
       </button>
 
-      <div data-sprk-toggle="content">
-        <p class="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
+      <div class="sprk-c-Toggle__content" data-sprk-toggle="content">
+        <p class="sprk-b-TypeBodyFour">
           This is an example of disclaimer content.
           The aria-expanded="true" attribute will be
           viewable in the DOM on the toggle link when this

--- a/html/components/award.stories.js
+++ b/html/components/award.stories.js
@@ -26,21 +26,22 @@ export const defaultStory = () => {
   >
     <h2
       class="
-        sprk-o-Stack__item 
-        sprk-o-Stack__item--center-column 
-        sprk-b-TypeDisplayFive 
-        sprk-b-Measure 
-        sprk-b-Measure--narrow 
-        sprk-u-TextAlign--center
+        sprk-o-Stack__item
+        sprk-o-Stack__item--center-column
+        sprk-b-TypeDisplayFive
+        sprk-b-Measure
+        sprk-b-Measure--narrow
+        sprk-b-Type--center
       ">
       Award Component Heading
     </h2>
 
-    <div 
+    <div
       class="
-        sprk-o-Stack__item 
-        sprk-o-Stack__item--center-column 
-        sprk-o-Stack sprk-o-Stack--medium 
+        sprk-o-Stack__item
+        sprk-o-Stack__item--center-column
+        sprk-o-Stack
+        sprk-o-Stack--medium
         sprk-o-Stack--split@s
       ">
       <a
@@ -53,12 +54,12 @@ export const defaultStory = () => {
           src="https://spark-assets.netlify.app/spark-logo-updated.svg" />
       </a>
 
-      <a 
+      <a
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--flex@s 
+          sprk-o-Stack__item
+          sprk-o-Stack__item--flex@s
           sprk-o-Stack
-        " 
+        "
         href="#nogo">
         <img
           class="sprk-o-Stack__item sprk-o-Stack__item--center-column"
@@ -73,9 +74,9 @@ export const defaultStory = () => {
     >
       <button
         class="
-          sprk-c-Toggle__trigger 
-          sprk-b-TypeBodyThree 
-          sprk-u-TextCrop--none
+          sprk-c-Toggle__trigger
+          sprk-b-TypeBodyThree
+          sprk-b-Type--crop-none
         "
         data-sprk-toggle="trigger">
           <svg

--- a/html/components/award.stories.js
+++ b/html/components/award.stories.js
@@ -78,9 +78,10 @@ export const defaultStory = () => {
           sprk-b-TypeBodyThree
           sprk-b-Type--crop-none
         "
-        data-sprk-toggle="trigger">
+        data-sprk-toggle="trigger"
+      >
           <svg
-            class="sprk-c-Icon sprk-c-Icon--xl sprk-c-Icon--toggle sprk-u-mrs"
+            class="sprk-c-Icon sprk-c-Icon--xl sprk-c-Icon--toggle sprk-c-Toggle__trigger-icon"
             data-sprk-toggle="icon"
             viewBox="0 0 64 64"
           >

--- a/html/components/card.stories.js
+++ b/html/components/card.stories.js
@@ -188,7 +188,7 @@ export const teaserWithDifferentElementOrder = () =>
           sprk-o-Stack__item
           sprk-c-Card__content
           sprk-b-TypeDisplayFive
-          "
+        "
         >
         Teaser Card Title
       </h3>
@@ -286,7 +286,8 @@ export const twoUpCards = () =>
           <div class="
             sprk-o-Stack__item
             sprk-o-Stack
-            sprk-o-Stack--end-column"
+            sprk-o-Stack--end-column
+          "
           >
             <a
               href="#nogo"
@@ -392,12 +393,13 @@ export const threeUpCards = () =>
         >
           <a
             href="#nogo"
-            class="sprk-u-AbsoluteCenter sprk-o-Stack__item"
+            class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--center-all"
             aria-label="Learn More"
           >
             <svg
               aria-hidden="true"
               class="
+                sprk-o-Stack__item
                 sprk-c-Icon
                 sprk-c-Icon--xl
               "
@@ -461,13 +463,15 @@ export const threeUpCards = () =>
         >
           <a
             href="#nogo"
-            class="sprk-u-AbsoluteCenter sprk-o-Stack__item"
+            class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--center-all"
             aria-label="Learn More"
           >
             <svg
               class="
+                sprk-o-Stack__item
                 sprk-c-Icon
-                sprk-c-Icon--xl"
+                sprk-c-Icon--xl
+              "
               height="75"
               aria-hidden="true"
               viewBox="0 0 220.63 197.62"
@@ -522,14 +526,16 @@ export const threeUpCards = () =>
         >
           <a
             href="#nogo"
-            class="sprk-u-AbsoluteCenter sprk-o-Stack__item"
+            class="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--center-all"
             aria-label="Learn More"
           >
             <svg
               aria-hidden="true"
               class="
+                sprk-o-Stack__item
                 sprk-c-Icon
-                sprk-c-Icon--xl"
+                sprk-c-Icon--xl
+              "
               height="75" viewBox="0 0 220.63 197.62">
               <use xlink:href="#call-team-member" />
             </svg>
@@ -620,7 +626,8 @@ export const fourUpCards = () =>
         class="
           sprk-o-Stack__item
           sprk-o-Stack__item--flex@xl
-          sprk-c-Card sprk-o-Stack
+          sprk-c-Card
+          sprk-o-Stack
         "
         data-id="card-four-up-2"
       >
@@ -644,7 +651,8 @@ export const fourUpCards = () =>
           <div class="
             sprk-o-Stack__item
             sprk-o-Stack
-            sprk-o-Stack--end-column"
+            sprk-o-Stack--end-column
+          "
           >
             <div class="sprk-o-Stack__item">
               <a href="#nogo" class="sprk-c-Button sprk-c-Button--secondary">

--- a/html/components/card.stories.js
+++ b/html/components/card.stories.js
@@ -80,7 +80,7 @@ export const highlightedHeader = () =>
           class="
             sprk-b-TypeDisplaySeven
             sprk-o-Stack__item
-            sprk-u-Color--white
+            sprk-c-Card__highlighted-heading
           "
         >
           Description
@@ -88,8 +88,9 @@ export const highlightedHeader = () =>
 
         <h4
           class="
-            sprk-b-TypeDisplayFive sprk-o-Stack__item
-            sprk-u-Color--white
+            sprk-b-TypeDisplayFive
+            sprk-o-Stack__item
+            sprk-c-Card__highlighted-heading
           "
         >
           Card Title
@@ -386,7 +387,7 @@ export const threeUpCards = () =>
             sprk-c-Card__content
             sprk-o-Stack
             sprk-o-Stack--large
-            sprk-u-TextAlign--center
+            sprk-b-Type--center
           "
         >
           <a
@@ -455,7 +456,7 @@ export const threeUpCards = () =>
             sprk-c-Card__content
             sprk-o-Stack
             sprk-o-Stack--large
-            sprk-u-TextAlign--center
+            sprk-b-Type--center
           "
         >
           <a
@@ -516,7 +517,7 @@ export const threeUpCards = () =>
             sprk-c-Card__content
             sprk-o-Stack
             sprk-o-Stack--large
-            sprk-u-TextAlign--center
+            sprk-b-Type--center
           "
         >
           <a

--- a/html/components/dropdown.js
+++ b/html/components/dropdown.js
@@ -4,12 +4,12 @@ import { isEscPressed } from '../utilities/keypress';
 
 const hideDropDown = (dropdown) => {
   dropdown.classList.remove('sprk-c-Dropdown--open');
-  dropdown.classList.add('sprk-u-Display--none');
+  dropdown.classList.add('sprk-c-Dropdown--is-hidden');
 };
 
 const showDropDown = (dropdown) => {
   dropdown.classList.add('sprk-c-Dropdown--open');
-  dropdown.classList.remove('sprk-u-Display--none');
+  dropdown.classList.remove('sprk-c-Dropdown--is-hidden');
 };
 
 const removeActiveStatus = (choices) => {

--- a/html/components/dropdown.stories.js
+++ b/html/components/dropdown.stories.js
@@ -35,7 +35,7 @@ export const defaultStory = () => {
     </a>
 
     <div
-      class="sprk-c-Dropdown sprk-u-Display--none"
+      class="sprk-c-Dropdown sprk-c-Dropdown--is-hidden"
       data-sprk-dropdown="dropdown01"
       data-id="dropdown-1"
     >
@@ -106,7 +106,7 @@ export const informational = () => {
     </a>
 
     <div
-      class="sprk-c-Dropdown sprk-u-Display--none"
+      class="sprk-c-Dropdown sprk-c-Dropdown--is-hidden"
       data-sprk-dropdown="dropdown02"
       data-id="dropdown-2"
     >

--- a/html/components/dropdown.stories.js
+++ b/html/components/dropdown.stories.js
@@ -29,7 +29,12 @@ export const defaultStory = () => {
       aria-haspopup="listbox"
       aria-label="Dropdown example description"
     >
-      <svg class="sprk-c-Icon sprk-c-Icon--l sprk-u-mls" viewBox="0 0 100 100">
+      <svg class="
+        sprk-c-Icon
+        sprk-c-Icon--l
+        sprk-c-Dropdown__trigger-icon
+      "
+      viewBox="0 0 100 100">
         <use xlink:href="#settings" />
       </svg>
     </a>
@@ -84,7 +89,12 @@ export const informational = () => {
 
   return `
     <a
-      class="sprk-c-Dropdown__trigger sprk-b-Link sprk-b-Link--plain sprk-u-mrs"
+      class="
+        sprk-c-Dropdown__trigger
+        sprk-b-Link
+        sprk-b-Link--plain
+        sprk-c-Dropdown__trigger--informational
+      "
       href="#nogo"
       data-sprk-dropdown-trigger="dropdown02"
       aria-haspopup="listbox"
@@ -98,7 +108,7 @@ export const informational = () => {
             sprk-c-Icon
             sprk-c-Icon--filled-current-color
             sprk-c-Icon--stroke-current-color
-            sprk-u-mls
+            sprk-c-Dropdown__trigger-icon
           "
           viewBox="0 0 100 100">
           <use xlink:href="#chevron-down" />

--- a/html/components/dropdown.stories.js
+++ b/html/components/dropdown.stories.js
@@ -95,9 +95,9 @@ export const informational = () => {
           >Make a selection...</span>
         <svg
           class="
-            sprk-c-Icon 
-            sprk-c-Icon--filled-current-color 
-            sprk-c-Icon--stroke-current-color 
+            sprk-c-Icon
+            sprk-c-Icon--filled-current-color
+            sprk-c-Icon--stroke-current-color
             sprk-u-mls
           "
           viewBox="0 0 100 100">
@@ -160,7 +160,7 @@ export const informational = () => {
       </ul>
 
       <div
-        class="sprk-c-Dropdown__footer sprk-u-TextAlign--center"
+        class="sprk-c-Dropdown__footer sprk-b-Type--center"
       >
         <a class="sprk-c-Button sprk-c-Button--secondary" href="#nogo">
           Go Elsewhere

--- a/html/components/footer.stories.js
+++ b/html/components/footer.stories.js
@@ -481,8 +481,7 @@ export const defaultStory = () => {
         <span
           class="
             sprk-c-Divider
-            sprk-u-mvn
-            sprk-u-mhm
+            sprk-c-Footer__divider
           "
           data-id="divider-1">
         </span>
@@ -551,7 +550,7 @@ export const defaultStory = () => {
                       sprk-c-Icon
                       sprk-c-Icon--xl
                       sprk-c-Icon--toggle
-                      sprk-u-mrs
+                      sprk-c-Toggle__trigger-icon
                     "
                     data-sprk-toggle="icon" viewBox="0 0 100 100">
                     <use xlink:href="#chevron-down-circle"></use>
@@ -559,12 +558,10 @@ export const defaultStory = () => {
                   My Award Disclaimer
                 </button>
 
-                <div data-sprk-toggle="content">
+                <div class="sprk-c-Toggle__content" data-sprk-toggle="content">
                   <p
                     class="
                       sprk-b-TypeBodyFour
-                      sprk-u-pts
-                      sprk-u-pbs
                       sprk-c-Footer__text
                     ">
                     Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/html/components/footer.stories.js
+++ b/html/components/footer.stories.js
@@ -235,8 +235,8 @@ export const defaultStory = () => {
                   sprk-o-Stack__item
                   sprk-o-Stack__item--third@m
                   sprk-o-Box
-                  sprk-u-PaddingRight--a
-                  sprk-o-Stack sprk-o-Stack--large
+                  sprk-o-Stack
+                  sprk-o-Stack--large
                 ">
                 <h3
                   class="

--- a/html/components/footer.stories.js
+++ b/html/components/footer.stories.js
@@ -46,8 +46,7 @@ export const defaultStory = () => {
               sprk-o-Stack__item--three-tenths@m
               sprk-o-Stack
               sprk-o-Stack--misc-b
-              sprk-o-Box
-              sprk-u-prh
+              sprk-c-Footer__global-links
             ">
             <h3
               class="
@@ -148,8 +147,7 @@ export const defaultStory = () => {
                 class="
                   sprk-o-Stack__item
                   sprk-o-Stack__item--third@m
-                  sprk-o-Box
-                  sprk-u-PaddingRight--a
+                  sprk-c-Footer__local-links
                   sprk-o-Stack
                   sprk-o-Stack--large
                 ">
@@ -491,8 +489,7 @@ export const defaultStory = () => {
             sprk-o-Stack__item
             sprk-o-Stack
             sprk-o-Stack--misc-b
-            sprk-o-Box
-            sprk-u-PaddingTop--b
+            sprk-c-Footer__awards
           ">
           <div
             class="
@@ -500,7 +497,8 @@ export const defaultStory = () => {
               sprk-o-Stack
               sprk-o-Stack--large
             "
-            data-id="award-1">
+            data-id="award-1"
+          >
             <h3
               class="
                 sprk-o-Stack__item
@@ -516,7 +514,7 @@ export const defaultStory = () => {
                 sprk-o-Stack
                 sprk-o-Stack--medium
                 sprk-o-Stack--split@s
-                sprk-u-mbm
+                sprk-c-Footer__awards-media
               ">
               <div class="sprk-o-Stack__item">
                 <a href="#nogo">

--- a/html/components/highlight-board.stories.js
+++ b/html/components/highlight-board.stories.js
@@ -22,7 +22,7 @@ then they should be \`<button>\` elements.
 
 export const defaultStory = () => `
     <div
-     class="sprk-c-HighlightBoard sprk-c-HighlightBoard--has-image sprk-u-mbm"
+     class="sprk-c-HighlightBoard sprk-c-HighlightBoard--has-image"
      data-id="highlightboard-1"
     >
       <img
@@ -86,7 +86,7 @@ defaultStory.story = {
 
 export const noImage = () => `
   <div
-   class="sprk-c-HighlightBoard sprk-u-mbm"
+   class="sprk-c-HighlightBoard"
    data-id="highlightboard-2"
   >
     <div class="
@@ -138,11 +138,11 @@ noImage.story = {
 
 export const stacked = () => `
   <div
-   class="
-     sprk-c-HighlightBoard
-     sprk-c-HighlightBoard--has-image
-     sprk-c-HighlightBoard--stacked
-     sprk-u-mbm"
+    class="
+      sprk-c-HighlightBoard
+      sprk-c-HighlightBoard--has-image
+      sprk-c-HighlightBoard--stacked
+    "
    data-id="highlightboard-3"
   >
     <img

--- a/html/components/masthead.js
+++ b/html/components/masthead.js
@@ -26,9 +26,9 @@ let direction = scrollYDirection();
 const toggleMenu = (scrollDirection) => {
   const masthead = document.querySelector('[data-sprk-masthead]');
   if (scrollDirection === 'down') {
-    masthead.classList.add('sprk-c-Masthead--hidden');
+    masthead.classList.add('sprk-c-Masthead--is-hidden');
   } else {
-    masthead.classList.remove('sprk-c-Masthead--hidden');
+    masthead.classList.remove('sprk-c-Masthead--is-hidden');
   }
 };
 
@@ -55,7 +55,7 @@ const toggleScrollEvent = (isMenuVisible) => {
   if (!isMenuVisible) {
     const masthead = document.querySelector('[data-sprk-masthead]');
     if (masthead) {
-      masthead.classList.remove('sprk-c-Masthead--hidden');
+      masthead.classList.remove('sprk-c-Masthead--is-hidden');
     }
   }
   if (isMenuVisible) {
@@ -83,7 +83,7 @@ const toggleMobileNav = (iconContainer, nav, masthead) => {
   iconContainer
     .querySelector('svg')
     .classList.toggle('sprk-c-Menu__icon--open');
-  nav.classList.toggle('sprk-u-Display--none');
+  nav.classList.toggle('sprk-c-Masthead__nav-collapsible--is-collapsed');
 
   toggleAriaExpanded(iconContainer);
 };
@@ -100,7 +100,7 @@ const hideMobileNavs = () => {
   document.body.classList.remove('sprk-u-Height--100');
   document.documentElement.classList.remove('sprk-u-Height--100');
   getElements('[data-sprk-mobile-nav]', (item) => {
-    item.classList.add('sprk-u-Display--none');
+    item.classList.add('sprk-c-Masthead__nav-collapsible--is-collapsed');
   });
   getElements('.sprk-c-Menu__icon--open', (item) => {
     item.classList.remove('sprk-c-Menu__icon--open');
@@ -138,7 +138,7 @@ const bindUIEvents = () => {
     // init aria-expanded
     if (!element.hasAttribute('aria-expanded')) {
       // If it doesn't have it then set it to the initial value
-      const isOpen = !nav.classList.contains('sprk-u-Display--none');
+      const isOpen = !nav.classList.contains('sprk-c-Masthead__nav-collapsible--is-collapsed');
 
       if (isOpen) {
         element.setAttribute('aria-expanded', 'true');
@@ -184,7 +184,7 @@ const bindUIEvents = () => {
 
     mainLayout.addEventListener('focusin', () => {
       const isOpen = !document
-        .querySelector('.sprk-c-Masthead__narrow-nav')
+        .querySelector('.sprk-c-Masthead__nav-collapsible')
         .classList.contains('sprk-u-HideWhenJs');
       focusTrap(isOpen, nav);
     });

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -640,7 +640,7 @@ export const extended = () => {
                 <div
                   class="
                     sprk-c-Masthead__selector-footer
-                    sprk-u-TextAlign--center
+                    sprk-b-Type--center
                   "
                 >
                   <a
@@ -792,7 +792,7 @@ export const extended = () => {
                 class="
                   sprk-c-Dropdown
                   sprk-u-Display--none
-                  sprk-u-TextAlign--left
+                  sprk-b-Type--left
                 "
                 data-sprk-dropdown="dropdown03"
               >
@@ -878,7 +878,7 @@ export const extended = () => {
                 class="
                   sprk-c-Dropdown
                   sprk-u-Display--none
-                  sprk-u-TextAlign--left
+                  sprk-b-Type--left
                 "
                 data-sprk-dropdown="dropdown04"
               >

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -357,7 +357,8 @@ export const defaultStory = () => {
                     sprk-c-Icon--xl
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                   viewBox="0 0 64 64"
                 >
@@ -385,7 +386,8 @@ export const defaultStory = () => {
                     sprk-c-Icon--xl
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                   viewBox="0 0 64 64"
                 >
@@ -611,7 +613,7 @@ export const extended = () => {
                 <ul class="sprk-c-Masthead__selector-dropdown-links">
                   <li class="sprk-c-Masthead__selector-dropdown-item">
                     <a
-                      class="sprk-c-Masthead__selector-dropdown-link sprk-u-ptm"
+                      class="sprk-c-Masthead__selector-dropdown-link"
                       href="#nogo"
                       data-sprk-dropdown-choice="Selection Choice Title 1"
                       role="option"
@@ -778,7 +780,7 @@ export const extended = () => {
                     sprk-c-Icon
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
-                    sprk-u-mls
+                    sprk-c-Dropdown__trigger-icon
                   "
                   viewBox="0 0 64 64"
                 >
@@ -864,7 +866,7 @@ export const extended = () => {
                     sprk-c-Icon
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
-                    sprk-u-mls
+                    sprk-c-Dropdown__trigger-icon
                   "
                   viewBox="0 0 64 64"
                 >
@@ -1068,7 +1070,6 @@ export const extended = () => {
                   sprk-c-Icon--filled-current-color
                   sprk-c-Icon--stroke-current-color
                   sprk-c-MastheadAccordion__icon
-                  sprk-u-mls
                 "
                 data-sprk-toggle="icon"
                 viewBox="0 0 64 64"
@@ -1238,7 +1239,8 @@ export const extended = () => {
                     sprk-c-Icon
                     sprk-c-Icon--xl
                     sprk-c-Icon--filled-current-color
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                   viewBox="0 0 64 64"
                 >
@@ -1257,7 +1259,8 @@ export const extended = () => {
                     sprk-c-Icon
                     sprk-c-Icon--xl
                     sprk-c-Icon--filled-current-color
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                   viewBox="0 0 64 64"
                 >
@@ -1286,7 +1289,8 @@ export const extended = () => {
                     sprk-c-Icon
                     sprk-c-Icon--xl
                     sprk-c-Icon--filled-current-color
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                   viewBox="0 0 64 64"
                 >

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -789,7 +789,7 @@ export const extended = () => {
               <div
                 class="
                   sprk-c-Dropdown
-                  sprk-u-Display--none
+                  sprk-c-Dropdown--is-hidden
                   sprk-b-Type--left
                 "
                 data-sprk-dropdown="dropdown03"
@@ -875,7 +875,7 @@ export const extended = () => {
               <div
                 class="
                   sprk-c-Dropdown
-                  sprk-u-Display--none
+                  sprk-c-Dropdown--is-hidden
                   sprk-b-Type--left
                 "
                 data-sprk-dropdown="dropdown04"

--- a/html/components/masthead.stories.js
+++ b/html/components/masthead.stories.js
@@ -243,7 +243,7 @@ export const defaultStory = () => {
       </div>
 
       <nav
-        class="sprk-c-Masthead__narrow-nav sprk-u-Display--none"
+        class="sprk-c-Masthead__nav-collapsible sprk-c-Masthead__nav-collapsible--is-collapsed"
         data-sprk-mobile-nav="mobileNav"
         role="navigation"
         data-id="navigation-narrow-1"
@@ -533,7 +533,7 @@ export const extended = () => {
               sprk-o-Stack--center-column sprk-o-Stack--center-row
             "
           >
-            <div class="sprk-o-Stack__item sprk-u-Position--relative">
+            <div class="sprk-o-Stack__item sprk-c-Masthead__selector-container">
               <a
                 class="
                   sprk-c-Masthead__selector
@@ -568,9 +568,9 @@ export const extended = () => {
               </a>
 
               <div
-                class="sprk-c-Masthead__selector-dropdown sprk-u-Display--none"
+                class="sprk-c-Masthead__selector-dropdown sprk-c-Dropdown--is-hidden"
                 data-sprk-dropdown="dropdown-selector-wide"
-                >
+              >
                 <div class="sprk-c-Masthead__selector-dropdown-header">
                   <a
                     class="
@@ -580,7 +580,6 @@ export const extended = () => {
                       sprk-o-Stack
                       sprk-o-Stack--split@xxs
                       sprk-o-Stack--center-column
-                      sprk-u-Width-100
                     "
                     href="#nogo"
                     aria-haspopup="true"
@@ -703,9 +702,8 @@ export const extended = () => {
               <div
                 class="
                   sprk-c-Dropdown
-                  sprk-u-Display--none
-                  sprk-u-Right--zero
-                  sprk-u-mrm
+                  sprk-c-Dropdown--is-hidden
+                  sprk-c-Masthead__dropdown
                 "
                 data-sprk-dropdown="dropdown02"
               >
@@ -922,8 +920,8 @@ export const extended = () => {
       </div>
       <nav
         class="
-          sprk-c-Masthead__narrow-nav
-          sprk-u-Display--none
+          sprk-c-Masthead__nav-collapsible
+          sprk-c-Masthead__nav-collapsible--is-collapsed
         "
         data-sprk-mobile-nav="mobileNav2"
         role="navigation"
@@ -965,7 +963,7 @@ export const extended = () => {
           </div>
 
           <div
-            class="sprk-c-Masthead__selector-dropdown sprk-u-Display--none"
+            class="sprk-c-Masthead__selector-dropdown sprk-c-Dropdown--is-hidden"
             data-sprk-dropdown="dropdown-selector"
           >
             <div class="sprk-c-Masthead__selector-dropdown-header">
@@ -977,7 +975,6 @@ export const extended = () => {
                   sprk-o-Stack
                   sprk-o-Stack--split@xxs
                   sprk-o-Stack--center-column
-                  sprk-u-Width-100
                 "
                 href="#nogo"
                 aria-haspopup="true"

--- a/html/components/modals.js
+++ b/html/components/modals.js
@@ -27,7 +27,7 @@ const isWaitModal = (modal) =>
 
 // Hide the modal, mask, remove aria-hidden on main and send focus back
 const hideModal = (modal, mask, main) => {
-  const isHidden = modal.classList.contains('sprk-u-Display--none');
+  const isHidden = modal.classList.contains('sprk-c-Modal--is-hidden');
   // Grab value of modal data-attr to get the trigger's corresponding modal name
   const modalName = modal.getAttribute('data-sprk-modal');
   // Grab modal trigger so it can be focused once modal is closed
@@ -36,8 +36,8 @@ const hideModal = (modal, mask, main) => {
   );
   // If modal is hidden already or there are no mask and main els then exit
   if (isHidden || mask === null || main === null) return;
-  modal.classList.add('sprk-u-Display--none');
-  mask.classList.add('sprk-u-Display--none');
+  modal.classList.add('sprk-c-Modal--is-hidden');
+  mask.classList.add('sprk-c-ModalMask--is-hidden');
   // Remove the hidden aria attr from main content
   main.removeAttribute('aria-hidden');
   // Remove overflow hidden to allow scrolling again
@@ -53,7 +53,7 @@ const currentOpenModal = (modalsList) => {
   let openModalEl;
   // Loop through modals to find open modal
   modalsList.forEach((modalEl) => {
-    const isHidden = modalEl.classList.contains('sprk-u-Display--none');
+    const isHidden = modalEl.classList.contains('sprk-c-Modal--is-hidden');
     if (!isHidden) openModalEl = modalEl;
   });
   return openModalEl;
@@ -109,15 +109,15 @@ const handleModalKeyEvents = (modalsList, mask, main, e) => {
 
 // Show the modal, mask and set aria-hidden=true on body
 const showModal = (modal, mask, main) => {
-  const isHidden = modal.classList.contains('sprk-u-Display--none');
+  const isHidden = modal.classList.contains('sprk-c-Modal--is-hidden');
   const focusableEls = getFocusableEls(modal);
 
   // If the modal is shown already or there are no mask and main els then exit
   if (!isHidden || mask === null || main === null) return;
 
   // Show modal and mask
-  modal.classList.remove('sprk-u-Display--none');
-  mask.classList.remove('sprk-u-Display--none');
+  modal.classList.remove('sprk-c-Modal--is-hidden');
+  mask.classList.remove('sprk-c-ModalMask--is-hidden');
 
   // Alert assistive devices that main content is hidden
   main.setAttribute('aria-hidden', 'true');

--- a/html/components/stepper.stories.js
+++ b/html/components/stepper.stories.js
@@ -151,7 +151,7 @@ export const withStepDescriptions = () => {
     >
       <div
         class="
-          sprk-c-Stepper__step-content 
+          sprk-c-Stepper__step-content
           sprk-c-Stepper__step-content--has-description
         "
       >
@@ -188,7 +188,7 @@ export const withStepDescriptions = () => {
     >
       <div
         class="
-          sprk-c-Stepper__step-content 
+          sprk-c-Stepper__step-content
           sprk-c-Stepper__step-content--has-description
         "
       >
@@ -224,7 +224,7 @@ export const withStepDescriptions = () => {
     >
       <div
         class="
-          sprk-c-Stepper__step-content 
+          sprk-c-Stepper__step-content
           sprk-c-Stepper__step-content--has-description
         "
       >
@@ -260,7 +260,7 @@ export const withStepDescriptions = () => {
     >
       <div
         class="
-          sprk-c-Stepper__step-content 
+          sprk-c-Stepper__step-content
           sprk-c-Stepper__step-content--has-description
         "
       >
@@ -305,7 +305,7 @@ export const withDarkBackground = () => {
   }, []);
 
   return `
-  <div class="sprk-u-BackgroundColor--purple-dark sprk-o-Box sprk-o-Box--large">
+  <div class="sprk-c-Stepper__container-dark sprk-o-Box sprk-o-Box--large">
     <ol
       class="sprk-c-Stepper sprk-c-Stepper--has-dark-bg "
       data-sprk-stepper="container"
@@ -319,9 +319,9 @@ export const withDarkBackground = () => {
         class="sprk-c-Stepper__step sprk-c-Stepper__step--selected"
         data-sprk-stepper="step"
       >
-        <div 
+        <div
           class="
-            sprk-c-Stepper__step-content 
+            sprk-c-Stepper__step-content
             sprk-c-Stepper__step-content--has-description
           "
         >
@@ -331,8 +331,8 @@ export const withDarkBackground = () => {
             id="step-background-1"
           >
             <span class="sprk-c-Stepper__step-icon"></span>
-            <h3 
-              class="sprk-c-Stepper__step-heading" 
+            <h3
+              class="sprk-c-Stepper__step-heading"
               data-sprk-stepper="heading"
             >
               Step One
@@ -358,9 +358,9 @@ export const withDarkBackground = () => {
         class="sprk-c-Stepper__step"
         data-sprk-stepper="step"
       >
-        <div 
+        <div
           class="
-            sprk-c-Stepper__step-content 
+            sprk-c-Stepper__step-content
             sprk-c-Stepper__step-content--has-description
           "
         >
@@ -370,8 +370,8 @@ export const withDarkBackground = () => {
             id="step-background-2"
           >
             <span class="sprk-c-Stepper__step-icon"></span>
-            <h3 
-              class="sprk-c-Stepper__step-heading" 
+            <h3
+              class="sprk-c-Stepper__step-heading"
               data-sprk-stepper="heading"
             >
               Step Two
@@ -397,9 +397,9 @@ export const withDarkBackground = () => {
         class="sprk-c-Stepper__step"
         data-sprk-stepper="step"
       >
-        <div 
+        <div
           class="
-            sprk-c-Stepper__step-content 
+            sprk-c-Stepper__step-content
             sprk-c-Stepper__step-content--has-description
           "
         >
@@ -409,8 +409,8 @@ export const withDarkBackground = () => {
             id="step-background-3"
           >
             <span class="sprk-c-Stepper__step-icon"></span>
-            <h3 
-              class="sprk-c-Stepper__step-heading" 
+            <h3
+              class="sprk-c-Stepper__step-heading"
               data-sprk-stepper="heading"
             >
               Step Three
@@ -436,9 +436,9 @@ export const withDarkBackground = () => {
         class="sprk-c-Stepper__step"
         data-sprk-stepper="step"
       >
-        <div 
+        <div
           class="
-            sprk-c-Stepper__step-content 
+            sprk-c-Stepper__step-content
             sprk-c-Stepper__step-content--has-description
           "
         >
@@ -448,8 +448,8 @@ export const withDarkBackground = () => {
             id="step-background-4"
           >
             <span class="sprk-c-Stepper__step-icon"></span>
-            <h3 
-              class="sprk-c-Stepper__step-heading" 
+            <h3
+              class="sprk-c-Stepper__step-heading"
               data-sprk-stepper="heading"
             >
               Step Four
@@ -513,11 +513,11 @@ export const withCarousel = () => {
 
   return `
   <div class="sprk-u-BackgroundColor--purple-dark sprk-o-Box sprk-o-Box--large">
-    <div 
+    <div
       class="
-        sprk-o-CenteredColumn 
-        sprk-o-Stack sprk-o-Stack--medium 
-        sprk-o-Stack--center-column 
+        sprk-o-CenteredColumn
+        sprk-o-Stack sprk-o-Stack--medium
+        sprk-o-Stack--center-column
         sprk-o-Stack--split-reverse@xl
       "
     >
@@ -526,12 +526,12 @@ export const withCarousel = () => {
           class="sprk-c-Carousel sprk-c-Carousel--has-dark-bg"
           data-sprk-carousel="stepper-carousel-01"
         >
-          <div 
+          <div
             class="
-              sprk-c-Carousel__controls 
-              sprk-o-Stack 
-              sprk-o-Stack--split@xxs 
-              sprk-o-Stack--center-row 
+              sprk-c-Carousel__controls
+              sprk-o-Stack
+              sprk-o-Stack--split@xxs
+              sprk-o-Stack--center-row
               sprk-o-Stack--center-column
             "
           >
@@ -539,8 +539,8 @@ export const withCarousel = () => {
               <span class="sprk-u-ScreenReaderText">Previous Slide</span>
               <svg
                 class="
-                  sprk-c-Icon 
-                  sprk-c-Icon--filled-current-color 
+                  sprk-c-Icon
+                  sprk-c-Icon--filled-current-color
                   sprk-c-Icon--xl
                 "
                 viewBox="0 0 100 100"
@@ -574,8 +574,8 @@ export const withCarousel = () => {
               <span class="sprk-u-ScreenReaderText">Next Slide</span>
               <svg
                 class="
-                  sprk-c-Icon 
-                  sprk-c-Icon--filled-current-color 
+                  sprk-c-Icon
+                  sprk-c-Icon--filled-current-color
                   sprk-c-Icon--xl
                 "
                 viewBox="0 0 100 100"
@@ -591,8 +591,8 @@ export const withCarousel = () => {
       <div class="sprk-o-Stack__item sprk-o-Stack__item--flex@xl">
         <ol
           class="
-            sprk-c-Stepper 
-            sprk-c-Stepper--has-dark-bg 
+            sprk-c-Stepper
+            sprk-c-Stepper--has-dark-bg
             sprk-c-Stepper--has-carousel
           "
           data-sprk-stepper="container"
@@ -607,24 +607,24 @@ export const withCarousel = () => {
             class="sprk-c-Stepper__step sprk-c-Stepper__step--selected"
             data-sprk-stepper="step"
           >
-            <div 
+            <div
               class="
-                sprk-c-Stepper__step-content 
+                sprk-c-Stepper__step-content
                 sprk-c-Stepper__step-content--has-description
               "
             >
               <span
                 class="
-                  sprk-c-Stepper__step-header 
-                  sprk-b-Link 
+                  sprk-c-Stepper__step-header
+                  sprk-b-Link
                   sprk-b-Link--plain
                 "
                 aria-controls="sc-target-1"
                 id="sc-step-1"
               >
                 <span class="sprk-c-Stepper__step-icon"></span>
-                <h3 
-                  class="sprk-c-Stepper__step-heading" 
+                <h3
+                  class="sprk-c-Stepper__step-heading"
                   data-sprk-stepper="heading"
                 >
                   Step One
@@ -639,7 +639,7 @@ export const withCarousel = () => {
                 role="tabpanel"
               >
                 <p class="sprk-b-TypeBodyTwo">
-                  Step 1 Lorem ipsum dolor sit amet 
+                  Step 1 Lorem ipsum dolor sit amet
                   consectetur adipisicing elit.
                 </p>
               </div>
@@ -651,24 +651,24 @@ export const withCarousel = () => {
             class="sprk-c-Stepper__step"
             data-sprk-stepper="step"
           >
-            <div 
+            <div
               class="
-                sprk-c-Stepper__step-content 
+                sprk-c-Stepper__step-content
                 sprk-c-Stepper__step-content--has-description
               "
             >
               <span
                 class="
-                  sprk-c-Stepper__step-header 
-                  sprk-b-Link 
+                  sprk-c-Stepper__step-header
+                  sprk-b-Link
                   sprk-b-Link--plain
                 "
                 aria-controls="sc-target-2"
                 id="sc-step-2"
               >
                 <span class="sprk-c-Stepper__step-icon"></span>
-                <h3 
-                  class="sprk-c-Stepper__step-heading" 
+                <h3
+                  class="sprk-c-Stepper__step-heading"
                   data-sprk-stepper="heading"
                 >
                   Step Two
@@ -683,7 +683,7 @@ export const withCarousel = () => {
                 role="tabpanel"
               >
                 <p class="sprk-b-TypeBodyTwo">
-                  Step 2 Lorem ipsum dolor sit amet 
+                  Step 2 Lorem ipsum dolor sit amet
                   consectetur adipisicing elit.
                 </p>
               </div>
@@ -695,24 +695,24 @@ export const withCarousel = () => {
             class="sprk-c-Stepper__step"
             data-sprk-stepper="step"
           >
-            <div 
+            <div
               class="
-                sprk-c-Stepper__step-content 
+                sprk-c-Stepper__step-content
                 sprk-c-Stepper__step-content--has-description
               "
             >
               <span
                 class="
-                  sprk-c-Stepper__step-header 
-                  sprk-b-Link 
+                  sprk-c-Stepper__step-header
+                  sprk-b-Link
                   sprk-b-Link--plain
                 "
                 aria-controls="sc-target-3"
                 id="sc-step-3"
               >
                 <span class="sprk-c-Stepper__step-icon"></span>
-                <h3 
-                  class="sprk-c-Stepper__step-heading" 
+                <h3
+                  class="sprk-c-Stepper__step-heading"
                   data-sprk-stepper="heading"
                 >
                   Step Three
@@ -727,7 +727,7 @@ export const withCarousel = () => {
                 role="tabpanel"
               >
                 <p class="sprk-b-TypeBodyTwo">
-                  Step 3 Lorem ipsum dolor sit amet 
+                  Step 3 Lorem ipsum dolor sit amet
                   consectetur adipisicing elit.
                 </p>
               </div>
@@ -739,23 +739,23 @@ export const withCarousel = () => {
             class="sprk-c-Stepper__step"
             data-sprk-stepper="step"
           >
-            <div 
+            <div
               class="
-                sprk-c-Stepper__step-content 
+                sprk-c-Stepper__step-content
                 sprk-c-Stepper__step-content--has-description
               "
             >
               <span
                 class="
-                  sprk-c-Stepper__step-header 
+                  sprk-c-Stepper__step-header
                   sprk-b-Link sprk-b-Link--plain
                 "
                 aria-controls="sc-target-4"
                 id="sc-step-4"
               >
                 <span class="sprk-c-Stepper__step-icon"></span>
-                <h3 
-                  class="sprk-c-Stepper__step-heading" 
+                <h3
+                  class="sprk-c-Stepper__step-heading"
                   data-sprk-stepper="heading"
                 >
                   Step Four
@@ -770,7 +770,7 @@ export const withCarousel = () => {
                 role="tabpanel"
               >
                 <p class="sprk-b-TypeBodyTwo">
-                  Step 4 Lorem ipsum dolor sit amet 
+                  Step 4 Lorem ipsum dolor sit amet
                   consectetur adipisicing elit.
                 </p>
               </div>

--- a/html/components/toggle.stories.js
+++ b/html/components/toggle.stories.js
@@ -37,7 +37,7 @@ export const defaultStory = () => {
             sprk-c-Icon
             sprk-c-Icon--xl
             sprk-c-Icon--toggle
-            sprk-u-mrs
+            sprk-c-Toggle__trigger-icon
           "
           data-sprk-toggle="icon"
           viewBox="0 0 64 64"
@@ -48,8 +48,8 @@ export const defaultStory = () => {
         My Disclaimer
       </button>
 
-      <div data-sprk-toggle="content">
-        <p class="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
+      <div class="sprk-c-Toggle__content" data-sprk-toggle="content">
+        <p class="sprk-b-TypeBodyFour">
           This is an example of disclaimer content.
           The aria-expanded="true" attribute
           will be viewable in the DOM on

--- a/html/components/toggle.stories.js
+++ b/html/components/toggle.stories.js
@@ -26,9 +26,9 @@ export const defaultStory = () => {
     >
       <button
         class="
-          sprk-c-Toggle__trigger 
-          sprk-b-TypeBodyThree 
-          sprk-u-TextCrop--none
+          sprk-c-Toggle__trigger
+          sprk-b-TypeBodyThree
+          sprk-b-Type--crop-none
         "
         data-sprk-toggle="trigger"
       >

--- a/html/objects/stack.stories.js
+++ b/html/objects/stack.stories.js
@@ -328,7 +328,7 @@ export const stackSplitLayoutMixed = () =>
               sprk-o-Stack
               sprk-o-Stack--center-all
             ">
-            <p class="sprk-o-Stack__item prk-b-TypeBodyOne">
+            <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
               Nested Item (flex)
             </p>
           </div>

--- a/html/objects/stack.stories.js
+++ b/html/objects/stack.stories.js
@@ -178,119 +178,130 @@ stackSplitLayoutThreeTenths.story = {
 export const stackSplitLayoutMixed = () =>
   `
     <div class="sprk-o-Stack sprk-o-Stack--split@xs">
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--fourth@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--fourth@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           fourth
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--half@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--half@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           half
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--fourth@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--fourth@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           fourth
         </p>
       </div>
     </div>
 
     <div class="sprk-o-Stack sprk-o-Stack--split@xs">
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--sixth@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--sixth@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           sixth
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--sixth@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--sixth@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           sixth
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--sixth@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--sixth@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           sixth
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--flex@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--flex@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           flex
         </p>
       </div>
     </div>
 
     <div class="sprk-o-Stack sprk-o-Stack--split@xs">
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--two-fifths@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--two-fifths@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           two-fifths
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--fifth@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--fifth@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           fifth
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--fifth@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--fifth@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           fifth
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--fifth@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--fifth@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           fifth
         </p>
       </div>
@@ -299,58 +310,63 @@ export const stackSplitLayoutMixed = () =>
     <div class="sprk-o-Stack sprk-o-Stack--split@xs">
       <div class="sprk-o-Stack__item sprk-o-Stack__item--half@xs">
         <div class="sprk-o-Stack sprk-o-Stack--split@xs">
-          <div 
+          <div
             class="
-              sprk-o-Stack__item 
-              sprk-o-Stack__item--flex@xs 
-              sprk-u-AbsoluteCenter
+              sprk-o-Stack__item
+              sprk-o-Stack__item--flex@xs
+              sprk-o-Stack
+              sprk-o-Stack--center-all
             ">
-            <p class="sprk-b-TypeBodyOne">
+            <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
               Nested Item (flex)
             </p>
           </div>
-          <div 
+          <div
             class="
-              sprk-o-Stack__item 
-              sprk-o-Stack__item--flex@xs 
-              sprk-u-AbsoluteCenter
+              sprk-o-Stack__item
+              sprk-o-Stack__item--flex@xs
+              sprk-o-Stack
+              sprk-o-Stack--center-all
             ">
-            <p class="sprk-b-TypeBodyOne">
+            <p class="sprk-o-Stack__item prk-b-TypeBodyOne">
               Nested Item (flex)
             </p>
           </div>
         </div>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--half@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--half@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           half
         </p>
       </div>
     </div>
 
     <div class="sprk-o-Stack sprk-o-Stack--split@xs">
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--two-fifths@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--two-fifths@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           two-fifths
         </p>
       </div>
-      <div 
+      <div
         class="
-          sprk-o-Stack__item 
-          sprk-o-Stack__item--three-fifths@xs 
-          sprk-u-AbsoluteCenter
+          sprk-o-Stack__item
+          sprk-o-Stack__item--three-fifths@xs
+          sprk-o-Stack
+          sprk-o-Stack--center-all
         ">
-        <p class="sprk-b-TypeBodyOne">
+        <p class="sprk-o-Stack__item sprk-b-TypeBodyOne">
           three-fifths
         </p>
       </div>

--- a/html/tests/alerts.tests.js
+++ b/html/tests/alerts.tests.js
@@ -12,6 +12,7 @@ describe('Alert tests', () => {
     containerNoDismiss = document.createElement('div');
     containerNoDismiss.setAttribute('data-sprk-alert', 'container');
     container.setAttribute('data-sprk-alert', 'container');
+    container.classList.add('sprk-c-Alert');
     dismissElement = document.createElement('button');
     dismissElement.setAttribute('data-sprk-alert', 'dismiss');
     container.append(dismissElement);
@@ -26,7 +27,7 @@ describe('Alert tests', () => {
 
   it('should hide alert', () => {
     dismissAlert(container);
-    expect(container.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(container.classList.toString()).toBe('sprk-c-Alert sprk-c-Alert--is-hidden');
   });
 
   it('should call getElements once with the correct selector', () => {
@@ -45,13 +46,13 @@ describe('Alert tests', () => {
     bindUIEvents(container);
     event = new window.Event('click');
     dismissElement.dispatchEvent(event);
-    expect(container.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(container.classList.toString()).toBe('sprk-c-Alert sprk-c-Alert--is-hidden');
   });
 
   it('should not hide alert on click if no dismiss button found', () => {
     bindUIEvents(containerNoDismiss);
     event = new window.Event('click');
     dismissElement.dispatchEvent(event);
-    expect(container.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(container.classList.contains('sprk-c-Alert--is-hidden')).toBe(false);
   });
 });

--- a/html/tests/autocomplete.tests.js
+++ b/html/tests/autocomplete.tests.js
@@ -83,54 +83,54 @@ describe('Autocomplete tests', () => {
   });
 
   it('should set aria-expanded="false" when the list is closed', () => {
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(false);
 
     const escKeyEvent = new window.Event('keydown');
     escKeyEvent.keyCode = 27;
     document.dispatchEvent(escKeyEvent);
 
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(true);
     expect(inputEl.parentNode.getAttribute('aria-expanded')).toEqual('false');
   });
 
   it('should close the search results if escape is pressed', () => {
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(false);
 
     const escKeyEvent = new window.Event('keydown');
     escKeyEvent.keyCode = 27;
     document.dispatchEvent(escKeyEvent);
 
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(true);
   });
 
   it('should close the search results if document is clicked', () => {
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(false);
 
     document.dispatchEvent(new window.Event('click'));
 
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(true);
   });
 
   it('should close the search results if an outside element is clicked', () => {
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(false);
 
     outsideElement.click();
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(true);
   });
 
   it(`it should not close the search results if search
   results are clicked`, () => {
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(false);
 
     listEl.dispatchEvent(new window.Event('click'));
 
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(false);
   });
 
   it('it should not close the search results if input is clicked', () => {
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(false);
     inputEl.click();
-    expect(listEl.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(listEl.classList.contains('sprk-c-Autocomplete__results--is-hidden')).toBe(false);
   });
 
   it('should move visual focus with down arrow', () => {
@@ -171,7 +171,7 @@ describe('Autocomplete tests', () => {
 
   it(`should not move visual focus with down arrow if the
   list is hidden`, () => {
-    listEl.classList.add('sprk-u-Display--none');
+    listEl.classList.add('sprk-c-Autocomplete__results--is-hidden');
 
     expect(
       listItem1.classList.contains('sprk-c-Autocomplete__result--active'),
@@ -223,7 +223,7 @@ describe('Autocomplete tests', () => {
   });
 
   it('should not move visual focus with up arrow if the list is hidden', () => {
-    listEl.classList.add('sprk-u-Display--none');
+    listEl.classList.add('sprk-c-Autocomplete__results--is-hidden');
 
     expect(
       listItem3.classList.contains('sprk-c-Autocomplete__result--active'),

--- a/html/tests/dropdown.tests.js
+++ b/html/tests/dropdown.tests.js
@@ -28,7 +28,7 @@ describe('Dropdown tests', () => {
     trigger.appendChild(triggerText);
     dropdown = document.createElement('div');
     dropdown.setAttribute('data-sprk-dropdown', '01');
-    dropdown.classList.add('sprk-u-Display--none');
+    dropdown.classList.add('sprk-c-Dropdown--is-hidden');
 
     choice1 = document.createElement('a');
     choice1.setAttribute('data-sprk-dropdown-choice', 'choice1');
@@ -58,7 +58,7 @@ describe('Dropdown tests', () => {
 
     dropdown2 = document.createElement('div');
     dropdown2.setAttribute('data-sprk-dropdown', '02');
-    dropdown2.classList.add('sprk-u-Display--none');
+    dropdown2.classList.add('sprk-c-Dropdown--is-hidden');
 
     choice2 = document.createElement('a');
     choice2.setAttribute('data-sprk-dropdown-choice', 'choice2');
@@ -73,27 +73,35 @@ describe('Dropdown tests', () => {
     document.body.innerHTML = '';
   });
 
-  it(`should remove the hide class and add open 
+  it(`should remove the hide class and add open
       class when show is called`, () => {
-    dropdown.classList.add('sprk-u-Display--none');
+    dropdown.classList.add('sprk-c-Dropdown--is-hidden');
     showDropDown(dropdown);
-    expect(dropdown.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(dropdown.classList.contains('sprk-c-Dropdown--is-hidden')).toBe(
+      false,
+    );
     expect(dropdown.classList.contains('sprk-c-Dropdown--open')).toBe(true);
   });
 
-  it(`should add the hide class and remove the 
+  it(`should add the hide class and remove the
       open class when hide is called`, () => {
     hideDropDown(dropdown);
-    expect(dropdown.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(dropdown.classList.contains('sprk-c-Dropdown--is-hidden')).toBe(
+      true,
+    );
     expect(dropdown.classList.contains('sprk-c-Dropdown--open')).toBe(false);
   });
 
   it('toggle should toggle the hide class and open class', () => {
     toggleDropDown(dropdown);
-    expect(dropdown.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(dropdown.classList.contains('sprk-c-Dropdown--is-hidden')).toBe(
+      false,
+    );
     expect(dropdown.classList.contains('sprk-c-Dropdown--open')).toBe(true);
     toggleDropDown(dropdown);
-    expect(dropdown.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(dropdown.classList.contains('sprk-c-Dropdown--is-hidden')).toBe(
+      true,
+    );
     expect(dropdown.classList.contains('sprk-c-Dropdown--open')).toBe(false);
   });
 
@@ -118,7 +126,7 @@ describe('Dropdown tests', () => {
     expect(triggerText.textContent).toBe('choice1');
   });
 
-  it(`should not update the trigger text if the trigger 
+  it(`should not update the trigger text if the trigger
       does not have a text-container and a choice is clicked`, () => {
     dropdowns();
     trigger2.click();
@@ -126,7 +134,7 @@ describe('Dropdown tests', () => {
     expect(triggerText2.textContent).toBe('trigger');
   });
 
-  it(`should not change the trigger text if something 
+  it(`should not change the trigger text if something
       is clicked outside the dropdown`, () => {
     dropdowns();
     trigger.click();
@@ -143,7 +151,7 @@ describe('Dropdown tests', () => {
     expect(dropdown.classList.contains('sprk-c-Dropdown--open')).toBe(false);
   });
 
-  it(`should not close the dropdown if a key 
+  it(`should not close the dropdown if a key
       that is not esc is pressed`, () => {
     dropdowns();
     trigger.click();
@@ -153,7 +161,7 @@ describe('Dropdown tests', () => {
     expect(dropdown.classList.contains('sprk-c-Dropdown--open')).toBe(true);
   });
 
-  it(`should close the dropdown if an element 
+  it(`should close the dropdown if an element
       outside the dropdown is focused`, () => {
     dropdowns();
     trigger.click();
@@ -161,7 +169,7 @@ describe('Dropdown tests', () => {
     expect(dropdown.classList.contains('sprk-c-Dropdown--open')).toBe(false);
   });
 
-  it(`should not close the dropdown if an element 
+  it(`should not close the dropdown if an element
       inside the dropdown is focused`, () => {
     dropdowns();
     trigger.click();

--- a/html/tests/masthead.tests.js
+++ b/html/tests/masthead.tests.js
@@ -33,8 +33,8 @@ describe('masthead init', () => {
 
     // Create narrow nav
     nav = document.createElement('nav');
-    nav.classList.add('sprk-u-Display--none');
-    nav.classList.add('sprk-c-Masthead__narrow-nav');
+    nav.classList.add('sprk-c-Masthead__nav-collapsible--is-collapsed');
+    nav.classList.add('sprk-c-Masthead__nav-collapsible');
     nav.setAttribute('data-sprk-mobile-nav', 'mobileNav');
 
     // Add nav to masthead
@@ -84,7 +84,7 @@ describe('masthead init', () => {
 
   it('should init aria-expanded as open correctly', () => {
     expect(iconContainer.getAttribute('aria-expanded')).toBe(null);
-    nav.classList.remove('sprk-u-Display--none');
+    nav.classList.remove('sprk-c-Masthead__nav-collapsible--is-collapsed');
 
     masthead();
 
@@ -232,7 +232,7 @@ describe('masthead UI Events tests', () => {
     navItem = document.createElement('button');
     // Add navItem to nav
     nav.appendChild(navItem);
-    nav.classList.add('sprk-u-Display--none');
+    nav.classList.add('sprk-c-Masthead__nav-collapsible--is-collapsed');
     nav.setAttribute('data-sprk-mobile-nav', 'mobileNav');
 
     // Add nav to masthead
@@ -289,7 +289,7 @@ describe('masthead UI Events tests', () => {
     event = new window.Event('click');
     iconContainer.dispatchEvent(event);
     expect(mastheadDiv.classList.contains('sprk-c-Masthead--open')).toBe(true);
-    expect(nav.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(nav.classList.contains('sprk-c-Masthead__nav-collapsible--is-collapsed')).toBe(false);
   });
 
   it(`should close the dropdown box when selector
@@ -357,7 +357,7 @@ describe('masthead UI Events tests', () => {
     event = new window.Event('scroll');
     window.dispatchEvent(event);
     toggleMenu('down');
-    expect(mastheadDiv.classList.contains('sprk-c-Masthead--hidden')).toBe(
+    expect(mastheadDiv.classList.contains('sprk-c-Masthead--is-hidden')).toBe(
       true,
     );
   });
@@ -366,7 +366,7 @@ describe('masthead UI Events tests', () => {
     event = new window.Event('scroll');
     window.dispatchEvent(event);
     toggleMenu('up');
-    expect(mastheadDiv.classList.contains('sprk-c-Masthead--hidden')).toBe(
+    expect(mastheadDiv.classList.contains('sprk-c-Masthead--is-hidden')).toBe(
       false,
     );
   });
@@ -430,16 +430,16 @@ describe('masthead UI Events tests', () => {
   });
 
   it('should close the nav when clicked and the nav is already open', () => {
-    nav.classList.remove('sprk-u-Display--none');
+    nav.classList.remove('sprk-c-Masthead__nav-collapsible--is-collapsed');
     event = new window.Event('click');
     iconContainer.dispatchEvent(event);
-    expect(nav.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(nav.classList.contains('sprk-c-Masthead__nav-collapsible--is-collapsed')).toBe(true);
   });
 
   it(`should do nothing when focusin is triggered on a narrow
       viewport when the nav is closed`, () => {
     iconContainer.focus();
-    nav.classList.add('sprk-c-Masthead__narrow-nav');
+    nav.classList.add('sprk-c-Masthead__nav-collapsible');
     nav.classList.add('sprk-u-HideWhenJs');
     event = new window.Event('focusin');
     main.dispatchEvent(event);
@@ -449,17 +449,17 @@ describe('masthead UI Events tests', () => {
   it(`should focus on the first nav item when focusin is triggered
       on a narrow viewport when the nav is open`, () => {
     iconContainer.focus();
-    nav.classList.add('sprk-c-Masthead__narrow-nav');
+    nav.classList.add('sprk-c-Masthead__nav-collapsible');
     event = new window.Event('focusin');
     main.dispatchEvent(event);
     expect(document.activeElement).toEqual(navItem);
   });
 
   it('should hide the navs if orientationchange is fired', () => {
-    nav.classList.remove('sprk-u-Display--none');
+    nav.classList.remove('sprk-c-Masthead__nav-collapsible--is-collapsed');
     event = new window.Event('orientationchange');
     window.dispatchEvent(event);
-    expect(nav.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(nav.classList.contains('sprk-c-Masthead__nav-collapsible--is-collapsed')).toBe(true);
   });
 });
 
@@ -476,7 +476,7 @@ describe('toggleMobileNav tests', () => {
     main = document.createElement('div');
     nav = document.createElement('div');
     main.setAttribute('data-sprk-masthead', null);
-    nav.classList.add('sprk-u-Display--none');
+    nav.classList.add('sprk-c-Masthead__nav-collapsible--is-collapsed');
     nav.setAttribute('data-sprk-mobile-nav', 'mobileNav');
     iconContainer = document.createElement('div');
     icon = document.createElement('svg');
@@ -495,10 +495,10 @@ describe('toggleMobileNav tests', () => {
     document.body.classList.remove('sprk-u-Height--100');
   });
 
-  it(`should toggle the class sprk-u-Display--none on the
+  it(`should toggle the class sprk-c-Masthead__nav-collapsible--is-collapsed on the
       nav element and the open class on the icon`, () => {
     toggleMobileNav(iconContainer, nav, mastheadDiv);
-    expect(nav.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(nav.classList.contains('sprk-c-Masthead__nav-collapsible--is-collapsed')).toBe(false);
     expect(icon.classList.contains('sprk-c-Menu__icon--open')).toBe(true);
     expect(
       document
@@ -511,7 +511,7 @@ describe('toggleMobileNav tests', () => {
         .getElementsByTagName('body')[0]
         .classList.contains('sprk-u-Overflow--hidden'),
     ).toBe(false);
-    expect(nav.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(nav.classList.contains('sprk-c-Masthead__nav-collapsible--is-collapsed')).toBe(true);
     expect(icon.classList.contains('sprk-c-Menu__icon--open')).toBe(false);
   });
 
@@ -590,7 +590,7 @@ describe('hideMobileNavs tests', () => {
         .getElementsByTagName('body')[0]
         .classList.contains('sprk-u-Overflow--hidden'),
     ).toBe(false);
-    expect(nav.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(nav.classList.contains('sprk-c-Masthead__nav-collapsible--is-collapsed')).toBe(true);
     expect(icon.classList.contains('sprk-c-Menu__icon--open')).toBe(false);
   });
 });
@@ -652,7 +652,7 @@ describe('masthead no selector test', () => {
     navItem = document.createElement('button');
     // Add navItem to nav
     nav.appendChild(navItem);
-    nav.classList.add('sprk-u-Display--none');
+    nav.classList.add('sprk-c-Masthead__nav-collapsible--is-collapsed');
     nav.setAttribute('data-sprk-mobile-nav', 'mobileNav');
 
     // Add nav to masthead

--- a/html/tests/modals.tests.js
+++ b/html/tests/modals.tests.js
@@ -52,7 +52,7 @@ describe('modal UI tests', () => {
   let main;
   let link;
   let outsideOfMainDiv;
-  const HIDE_CLASS = 'sprk-u-Display--none';
+  const HIDE_CLASS = 'sprk-c-Modal--is-hidden';
   let event;
 
   beforeEach(() => {
@@ -154,12 +154,12 @@ describe('modal UI tests', () => {
     );
     event = new window.Event('click');
     triggerDefaultModal.dispatchEvent(event);
-    expect(defaultModal.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(defaultModal.classList.contains('sprk-c-Modal--is-hidden')).toBe(false);
     cancelDefault.dispatchEvent(event);
-    expect(defaultModal.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(defaultModal.classList.contains('sprk-c-Modal--is-hidden')).toBe(true);
   });
 
-  it(`should hide the correct modal when cancel is 
+  it(`should hide the correct modal when cancel is
       triggered if preventDefault is not set`, () => {
     triggerDefaultModal.removeAttribute(
       'data-sprk-modal-trigger-prevent-default',
@@ -173,9 +173,9 @@ describe('modal UI tests', () => {
     );
     event = new window.Event('click');
     triggerDefaultModal.dispatchEvent(event);
-    expect(defaultModal.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(defaultModal.classList.contains('sprk-c-Modal--is-hidden')).toBe(false);
     cancelDefault.dispatchEvent(event);
-    expect(defaultModal.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(defaultModal.classList.contains('sprk-c-Modal--is-hidden')).toBe(true);
   });
 
   it('should bind a click event to each cancel', () => {
@@ -189,7 +189,7 @@ describe('modal UI tests', () => {
     expect(cancelDefault.addEventListener.getCall(0).args[0]).toBe('click');
   });
 
-  it(`should bind a click event to the mask, 
+  it(`should bind a click event to the mask,
       if there is a modal and a mask`, () => {
     bindUIEvents(
       modalMask,
@@ -220,12 +220,12 @@ describe('modal UI tests', () => {
       [defaultModal, waitModal],
       [cancelDefault],
     );
-    expect(defaultModal.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(defaultModal.classList.contains('sprk-c-Modal--is-hidden')).toBe(true);
     showModal(defaultModal, modalMask, main);
-    expect(defaultModal.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(defaultModal.classList.contains('sprk-c-Modal--is-hidden')).toBe(false);
     event = new window.Event('click');
     modalMask.dispatchEvent(event);
-    expect(defaultModal.classList.contains('sprk-u-Display--none')).toBe(true);
+    expect(defaultModal.classList.contains('sprk-c-Modal--is-hidden')).toBe(true);
   });
 });
 
@@ -256,7 +256,8 @@ describe('Modal tests', () => {
   let link;
   let link2;
   let outsideOfMainDiv;
-  const HIDE_CLASS = 'sprk-u-Display--none';
+  const HIDE_CLASS = 'sprk-c-Modal--is-hidden';
+  const HIDE_CLASS_MASK = 'sprk-c-ModalMask--is-hidden';
   let event;
 
   beforeEach(() => {
@@ -268,7 +269,7 @@ describe('Modal tests', () => {
     modalMask = document.createElement('div');
     modalMask.setAttribute('data-sprk-modal-mask', 'true');
     modalMask.setAttribute('tabindex', '-1');
-    modalMask.classList.add('sprk-c-ModalMask', HIDE_CLASS);
+    modalMask.classList.add('sprk-c-ModalMask', HIDE_CLASS_MASK);
     sinon.spy(modalMask.classList, 'add');
 
     defaultModal = document.createElement('div');
@@ -340,12 +341,12 @@ describe('Modal tests', () => {
     expect(modalEl).toEqual(defaultModal);
   });
 
-  it(`should show the default modal, mask and set 
+  it(`should show the default modal, mask and set
       aria-hidden=true on main container`, () => {
     showModal(defaultModal, modalMask, main);
 
     // showModal should remove the hide class from the modal mask
-    expect(modalMask.classList.contains(HIDE_CLASS)).toBe(false);
+    expect(modalMask.classList.contains(HIDE_CLASS_MASK)).toBe(false);
 
     // showModal should remove the hide class from the modal
     expect(defaultModal.classList.contains(HIDE_CLASS)).toBe(false);
@@ -359,12 +360,12 @@ describe('Modal tests', () => {
     expect(defaultModal.classList.add.called).toBe(false);
   });
 
-  it(`should show the wait modal, mask and set 
+  it(`should show the wait modal, mask and set
       aria-hidden=true on main`, () => {
     showModal(waitModal, modalMask, main);
 
     // showModal should remove the hide class from the modal mask
-    expect(modalMask.classList.contains(HIDE_CLASS)).toBe(false);
+    expect(modalMask.classList.contains(HIDE_CLASS_MASK)).toBe(false);
 
     // showModal should remove the hide class from the modal
     expect(waitModal.classList.contains(HIDE_CLASS)).toBe(false);
@@ -373,14 +374,14 @@ describe('Modal tests', () => {
     expect(main.hasAttribute('aria-hidden')).toBe(true);
   });
 
-  it(`should hide the default modal, mask, remove aria-hidden=true 
+  it(`should hide the default modal, mask, remove aria-hidden=true
       on main, and send focus back to trigger element`, () => {
     // First we show the modal
     showModal(defaultModal, modalMask, main);
     hideModal(defaultModal, modalMask, main);
 
     // hideModal should remove the hide class from the modal mask
-    expect(modalMask.classList.contains(HIDE_CLASS)).toBe(true);
+    expect(modalMask.classList.contains(HIDE_CLASS_MASK)).toBe(true);
 
     // hideModal should remove the hide class from the modal
     expect(defaultModal.classList.contains(HIDE_CLASS)).toBe(true);
@@ -392,20 +393,20 @@ describe('Modal tests', () => {
     expect(triggerDefaultModal).toEqual(document.activeElement);
   });
 
-  it(`should return if the modal is already hidden or if the 
+  it(`should return if the modal is already hidden or if the
       mask or main section is not defined`, () => {
     hideModal(defaultModal, modalMask, main);
     expect(modalMask.classList.add.called).toBe(false);
   });
 
-  it(`should hide the wait modal, mask, remove aria-hidden=true 
+  it(`should hide the wait modal, mask, remove aria-hidden=true
       on main, and send focus back to trigger element`, () => {
     // First we show the modal
     showModal(waitModal, modalMask, main);
     hideModal(waitModal, modalMask, main);
 
     // hideModal should remove the hide class from the modal mask
-    expect(modalMask.classList.contains(HIDE_CLASS)).toBe(true);
+    expect(modalMask.classList.contains(HIDE_CLASS_MASK)).toBe(true);
 
     // hideModal should remove the hide class from the modal
     expect(waitModal.classList.contains(HIDE_CLASS)).toBe(true);
@@ -551,7 +552,7 @@ describe('Modal tests', () => {
     expect(document.activeElement).toEqual(waitModal);
   });
 
-  it(`should return focus to the open wait 
+  it(`should return focus to the open wait
       modal if shift + tab is pressed`, () => {
     const modalsList = document.querySelectorAll('[data-sprk-modal]');
     const tabKeyEvent = new window.Event('keydown');
@@ -574,7 +575,7 @@ describe('Modal tests', () => {
     expect(document.activeElement).toEqual(cancelDefault);
   });
 
-  it(`should return focus to the first element if tab + shift 
+  it(`should return focus to the first element if tab + shift
       is pressed while the first focusable element is focused`, () => {
     const modalsList = document.querySelectorAll('[data-sprk-modal]');
     const tabKeyEvent = new window.Event('keydown');
@@ -587,7 +588,7 @@ describe('Modal tests', () => {
     expect(document.activeElement).toEqual(link2);
   });
 
-  it(`should do nothing if tab + shift is pressed while 
+  it(`should do nothing if tab + shift is pressed while
       the focused element is not first`, () => {
     const modalsList = document.querySelectorAll('[data-sprk-modal]');
     const tabKeyEvent = new window.Event('keydown');
@@ -599,7 +600,7 @@ describe('Modal tests', () => {
     expect(document.activeElement).toEqual(link2);
   });
 
-  it(`should do nothing if tab is pressed while 
+  it(`should do nothing if tab is pressed while
       the focused element is not last`, () => {
     const modalsList = document.querySelectorAll('[data-sprk-modal]');
     const tabKeyEvent = new window.Event('keydown');
@@ -617,7 +618,7 @@ describe('Modal tests', () => {
       target: modalMask,
       preventDefault: () => {},
     });
-    expect(waitModal.classList.contains('sprk-u-Display--none')).toBe(false);
+    expect(waitModal.classList.contains(HIDE_CLASS)).toBe(false);
   });
 
   it('should perform modal mask click event only while a modal is open', () => {

--- a/react/src/base/links/SprkLink.stories.js
+++ b/react/src/base/links/SprkLink.stories.js
@@ -72,9 +72,10 @@ export const iconWithTextLink = () => (
   >
     <SprkIcon
       additionalClasses="
-            sprk-c-Icon--xl
-            sprk-u-mrs
-            sprk-c-Icon--filled-current-color"
+        sprk-c-Icon--xl
+        sprk-b-Link__icon
+        sprk-c-Icon--filled-current-color
+      "
       iconName="arrow-left"
     />
     Back
@@ -148,9 +149,10 @@ export const disabledIconWithTextLink = () => (
   >
     <SprkIcon
       additionalClasses="
-              sprk-c-Icon--xl
-              sprk-u-mrs
-              sprk-c-Icon--filled-current-color"
+        sprk-c-Icon--xl
+        sprk-b-Link__icon
+        sprk-c-Icon--filled-current-color
+      "
       iconName="arrow-left"
     />
     Back

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -72,7 +72,8 @@ class SprkAccordionItem extends Component {
     const leadingIconClasses = classnames(
       'sprk-c-Icon--filled-current-color',
       'sprk-c-Icon--xl',
-      'sprk-u-mrs',
+      'sprk-c-Accordion__icon',
+      'sprk-c-Accordion__icon--leading',
       leadingIconAdditionalClasses,
     );
 

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -89,7 +89,7 @@ const SprkAward = (props) => {
           analyticsString={disclaimerAnalytics}
           additionalClasses="sprk-o-Stack__item"
         >
-          <p className="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
+          <p className="sprk-b-TypeBodyFour">
             {disclaimerText}
           </p>
         </SprkToggle>

--- a/react/src/components/awards/SprkAward.js
+++ b/react/src/components/awards/SprkAward.js
@@ -32,7 +32,8 @@ const SprkAward = (props) => {
           sprk-b-TypeDisplayFive
           sprk-b-Measure
           sprk-b-Measure--narrow
-          sprk-u-TextAlign--center"
+          sprk-b-Type--center
+        "
       >
         {heading}
       </h2>

--- a/react/src/components/card/SprkCard.stories.js
+++ b/react/src/components/card/SprkCard.stories.js
@@ -67,7 +67,7 @@ export const highlightedHeader = () => (
         <SprkHeading
           element="h3"
           variant="displaySeven"
-          additionalClasses="sprk-u-Color--white"
+          additionalClasses="sprk-c-Card__highlighted-heading"
         >
           Description
         </SprkHeading>
@@ -77,7 +77,7 @@ export const highlightedHeader = () => (
         <SprkHeading
           element="h4"
           variant="displayFive"
-          additionalClasses="sprk-u-Color--white"
+          additionalClasses="sprk-c-Card__highlighted-heading"
         >
           Card Title
         </SprkHeading>
@@ -154,7 +154,7 @@ export const teaserWithIcon = () => (
       additionalClasses="
         sprk-o-Stack__item
         sprk-c-Card__content
-        sprk-u-TextAlign--center
+        sprk-b-Type--center
       "
     >
       <SprkStackItem>

--- a/react/src/components/dropdown/SprkDropdown.js
+++ b/react/src/components/dropdown/SprkDropdown.js
@@ -154,7 +154,10 @@ class SprkDropdown extends Component {
           variant="plain"
           additionalClasses={classNames(
             'sprk-c-Dropdown__trigger',
-            { 'sprk-u-mrs': variant === 'informational' },
+            {
+              'sprk-c-Dropdown__trigger--informational':
+                variant === 'informational',
+            },
             triggerAdditionalClasses,
           )}
           aria-expanded={isOpen}
@@ -176,7 +179,7 @@ class SprkDropdown extends Component {
                   `
                   sprk-c-Icon--filled-current-color
                   sprk-c-Icon--stroke-current-color
-                  sprk-u-mls
+                  sprk-c-Dropdown__trigger-icon
                 `,
                 )}
                 iconName={iconName}

--- a/react/src/components/dropdown/SprkDropdown.js
+++ b/react/src/components/dropdown/SprkDropdown.js
@@ -292,7 +292,7 @@ class SprkDropdown extends Component {
               })}
             </ul>
             {footer && (
-              <div className="sprk-c-Dropdown__footer sprk-u-TextAlign--center">
+              <div className="sprk-c-Dropdown__footer sprk-b-Type--center">
                 {footer}
               </div>
             )}

--- a/react/src/components/footer/SprkFooter.js
+++ b/react/src/components/footer/SprkFooter.js
@@ -5,6 +5,7 @@ import uniqueId from 'lodash/uniqueId';
 import SprkIcon from '../icons/SprkIcon';
 import SprkFooterGlobalSection from './components/SprkFooterGlobalSection/SprkFooterGlobalSection';
 import SprkFooterConnectIcons from './components/SprkFooterConnectIcons/SprkFooterConnectIcons';
+import SprkDivider from '../dividers/SprkDivider';
 import SprkFooterAwards from './components/SprkFooterAwards/SprkFooterAwards';
 
 class SprkFooter extends Component {
@@ -145,7 +146,7 @@ class SprkFooter extends Component {
             </div>
           </div>
 
-          <span className="sprk-c-Divider sprk-u-mvn sprk-u-mhm" />
+          <SprkDivider element="span" additionalClasses="sprk-c-Footer__divider" />
 
           <div
             className="sprk-o-Stack__item

--- a/react/src/components/footer/SprkFooter.js
+++ b/react/src/components/footer/SprkFooter.js
@@ -80,12 +80,13 @@ class SprkFooter extends Component {
                   linkColumnsHasIds.map((column) => (
                     <div
                       key={column.id}
-                      className="sprk-o-Stack__item
+                      className="
+                        sprk-o-Stack__item
                         sprk-o-Stack__item--third@m
-                        sprk-o-Box
-                        sprk-u-PaddingRight--a
+                        sprk-c-Footer__local-links
                         sprk-o-Stack
-                        sprk-o-Stack--large"
+                        sprk-o-Stack--large
+                      "
                     >
                       <h3
                         className="
@@ -149,11 +150,12 @@ class SprkFooter extends Component {
           <SprkDivider element="span" additionalClasses="sprk-c-Footer__divider" />
 
           <div
-            className="sprk-o-Stack__item
-            sprk-o-Stack
-            sprk-o-Stack--misc-b
-            sprk-o-Box
-            sprk-u-PaddingTop--b"
+            className="
+              sprk-o-Stack__item
+              sprk-o-Stack
+              sprk-o-Stack--misc-b
+              sprk-c-Footer__awards
+            "
           >
             {Object.keys(awards).length > 1 && (
               <SprkFooterAwards awards={awards} />

--- a/react/src/components/footer/SprkFooter.stories.js
+++ b/react/src/components/footer/SprkFooter.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import SprkFooter from './SprkFooter';
 import SprkLink from '../../base/links/SprkLink';
-import SprkStack from '../../objects/stack/SprkStack';
 import SprkStackItem from '../../objects/stack/components/SprkStackItem/SprkStackItem';
 import { markdownDocumentationLinkBuilder } from '../../../../storybook-utilities/markdownDocumentationLinkBuilder';
 import SprkFooterAwards from './components/SprkFooterAwards/SprkFooterAwards';

--- a/react/src/components/footer/SprkFooter.stories.js
+++ b/react/src/components/footer/SprkFooter.stories.js
@@ -78,7 +78,7 @@ export const defaultStory = () => (
         links: [
           {
             href: '#nogo',
-            text: 'About This.',
+            text: 'About This',
             analyticsString: 'about-this-link',
             element: 'a',
           },

--- a/react/src/components/footer/components/SprkFooterAwards/SprkFooterAwards.js
+++ b/react/src/components/footer/components/SprkFooterAwards/SprkFooterAwards.js
@@ -21,13 +21,21 @@ class SprkFooterAwards extends Component {
       <div className="sprk-o-Stack__item sprk-o-Stack sprk-o-Stack--large">
         <h3
           className="
-          sprk-o-Stack__item sprk-b-TypeBodyOne sprk-c-Footer__text"
+            sprk-o-Stack__item
+            sprk-b-TypeBodyOne
+            sprk-c-Footer__text
+          "
         >
           {awards.heading}
         </h3>
         <div
-          className="sprk-o-Stack__item
-          sprk-o-Stack sprk-o-Stack--medium sprk-o-Stack--split@s sprk-u-mbm"
+          className="
+            sprk-o-Stack__item
+            sprk-o-Stack
+            sprk-o-Stack--medium
+            sprk-o-Stack--split@s
+            sprk-c-Footer__awards
+          "
         >
           {awardsImagesHasIds.map((image) => {
             const {
@@ -64,7 +72,8 @@ class SprkFooterAwards extends Component {
         >
           <p
             className="
-            sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs sprk-c-Footer__text"
+              sprk-b-TypeBodyFour sprk-c-Footer__text
+            "
           >
             {awards.disclaimerText}
           </p>

--- a/react/src/components/footer/components/SprkFooterGlobalSection/SprkFooterGlobalSection.js
+++ b/react/src/components/footer/components/SprkFooterGlobalSection/SprkFooterGlobalSection.js
@@ -16,7 +16,13 @@ class SprkFooterGlobalSection extends Component {
     const { globalItems } = this.props;
     const { globalItemsHasIds } = this.state;
     return (
-      <div className="sprk-o-Stack__item sprk-o-Stack__item--three-tenths@m sprk-o-Stack sprk-o-Stack--misc-b sprk-o-Box sprk-u-prh">
+      <div className="
+            sprk-o-Stack__item
+            sprk-o-Stack__item--three-tenths@m
+            sprk-o-Stack
+            sprk-o-Stack--misc-b
+            sprk-c-Footer__global-links
+          ">
         <h3 className="sprk-o-Stack__item sprk-b-TypeBodyOne sprk-c-Footer__text">
           {globalItems.heading}
         </h3>
@@ -72,7 +78,11 @@ SprkFooterGlobalSection.propTypes = {
   globalItems: PropTypes.shape({
     /** Main headline for the global section. */
     heading: PropTypes.string,
-    /** Object used to configure each item in global items section such as `mediaType`, `src`, `description` etc. */
+    /**
+     * Object used to configure each item in
+     * global items section such as
+     * `mediaType`, `src`, `description` etc.
+     */
     items: PropTypes.arrayOf(
       PropTypes.shape({
         /** The type of media element to render. */
@@ -98,7 +108,8 @@ SprkFooterGlobalSection.propTypes = {
         /** The description of the image */
         description: PropTypes.string,
         /**
-         * Assigned to the `data-analytics` attribute serving as a unique selector for outside libraries to capture data.
+         * Assigned to the `data-analytics` attribute serving
+         * as a unique selector for outside libraries to capture data.
          */
         analyticsString: PropTypes.string,
         /**

--- a/react/src/components/highlight-board/SprkHighlightBoard.js
+++ b/react/src/components/highlight-board/SprkHighlightBoard.js
@@ -39,7 +39,6 @@ const SprkHighlightBoard = (props) => {
 
   const classNames = classnames(
     'sprk-c-HighlightBoard',
-    'sprk-u-mbm',
     additionalClasses,
     { 'sprk-c-HighlightBoard--has-image': imgSrc },
     { 'sprk-c-HighlightBoard--stacked': variant === 'stacked' },

--- a/react/src/components/masthead/SprkMasthead.stories.js
+++ b/react/src/components/masthead/SprkMasthead.stories.js
@@ -80,17 +80,6 @@ const links = [
     text: 'Item 2',
     to: '#nogo',
   },
-  {
-    element: SprkLink,
-    text: 'Item 3',
-    subNavLinks: [
-      {
-        element: 'a',
-        text: 'Placeholder',
-        to: '#nogo',
-      },
-    ],
-  },
 ];
 
 const addedNarrowNavLinks = [
@@ -175,7 +164,7 @@ const utilityItems = [
     element="a"
     href="#nogo"
     variant="secondary"
-    additionalClasses="sprk-u-Right--zero sprk-c-Button--compact"
+    additionalClasses="sprk-c-Button--compact"
   >
     Sign In
   </SprkButton>,

--- a/react/src/components/masthead/SprkMasthead.test.js
+++ b/react/src/components/masthead/SprkMasthead.test.js
@@ -211,7 +211,7 @@ describe('SprkMasthead:', () => {
     const wrapper = mount(<SprkMasthead narrowNavLinks={[{ text: 'Hi' }]} />);
     const hamburgerIcon = wrapper.find('.sprk-c-Menu');
     hamburgerIcon.simulate('click');
-    const narrowNavElement = wrapper.find('.sprk-c-Masthead__narrow-nav');
+    const narrowNavElement = wrapper.find('.sprk-c-Masthead__nav-collapsible');
     const narrowNavElementId = narrowNavElement.getDOMNode().getAttribute('id');
     const hamburgerIconAriaControls = hamburgerIcon.getDOMNode().getAttribute('aria-controls');
 
@@ -229,7 +229,7 @@ describe('SprkMasthead:', () => {
     );
     const hamburgerIcon = wrapper.find('.sprk-c-Menu');
     hamburgerIcon.simulate('click');
-    const narrowNavElement = wrapper.find('.sprk-c-Masthead__narrow-nav');
+    const narrowNavElement = wrapper.find('.sprk-c-Masthead__nav-collapsible');
     const narrowNavElementId = narrowNavElement.getDOMNode().getAttribute('id');
     const hamburgerIconAriaControls = hamburgerIcon.getDOMNode().getAttribute('aria-controls');
 

--- a/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
+++ b/react/src/components/masthead/components/SprkMastheadAccordionItem/SprkMastheadAccordionItem.js
@@ -155,7 +155,8 @@ class SprkMastheadAccordionItem extends Component {
                     sprk-c-Icon--filled-current-color
                     sprk-c-Icon--stroke-current-color
                     sprk-c-Icon--xl
-                    sprk-u-mrs
+                    sprk-c-MastheadAccordion__icon
+                    sprk-c-MastheadAccordion__icon--leading
                   "
                   iconName={leadingIcon}
                 />

--- a/react/src/components/masthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
+++ b/react/src/components/masthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
@@ -78,7 +78,7 @@ class SprkMastheadDropdown extends Component {
         <SprkLink
           variant="simple"
           additionalClasses={classNames(
-            { 'sprk-u-mrs': variant === 'informational' },
+            { 'sprk-b-Link__icon': variant === 'informational' },
             'sprk-c-Masthead__link',
             'sprk-c-Masthead__link--big-nav',
             additionalTriggerClasses,
@@ -97,7 +97,7 @@ class SprkMastheadDropdown extends Component {
             additionalClasses={classNames(
               `sprk-c-Icon--filled-current-color
               sprk-c-Icon--stroke-current-color
-              sprk-u-mls`,
+              sprk-c-Dropdown__trigger-icon`,
               additionalIconClasses,
             )}
             iconName={iconName}

--- a/react/src/components/masthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
+++ b/react/src/components/masthead/components/SprkMastheadDropdown/SprkMastheadDropdown.js
@@ -106,7 +106,7 @@ class SprkMastheadDropdown extends Component {
         {isOpen && (
           <div
             className={classNames(
-              'sprk-c-Dropdown sprk-u-TextAlign--left',
+              'sprk-c-Dropdown sprk-b-Type--left',
               additionalClasses,
             )}
           >

--- a/react/src/components/masthead/components/SprkMastheadNarrowNav/SprkMastheadNarrowNav.js
+++ b/react/src/components/masthead/components/SprkMastheadNarrowNav/SprkMastheadNarrowNav.js
@@ -15,7 +15,7 @@ const SprkMastheadNarrowNav = ({
   <>
     {isOpen && (
       <nav
-        className="sprk-c-Masthead__narrow-nav"
+        className="sprk-c-Masthead__nav-collapsible"
         role="navigation"
         data-id={idString}
         id={narrowNavId}
@@ -37,6 +37,11 @@ SprkMastheadNarrowNav.propTypes = {
    * serving as a unique selector for automated tools.
    */
   idString: PropTypes.string,
+  /**
+   * Assigned to the `id` attribute
+   * on the nav element.
+   */
+  narrowNavId: PropTypes.string,
   /**
    * If `true`, will render the Narrow Navigation.
    */

--- a/react/src/components/masthead/components/SprkMastheadNarrowNav/SprkMastheadNarrowNav.test.js
+++ b/react/src/components/masthead/components/SprkMastheadNarrowNav/SprkMastheadNarrowNav.test.js
@@ -17,7 +17,7 @@ describe('SprkMastheadNarrowNav:', () => {
   it('should render the nav if isOpen is true', () => {
     const links = [{ text: 'Item 1' }];
     const wrapper = mount(<SprkMastheadNarrowNav isOpen links={links} />);
-    expect(wrapper.find('.sprk-c-Masthead__narrow-nav').length).toBe(1);
+    expect(wrapper.find('.sprk-c-Masthead__nav-collapsible').length).toBe(1);
   });
 
   it('should render the selector if selector (and items) are defined', () => {

--- a/react/src/components/stepper/SprkStepper.js
+++ b/react/src/components/stepper/SprkStepper.js
@@ -200,7 +200,7 @@ class SprkStepper extends Component {
       return (
         <div
           className={classnames(
-            'sprk-u-BackgroundColor--purple-dark sprk-o-Box sprk-o-Box--large',
+            'sprk-c-Stepper__container-dark sprk-o-Box sprk-o-Box--large',
             additionalClasses,
           )}
         >

--- a/react/src/components/stepper/SprkStepper.test.js
+++ b/react/src/components/stepper/SprkStepper.test.js
@@ -86,7 +86,7 @@ describe('SprkStepper:', () => {
   });
 
   it('should have the correct structure with a dark background', () => {
-    const expected = 'div.sprk-u-BackgroundColor--purple-dark';
+    const expected = 'div.sprk-c-Stepper__container-dark';
 
     const wrapper = mount(
       <SprkStepper hasDarkBackground>

--- a/react/src/components/toggle/SprkToggle.js
+++ b/react/src/components/toggle/SprkToggle.js
@@ -54,11 +54,11 @@ class SprkToggle extends Component {
     const containerClasses = classnames('sprk-c-Toggle', additionalClasses);
 
     const titleClasses = classnames(
-      'sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-u-TextCrop--none',
+      'sprk-c-Toggle__trigger sprk-b-TypeBodyThree sprk-b-Type--crop-none',
       triggerTextAdditionalClasses,
     );
     const iconClasses = classnames(
-      'sprk-c-Icon--xl sprk-c-Icon--toggle sprk-u-mrs',
+      'sprk-c-Icon--xl sprk-c-Icon--toggle sprk-c-Toggle__trigger-icon',
       { 'sprk-c-Icon--open': isOpen },
       iconAdditionalClasses,
     );

--- a/react/src/components/toggle/SprkToggle.stories.js
+++ b/react/src/components/toggle/SprkToggle.stories.js
@@ -14,7 +14,7 @@ export default {
 
 export const defaultStory = () => (
   <SprkToggle triggerText="My Disclaimer" analyticsString="toggle-1">
-    <p className="sprk-b-TypeBodyFour sprk-u-pts sprk-u-pbs">
+    <p className="sprk-b-TypeBodyFour">
       This is an example of disclaimer content. The
       aria-expanded=&quot;true&quot; attribute will be viewable in the DOM on
       the toggle link when this content is shown. When this content is hidden

--- a/react/src/objects/stack/SprkStack.js
+++ b/react/src/objects/stack/SprkStack.js
@@ -10,6 +10,7 @@ const SprkStack = (props) => {
     additionalClasses,
     idString,
     analyticsString,
+    isStackItem,
     ...other
   } = props;
 
@@ -30,6 +31,7 @@ const SprkStack = (props) => {
     'sprk-o-Stack--split@m': splitAt === 'medium',
     'sprk-o-Stack--split@l': splitAt === 'large',
     'sprk-o-Stack--split@xl': splitAt === 'huge',
+    'sprk-o-Stack__item': isStackItem,
   });
 
   return (
@@ -46,6 +48,7 @@ const SprkStack = (props) => {
 
 SprkStack.propTypes = {
   children: PropTypes.node,
+
   /**
    * Determines when the layout will switch `flex-direction` from `column` to
    * `row` based on breakpoint.
@@ -59,6 +62,7 @@ SprkStack.propTypes = {
     'huge',
     '',
   ]),
+
   /**
    * Determines spacing between items.
    */
@@ -78,21 +82,30 @@ SprkStack.propTypes = {
     'miscD',
     '',
   ]),
+
   /**
    * Assigned to the `data-id` attribute serving as a unique selector for
    * automated tools.
    */
   idString: PropTypes.string,
+
   /**
    * Assigned to the `data-analytics` attribute serving as a unique selector
    * for outside libraries to capture data.
    */
   analyticsString: PropTypes.string,
+
   /**
    * A space-separated string of classes to add to the outermost container of
    * the component.
    */
   additionalClasses: PropTypes.string,
+
+  /**
+   * Use in cases of nested Stack components where the Stack is also
+   * a Stack item.
+   */
+  isStackItem: PropTypes.bool,
 };
 
 export default SprkStack;

--- a/react/src/objects/stack/SprkStack.stories.js
+++ b/react/src/objects/stack/SprkStack.stories.js
@@ -169,21 +169,30 @@ stackSplitLayoutThreeTenths.story = {
 };
 
 export const stackSplitLayoutMixed = () => (
-  <div>
+  <>
     <SprkStack splitAt="tiny">
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">fourth</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">half</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">fourth</p>
         </SprkStackItem>
@@ -191,25 +200,37 @@ export const stackSplitLayoutMixed = () => (
     </SprkStack>
 
     <SprkStack splitAt="tiny">
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">sixth</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">sixth</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">sixth</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">flex</p>
         </SprkStackItem>
@@ -217,25 +238,37 @@ export const stackSplitLayoutMixed = () => (
     </SprkStack>
 
     <SprkStack splitAt="tiny">
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">two-fifths</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">fifth</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">fifth</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">fifth</p>
         </SprkStackItem>
@@ -249,13 +282,19 @@ export const stackSplitLayoutMixed = () => (
             <p className="sprk-b-TypeBodyOne">Nested Item (flex)</p>
           </SprkStackItem>
 
-          <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all">
+          <SprkStack
+            isStackItem
+            additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
+          >
             <SprkStackItem>
               <p className="sprk-b-TypeBodyOne">Nested Item (flex)</p>
             </SprkStackItem>
           </SprkStack>
 
-          <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all">
+          <SprkStack
+            isStackItem
+            additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all"
+          >
             <SprkStackItem>
               <p className="sprk-b-TypeBodyOne">Nested Item (flex)</p>
             </SprkStackItem>
@@ -263,7 +302,10 @@ export const stackSplitLayoutMixed = () => (
         </SprkStack>
       </SprkStackItem>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">half</p>
         </SprkStackItem>
@@ -271,19 +313,25 @@ export const stackSplitLayoutMixed = () => (
     </SprkStack>
 
     <SprkStack splitAt="tiny">
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">two-fifths</p>
         </SprkStackItem>
       </SprkStack>
 
-      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--three-fifths@xs sprk-o-Stack--center-all">
+      <SprkStack
+        isStackItem
+        additionalClasses="sprk-o-Stack__item--three-fifths@xs sprk-o-Stack--center-all"
+      >
         <SprkStackItem>
           <p className="sprk-b-TypeBodyOne">three-fifths</p>
         </SprkStackItem>
       </SprkStack>
     </SprkStack>
-  </div>
+  </>
 );
 
 stackSplitLayoutMixed.story = {

--- a/react/src/objects/stack/SprkStack.stories.js
+++ b/react/src/objects/stack/SprkStack.stories.js
@@ -171,66 +171,117 @@ stackSplitLayoutThreeTenths.story = {
 export const stackSplitLayoutMixed = () => (
   <div>
     <SprkStack splitAt="tiny">
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--fourth@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">fourth</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--half@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">half</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--fourth@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">fourth</p>
-      </SprkStackItem>
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">fourth</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">half</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fourth@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">fourth</p>
+        </SprkStackItem>
+      </SprkStack>
     </SprkStack>
+
     <SprkStack splitAt="tiny">
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">sixth</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">sixth</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">sixth</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">flex</p>
-      </SprkStackItem>
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">sixth</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">sixth</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--sixth@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">sixth</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">flex</p>
+        </SprkStackItem>
+      </SprkStack>
     </SprkStack>
+
     <SprkStack splitAt="tiny">
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">two-fifths</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">fifth</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">fifth</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">fifth</p>
-      </SprkStackItem>
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">two-fifths</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">fifth</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">fifth</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--fifth@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">fifth</p>
+        </SprkStackItem>
+      </SprkStack>
     </SprkStack>
+
     <SprkStack splitAt="tiny">
       <SprkStackItem additionalClasses="sprk-o-Stack__item--half@xs">
         <SprkStack splitAt="tiny">
-          <SprkStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-u-AbsoluteCenter">
+          <SprkStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack sprk-o-Stack--center-all">
             <p className="sprk-b-TypeBodyOne">Nested Item (flex)</p>
           </SprkStackItem>
-          <SprkStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-u-AbsoluteCenter">
-            <p className="sprk-b-TypeBodyOne">Nested Item (flex)</p>
-          </SprkStackItem>
+
+          <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all">
+            <SprkStackItem>
+              <p className="sprk-b-TypeBodyOne">Nested Item (flex)</p>
+            </SprkStackItem>
+          </SprkStack>
+
+          <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--flex@xs sprk-o-Stack--center-all">
+            <SprkStackItem>
+              <p className="sprk-b-TypeBodyOne">Nested Item (flex)</p>
+            </SprkStackItem>
+          </SprkStack>
         </SprkStack>
       </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--half@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">half</p>
-      </SprkStackItem>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--half@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">half</p>
+        </SprkStackItem>
+      </SprkStack>
     </SprkStack>
+
     <SprkStack splitAt="tiny">
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">two-fifths</p>
-      </SprkStackItem>
-      <SprkStackItem additionalClasses="sprk-o-Stack__item--three-fifths@xs sprk-u-AbsoluteCenter">
-        <p className="sprk-b-TypeBodyOne">three-fifths</p>
-      </SprkStackItem>
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--two-fifths@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">two-fifths</p>
+        </SprkStackItem>
+      </SprkStack>
+
+      <SprkStack isStackItem additionalClasses="sprk-o-Stack__item--three-fifths@xs sprk-o-Stack--center-all">
+        <SprkStackItem>
+          <p className="sprk-b-TypeBodyOne">three-fifths</p>
+        </SprkStackItem>
+      </SprkStack>
     </SprkStack>
   </div>
 );

--- a/react/src/objects/stack/SprkStack.test.js
+++ b/react/src/objects/stack/SprkStack.test.js
@@ -12,6 +12,11 @@ describe('SprkStack:', () => {
     expect(wrapper.html()).toEqual('<div class="sprk-o-Stack"></div>');
   });
 
+  it('should add Stack Item class if isStackItem is true', () => {
+    const wrapper = shallow(<SprkStack isStackItem />);
+    expect(wrapper.html()).toEqual('<div class="sprk-o-Stack sprk-o-Stack__item"></div>');
+  });
+
   it(
     'should set the tiny spacing class in addition to the base class when' +
       ' itemSpacing is "tiny"',

--- a/storybook-utilities/storybook-theming/_docs.scss
+++ b/storybook-utilities/storybook-theming/_docs.scss
@@ -113,7 +113,7 @@ body {
 
 .sb-show-main .sb-decorate .sprk-o-CenteredColumn,
 .sb-show-main .sb-decorate .sprk-o-Box,
-.sb-show-main .sb-decorate .sprk-o-Stack__item {
+.sb-show-main .sb-decorate .sprk-o-Stack.sprk-o-Stack__item {
   background-color: $sprk-black-tint-40;
   border: 2px solid $sprk-black;
   height: 4rem;

--- a/storybook-utilities/storybook-theming/_docs.scss
+++ b/storybook-utilities/storybook-theming/_docs.scss
@@ -113,10 +113,21 @@ body {
 
 .sb-show-main .sb-decorate .sprk-o-CenteredColumn,
 .sb-show-main .sb-decorate .sprk-o-Box,
-.sb-show-main .sb-decorate .sprk-o-Stack.sprk-o-Stack__item {
+.sb-show-main
+  .sb-decorate
+  .sprk-o-Stack.sprk-o-Stack__item.sprk-o-Stack--center-all,
+.sb-show-main .sb-decorate .sprk-o-Stack .sprk-o-Stack__item {
   background-color: $sprk-black-tint-40;
   border: 2px solid $sprk-black;
   height: 4rem;
+}
+
+.sb-show-main
+  .sb-decorate
+  .sprk-o-Stack.sprk-o-Stack__item.sprk-o-Stack--center-all
+  .sprk-o-Stack__item {
+  border: 0;
+  height: auto;
 }
 
 .sb-show-main .sb-decorate .sprk-o-Stack__item.sprk-o-Box {

--- a/styles/android/spark_design_tokens_colors.xml
+++ b/styles/android/spark_design_tokens_colors.xml
@@ -31,6 +31,7 @@
   <color name="sprk_card_shadow_color_standout">#1a000000</color><!-- The box shadow color of the Standout Card variant on narrow viewports. -->
   <color name="sprk_card_shadow_color_standout_wide_viewport">#1a000000</color><!-- The box shadow color of the Standout Card variant on wide viewports. -->
   <color name="sprk_card_header_bg_color">#ff603aa1</color><!-- The background color of the header area for the Highlighted Header Card. -->
+  <color name="sprk_card_highlighted_heading_color">#ffffffff</color><!-- The color of the highlighted heading for the Highlighted Header Card. -->
   <color name="sprk_card_header_text_color">#ffffffff</color><!-- The text color for the Highlighted Header Card. -->
   <color name="sprk_red">#ffc8102e</color><!-- Red for key branded moments throughout the product as our primary brand color. -->
   <color name="sprk_deep_red">#ff76232f</color><!-- Darkest red for key branded moments throughout the product. -->

--- a/styles/android/spark_design_tokens_colors.xml
+++ b/styles/android/spark_design_tokens_colors.xml
@@ -104,6 +104,7 @@
   <color name="sprk_masthead_selector_dropdown_active_background_color">#fff7f7f7</color><!-- The background color of the Selector Dropdown items that are active or hovered. Found in a Masthead with Extended Navigation. -->
   <color name="sprk_masthead_mask_color">#80000000</color><!-- The color of the mask that gets applied when the Masthead Selector Dropdown is open on narrow screens. -->
   <color name="sprk_modal_mask_color">#59222222</color><!-- The color of the mask overlay that is shown behind the Modal. -->
+  <color name="sprk_stepper_dark_bg">#ff3c3174</color><!-- The background color of the Stepper with a dark background. -->
   <color name="sprk_stepper_icon_border_color">#ff8d8d8c</color><!-- The color of the border around the Stepper icon. -->
   <color name="sprk_stepper_icon_border_color_selected">#ff3c3174</color><!-- The color of the step icon when the step is selected in the Stepper. -->
   <color name="sprk_stepper_icon_border_color_selected_dark_bg">#ffe7e2f2</color><!-- The color of the step icon in front of a dark background when the step is selected in the Stepper. -->

--- a/styles/android/spark_design_tokens_dimens.xml
+++ b/styles/android/spark_design_tokens_dimens.xml
@@ -285,6 +285,8 @@
   <dimen name="sprk_tooltip_animation_offset">8.00dp</dimen><!-- The distance the tooltip should move during its animation. -->
   <dimen name="sprk_typography_breakpoint">864.00dp</dimen><!-- The breakpoint used for typography. -->
   <dimen name="sprk_measure">640.00dp</dimen><!-- The max-width value for the .sprk-u-Measure class. -->
+  <dimen name="sprk_type_crop_none_margin_bottom">0.00dp</dimen><!-- The margin bottom value for the crop none helper class. -->
+  <dimen name="sprk_type_crop_none_margin_top">0.00dp</dimen><!-- The margin top value for the crop none helper class. -->
   <dimen name="sprk_narrow_measure">400.00dp</dimen><!-- The max-width value for the narrow measure. -->
   <dimen name="sprk_page_title_mark_width">32.00dp</dimen><!-- The width of the Page Title mark. -->
   <dimen name="sprk_page_title_mark_height">5.00dp</dimen><!-- The height of the Page Title mark. -->

--- a/styles/android/spark_design_tokens_dimens.xml
+++ b/styles/android/spark_design_tokens_dimens.xml
@@ -148,6 +148,7 @@
   <dimen name="sprk_layer_height_m">32000.00dp</dimen><!-- The medium z-index value setting. -->
   <dimen name="sprk_layer_height_l">48000.00dp</dimen><!-- The large z-index value setting. -->
   <dimen name="sprk_layer_height_xl">159984.00dp</dimen><!-- The extra large z-index value setting. -->
+  <dimen name="sprk_link_icon_margin">0 8.00dp 0 0</dimen><!-- The default margin on icons inside Links. -->
   <dimen name="sprk_link_underline_width">2.00dp</dimen><!-- The width of the underline on Links. -->
   <dimen name="sprk_link_simple_hover_underline_width">2.00dp</dimen><!-- The underline width value of Simple Links on hover. -->
   <dimen name="sprk_link_simple_underline_width">2.00dp</dimen><!-- The underline width value of Simple Links. -->
@@ -268,10 +269,13 @@
   <dimen name="sprk_table_secondary_row_comp_row_spacing">0.00dp</dimen><!-- The distance between the borders of adjacent cells in the Secondary Row Comparison Table (horizontal | vertical). -->
   <dimen name="sprk_table_secondary_row_comp_border_width">1.00dp</dimen><!-- The width of the borders in the Secondary Row Comparison Table cells. -->
   <dimen name="sprk_tab_navigation_breakpoint">736.00dp</dimen><!-- The breakpoint at which the tabs go from stacked layout to side by side in Tabbed Navigation. -->
+  <dimen name="sprk_toggle_trigger_icon_margin">0 8.00dp 0 0</dimen><!-- The default margin on the icon inside the Toggle trigger. -->
   <dimen name="sprk_toggle_trigger_padding_top">0.00dp</dimen><!-- The padding top for Toggle Trigger. -->
   <dimen name="sprk_toggle_trigger_padding_right">0.00dp</dimen><!-- The padding right for Toggle Trigger. -->
   <dimen name="sprk_toggle_trigger_padding_bottom">0.00dp</dimen><!-- The padding bottom for Toggle Trigger. -->
   <dimen name="sprk_toggle_trigger_padding_left">0.00dp</dimen><!-- The padding left for Toggle Trigger. -->
+  <dimen name="sprk_toggle_content_padding_top">8.00dp</dimen><!-- The padding top for the content in the Toggle. -->
+  <dimen name="sprk_toggle_content_padding_bottom">8.00dp</dimen><!-- The padding bottom for the content in the Toggle. -->
   <dimen name="sprk_tooltip_caret_offset">16.00dp</dimen><!-- The space that the Tooltip's caret is offset from the edge. -->
   <dimen name="sprk_tooltip_caret_width">16.00dp</dimen><!-- The width of the tooltip caret. -->
   <dimen name="sprk_tooltip_trigger_hover_offset">16.00dp</dimen><!-- The surrounding hover area around the trigger when the Tooltip is visible. -->

--- a/styles/android/spark_design_tokens_dimens.xml
+++ b/styles/android/spark_design_tokens_dimens.xml
@@ -163,6 +163,7 @@
   <dimen name="sprk_list_indented_margin_left">32.00dp</dimen><!-- The default margin left indentation on Lists. -->
   <dimen name="sprk_masthead_menu_icon_width">32.00dp</dimen><!-- The width of the menu icon on narrow viewports in the Masthead. -->
   <dimen name="sprk_masthead_menu_icon_height">32.00dp</dimen><!-- The height of the menu icon on narrow viewports in the Masthead. -->
+  <dimen name="sprk_masthead_dropdown_right">0.00dp</dimen><!-- The right value of the dropdown in the Masthead. -->
   <dimen name="sprk_masthead_content_padding">8.00dp</dimen><!-- The padding around the content section in the Masthead on wide viewports. -->
   <dimen name="sprk_masthead_content_padding_wide">16.00dp</dimen><!-- The padding of the Masthead content, menu, and branding sections. -->
   <dimen name="sprk_masthead_content_item_padding_top">8.00dp</dimen><!-- The padding top around the content items in the content section of the Masthead. -->

--- a/styles/android/spark_design_tokens_dimens.xml
+++ b/styles/android/spark_design_tokens_dimens.xml
@@ -148,7 +148,6 @@
   <dimen name="sprk_layer_height_m">32000.00dp</dimen><!-- The medium z-index value setting. -->
   <dimen name="sprk_layer_height_l">48000.00dp</dimen><!-- The large z-index value setting. -->
   <dimen name="sprk_layer_height_xl">159984.00dp</dimen><!-- The extra large z-index value setting. -->
-  <dimen name="sprk_link_icon_margin">0 8.00dp 0 0</dimen><!-- The default margin on icons inside Links. -->
   <dimen name="sprk_link_underline_width">2.00dp</dimen><!-- The width of the underline on Links. -->
   <dimen name="sprk_link_simple_hover_underline_width">2.00dp</dimen><!-- The underline width value of Simple Links on hover. -->
   <dimen name="sprk_link_simple_underline_width">2.00dp</dimen><!-- The underline width value of Simple Links. -->
@@ -269,7 +268,6 @@
   <dimen name="sprk_table_secondary_row_comp_row_spacing">0.00dp</dimen><!-- The distance between the borders of adjacent cells in the Secondary Row Comparison Table (horizontal | vertical). -->
   <dimen name="sprk_table_secondary_row_comp_border_width">1.00dp</dimen><!-- The width of the borders in the Secondary Row Comparison Table cells. -->
   <dimen name="sprk_tab_navigation_breakpoint">736.00dp</dimen><!-- The breakpoint at which the tabs go from stacked layout to side by side in Tabbed Navigation. -->
-  <dimen name="sprk_toggle_trigger_icon_margin">0 8.00dp 0 0</dimen><!-- The default margin on the icon inside the Toggle trigger. -->
   <dimen name="sprk_toggle_trigger_padding_top">0.00dp</dimen><!-- The padding top for Toggle Trigger. -->
   <dimen name="sprk_toggle_trigger_padding_right">0.00dp</dimen><!-- The padding right for Toggle Trigger. -->
   <dimen name="sprk_toggle_trigger_padding_bottom">0.00dp</dimen><!-- The padding bottom for Toggle Trigger. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -61,6 +61,7 @@
   <string name="sprk_dictionary_border">1px solid #fff7f7f7</string><!-- The border surrounding the Dictionary. -->
   <string name="sprk_divider_border_style">solid</string><!-- The style value of border for Dividers. -->
   <string name="sprk_divider_border">2.00dp solid #ffe6e6e6</string><!-- The value of border for Dividers. -->
+  <string name="sprk_dropdown_display_hidden">none</string><!-- The display value of dropdown when hidden. -->
   <string name="sprk_dropdown_active_border">2.5px solid #ff603aa1</string><!-- The left border of the Dropdown item that is active. -->
   <string name="sprk_dropdown_active_box_shadow">-1px 0 0 0 #ff603aa1</string><!-- The box-shadow of the Dropdown item that is active. -->
   <string name="sprk_dropdown_border_style">solid</string><!-- The border style of the Dropdown. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -69,6 +69,10 @@
   <string name="sprk_dropdown_shadow">0 0 40px 2px rgba(0, 0, 0, 0.1)</string><!-- The box shadow of the Dropdown. -->
   <string name="sprk_dropdown_trigger_icon_margin">0 0 0 8.00dp</string><!-- The default margin on the icon inside the Dropdown trigger. -->
   <string name="sprk_dropdown_trigger_informational_margin">0 8.00dp 0 0</string><!-- The default margin on the informational trigger for the Dropdown. -->
+  <string name="sprk_footer_awards_media_margin">0 0 16.00dp 0</string><!-- Margin setting for the awards media section in the Footer. -->
+  <string name="sprk_footer_global_links_padding">16.00dp 64.00dp 16.00dp 16.00dp</string><!-- Padding setting for the global links section in the Footer. -->
+  <string name="sprk_footer_local_links_padding">16.00dp 24.00dp 16.00dp 16.00dp</string><!-- Padding setting for the local links section in the Footer. -->
+  <string name="sprk_footer_awards_padding">40.00dp 16.00dp 16.00dp 16.00dp</string><!-- Padding setting for the awards section in the Footer. -->
   <string name="sprk_footer_divider_margin">0 16.00dp 0 16.00dp</string><!-- Margin value for the Divider in the Footer. -->
   <string name="sprk_footer_trigger_font_weight">normal</string><!-- Toggle trigger font-weight on the Footer. -->
   <string name="sprk_footer_trigger_hover_font_weight">normal</string><!-- Toggle trigger hover font-weight on the Footer. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -216,6 +216,7 @@
   <string name="sprk_masthead_shadow_wide">none</string><!-- The box shadow of the Masthead in wide viewports. -->
   <string name="sprk_masthead_shadow_scroll">0 0 40px rgba(0, 0, 0, 0.1)</string><!-- The Masthead shadow that gets applied when the page is scrolled. -->
   <string name="sprk_masthead_selector_border">2px solid #ffbababa</string><!-- The border of the Selector, found in a Masthead with Extended Navigation. -->
+  <string name="sprk_masthead_selector_icon_margin"> 0 8.00dp 0 8.00dp</string><!-- The margin for the icon in the selector in the Masthead. -->
   <string name="sprk_masthead_selector_container_position">relative</string><!-- The position setting of the Selector in the Masthead. -->
   <string name="sprk_masthead_selector_dropdown_z_index">32000.00dp</string><!-- The z-index of the Selector Dropdown, found in a Masthead with Extended Navigation. -->
   <string name="sprk_masthead_selector_dropdown_link_padding">16.00dp 24.00dp</string><!-- The padding of the Selector Dropdown links, found in a Masthead with Extended Navigation. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -270,6 +270,9 @@
   <string name="sprk_tooltip_text_align">left</string><!-- The text align for the tooltip. -->
   <string name="sprk_tooltip_preferred_width">max-content</string><!-- The preferred width of the tooltip. -->
   <string name="sprk_tooltip_transition">all 200ms ease-out</string><!-- The transition applied to the tooltip. -->
+  <string name="sprk_type_right">right</string><!-- The text align right value. -->
+  <string name="sprk_type_left">left</string><!-- The text align left value. -->
+  <string name="sprk_type_center">center</string><!-- The text align center value. -->
   <string name="sprk_webfonts">''</string><!-- Expects a Sass List containing one or more nested Sass Lists. The nested lists should each contain: A List of urls to download a font, the name of the font and the weight of the font. -->
   <string name="sprk_page_title_mark_padding">0 0 24.00dp</string><!-- Amount of padding between the mark and the text on the page title mark. -->
   <string name="sprk_page_title_mark_padding_wide_viewport">0 0 16.00dp</string><!-- Amount of padding between the mark and the text on a large viewport (using $sprk-typography-breakpoint). -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -208,6 +208,7 @@
   <string name="sprk_link_has_icon_visited_border_bottom">0.00dp solid transparent</string><!-- The border settings for Links with icons in the hover state. -->
   <string name="sprk_link_disabled_border_bottom">0.00dp solid #ff8d8d8c</string><!-- The underline settings for the disabled Link. -->
   <string name="sprk_link_disabled_hover_border_bottom">0.00dp solid #ff8d8d8c</string><!-- The underline settings for the disabled Link. -->
+  <string name="sprk_masthead_dropdown_margin">0 16.00dp 0 0</string><!-- The margin color of the dropdown in the Masthead. -->
   <string name="sprk_masthead_border_bottom_style">solid</string><!-- The bottom border style on the Masthead. -->
   <string name="sprk_masthead_border_bottom">1.00dp solid #fff7f7f7</string><!-- The bottom border on the Masthead. -->
   <string name="sprk_masthead_site_links_border_right">2px solid #ffbababa</string><!-- The right border on the site links in the Masthead. -->
@@ -215,6 +216,7 @@
   <string name="sprk_masthead_shadow_wide">none</string><!-- The box shadow of the Masthead in wide viewports. -->
   <string name="sprk_masthead_shadow_scroll">0 0 40px rgba(0, 0, 0, 0.1)</string><!-- The Masthead shadow that gets applied when the page is scrolled. -->
   <string name="sprk_masthead_selector_border">2px solid #ffbababa</string><!-- The border of the Selector, found in a Masthead with Extended Navigation. -->
+  <string name="sprk_masthead_selector_container_position">relative</string><!-- The position setting of the Selector in the Masthead. -->
   <string name="sprk_masthead_selector_dropdown_z_index">32000.00dp</string><!-- The z-index of the Selector Dropdown, found in a Masthead with Extended Navigation. -->
   <string name="sprk_masthead_selector_dropdown_link_padding">16.00dp 24.00dp</string><!-- The padding of the Selector Dropdown links, found in a Masthead with Extended Navigation. -->
   <string name="sprk_masthead_selector_dropdown_text_decoration">none</string><!-- The text decoration of the Selector Dropdown, found in a Masthead with Extended Navigation. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -62,7 +62,7 @@
   <string name="sprk_dictionary_border">1px solid #fff7f7f7</string><!-- The border surrounding the Dictionary. -->
   <string name="sprk_divider_border_style">solid</string><!-- The style value of border for Dividers. -->
   <string name="sprk_divider_border">2.00dp solid #ffe6e6e6</string><!-- The value of border for Dividers. -->
-  <string name="sprk_dropdown_display_hidden">none</string><!-- The display value of dropdown when hidden. -->
+  <string name="sprk_dropdown_display_hidden">none</string><!-- The display value of Dropdown when hidden. -->
   <string name="sprk_dropdown_active_border">2.5px solid #ff603aa1</string><!-- The left border of the Dropdown item that is active. -->
   <string name="sprk_dropdown_active_box_shadow">-1px 0 0 0 #ff603aa1</string><!-- The box-shadow of the Dropdown item that is active. -->
   <string name="sprk_dropdown_border_style">solid</string><!-- The border style of the Dropdown. -->
@@ -287,6 +287,7 @@
   <string name="sprk_tooltip_preferred_width">max-content</string><!-- The preferred width of the tooltip. -->
   <string name="sprk_tooltip_transition">all 200ms ease-out</string><!-- The transition applied to the tooltip. -->
   <string name="sprk_type_right">right</string><!-- The text align right value. -->
+  <string name="sprk_type_crop_none_content">none</string><!-- The content value for the crop none helper class. -->
   <string name="sprk_type_left">left</string><!-- The text align left value. -->
   <string name="sprk_type_center">center</string><!-- The text align center value. -->
   <string name="sprk_webfonts">''</string><!-- Expects a Sass List containing one or more nested Sass Lists. The nested lists should each contain: A List of urls to download a font, the name of the font and the weight of the font. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -3,6 +3,7 @@
 
 <resources>
   <string name="sprk_accordion_border">2px solid rgb(230, 230, 230)</string><!-- The border of Accordions. -->
+  <string name="sprk_accordion_icon_leading_margin">0 8.00dp 0 0</string><!-- The margin of leading icon in Accordions. -->
   <string name="sprk_accordion_summary_text_decoration">none</string><!-- The text decoration of the Accordion item summary. -->
   <string name="sprk_accordion_summary_text_align">left</string><!-- The text-align value of the Accordion item summary. -->
   <string name="sprk_accordion_summary_active_text_decoration">none</string><!-- The text decoration of the Accordion item summary when active. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -67,6 +67,9 @@
   <string name="sprk_dropdown_border_style">solid</string><!-- The border style of the Dropdown. -->
   <string name="sprk_dropdown_border">1.00dp solid #fff7f7f7</string><!-- The border of the Dropdown. -->
   <string name="sprk_dropdown_shadow">0 0 40px 2px rgba(0, 0, 0, 0.1)</string><!-- The box shadow of the Dropdown. -->
+  <string name="sprk_dropdown_trigger_icon_margin">0 0 0 8.00dp</string><!-- The default margin on the icon inside the Dropdown trigger. -->
+  <string name="sprk_dropdown_trigger_informational_margin">0 8.00dp 0 0</string><!-- The default margin on the informational trigger for the Dropdown. -->
+  <string name="sprk_footer_divider_margin">0 16.00dp 0 16.00dp</string><!-- Margin value for the Divider in the Footer. -->
   <string name="sprk_footer_trigger_font_weight">normal</string><!-- Toggle trigger font-weight on the Footer. -->
   <string name="sprk_footer_trigger_hover_font_weight">normal</string><!-- Toggle trigger hover font-weight on the Footer. -->
   <string name="sprk_footer_trigger_hover_text_decoration">underline</string><!-- Toggle trigger hover text decoration on the Footer. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -229,6 +229,7 @@
   <string name="sprk_masthead_selector_hover_border">2px solid #ff603aa1</string><!-- The border of the Selector when hovered, found in a Masthead with Extended Navigation. -->
   <string name="sprk_masthead_transition">all 0.3s ease-in</string><!-- The transition applied to the Masthead. -->
   <string name="sprk_masthead_translate_y">translateY(-100%)</string><!-- The transform length that gets applied when the Masthead scrolls out of view on narrow screens. -->
+  <string name="sprk_masthead_accordion_icon_leading_margin">0 8.00dp 0 0</string><!-- The margin for the leading Masthead accordion icon -->
   <string name="sprk_masthead_accordion_active_left_border">3px solid #ffc8102e</string><!-- The left border of the active item in the navigation links when masthead is on narrow viewports. -->
   <string name="sprk_masthead_accordion_item_text_align">left</string><!-- The text alignment of the items in the navigation links when masthead is on narrow viewports. -->
   <string name="sprk_masthead_accordion_item_background">transparent</string><!-- The background of the items in the navigation links when masthead is on narrow viewports. -->
@@ -237,6 +238,7 @@
   <string name="sprk_big_nav_item_border_bottom">0.125rem solid transparent</string><!-- The border bottom of the big navigation items in the Masthead Extended. -->
   <string name="sprk_big_nav_item_open_border_bottom">0.125rem solid #ffc8102e</string><!-- The border bottom of open big navigation items in the Masthead Extended. -->
   <string name="sprk_menu_icon_transition">transform 0.3s ease-in-out, opacity 0.2s ease-in-out</string><!-- The transition on the menu icon that turns the menu icon into an 'X'. -->
+  <string name="sprk_modal_display_hidden">none</string><!-- The value for the display property when Modal is hidden. -->
   <string name="sprk_modal_shadow">0 4px 5px rgba(0, 0, 0, 0.6)</string><!-- The box shadow on the Modal. -->
   <string name="sprk_promo_border">1px solid #ffa4a4a3</string><!-- The border of the Promo component. -->
   <string name="sprk_promo_margin">0 auto</string><!-- The margin of the Promo component. -->

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -172,6 +172,7 @@
   <string name="sprk_checkbox_checkmark_border_bottom">2px solid #ffffffff</string><!-- The border settings to create the right portion of the checkmark. -->
   <string name="sprk_checkbox_checkmark_transform">rotate(-45deg)</string><!-- The rotation setting to create the checkmark. -->
   <string name="sprk_link_transition">0.3s</string><!-- The transition timing for hover, active and focus styles on Links. -->
+  <string name="sprk_link_icon_margin">0 8.00dp 0 0</string><!-- The default margin on icons inside Links. -->
   <string name="sprk_link_text_decoration">none</string><!-- The text decoration on Links. -->
   <string name="sprk_link_border_bottom_style">solid</string><!-- The border style of the underline on Links. -->
   <string name="sprk_link_border_bottom">2.00dp solid #ff603aa1</string><!-- The style of the underline on Links. -->
@@ -254,6 +255,7 @@
   <string name="sprk_tab_navigation_btn_active_border_bottom">3px solid #ffc8102e</string><!-- The button tab bottom border of the currently active tab in Tabbed Navigation. -->
   <string name="sprk_tab_navigation_btn_border_bottom">3px solid #fff7f7f7</string><!-- The border on the bottom of the button tabs in Tabbed Navigation. -->
   <string name="sprk_tab_navigation_btn_hover_border_bottom">3px solid #ff603aa1</string><!-- The border on the bottom of the button tabs on hover in Tabbed Navigation. -->
+  <string name="sprk_toggle_trigger_icon_margin">0 8.00dp 0 0</string><!-- The default margin on the icon inside the Toggle trigger. -->
   <string name="sprk_toggle_trigger_border_top">none</string><!-- The top border style for Toggle Trigger. -->
   <string name="sprk_toggle_trigger_border_right">none</string><!-- The right border style for Toggle Trigger. -->
   <string name="sprk_toggle_trigger_border_bottom">0.00dp solid transparent</string><!-- The bottom border style for Toggle Trigger. -->

--- a/styles/base/_links.scss
+++ b/styles/base/_links.scss
@@ -107,6 +107,9 @@
   fill: $sprk-link-has-icon-fill;
   stroke: $sprk-link-has-icon-stroke;
   transition: $sprk-link-has-icon-transition;
+}
+
+.sprk-b-Link__icon {
   margin: $sprk-link-icon-margin;
 }
 

--- a/styles/base/_links.scss
+++ b/styles/base/_links.scss
@@ -101,11 +101,13 @@
   }
 }
 
-.sprk-b-Link--has-icon .sprk-c-Icon {
+.sprk-b-Link--has-icon .sprk-c-Icon,
+.sprk-b-Link--has-icon .sprk-b-Link__icon {
   color: $sprk-link-has-icon-color-icon;
   fill: $sprk-link-has-icon-fill;
   stroke: $sprk-link-has-icon-stroke;
   transition: $sprk-link-has-icon-transition;
+  margin: $sprk-link-icon-margin;
 }
 
 .sprk-b-Link--has-icon:hover .sprk-c-Icon,

--- a/styles/base/_typography.scss
+++ b/styles/base/_typography.scss
@@ -268,6 +268,29 @@ body,
   }
 }
 
+// Type Helpers
 .sprk-b-Type--center {
-  text-align: center;
+  text-align: $sprk-type-center;
+}
+
+.sprk-b-Type--left {
+  text-align: $sprk-type-left;
+}
+
+.sprk-b-Type--right {
+  text-align: $sprk-type-right;
+}
+
+/// When placed on an element that contains text or any of
+/// the typography classes, it will remove the text cropping
+/// and the negative margins applied by the crop.
+/// NOTE: There is also a util available that utilizes !important if you
+/// need that instead, `.sprk-u-TextCrop--none`
+.sprk-b-Type--crop-none {
+  &::before,
+  &::after {
+    content: none;
+    margin-bottom: 0;
+    margin-top: 0;
+  }
 }

--- a/styles/base/_typography.scss
+++ b/styles/base/_typography.scss
@@ -289,8 +289,8 @@ body,
 .sprk-b-Type--crop-none {
   &::before,
   &::after {
-    content: none;
-    margin-bottom: 0;
-    margin-top: 0;
+    content: $sprk-type-crop-none-content;
+    margin-bottom: $sprk-type-crop-none-margin-bottom;
+    margin-top: $sprk-type-crop-none-margin-top;
   }
 }

--- a/styles/base/_typography.scss
+++ b/styles/base/_typography.scss
@@ -267,3 +267,7 @@ body,
     }
   }
 }
+
+.sprk-b-Type--center {
+  text-align: center;
+}

--- a/styles/components/_accordions.scss
+++ b/styles/components/_accordions.scss
@@ -32,6 +32,10 @@
   flex: 0 0 auto;
 }
 
+.sprk-c-Accordion__icon--leading {
+  margin: $sprk-accordion-icon-leading-margin;
+}
+
 .sprk-c-Accordion__summary {
   align-items: center;
   background-color: $sprk-accordion-summary-background-color;

--- a/styles/components/_alerts.scss
+++ b/styles/components/_alerts.scss
@@ -15,6 +15,10 @@
   justify-content: center;
 }
 
+.sprk-c-Alert--is-hidden {
+  display: none;
+}
+
 /// Styles the alert as an information alert.
 .sprk-c-Alert--info {
   background-color: $sprk-alert-bg-color-info;

--- a/styles/components/_alerts.scss
+++ b/styles/components/_alerts.scss
@@ -16,7 +16,7 @@
 }
 
 .sprk-c-Alert--is-hidden {
-  display: none;
+  display: $sprk-alert-display-hidden;
 }
 
 /// Styles the alert as an information alert.

--- a/styles/components/_card.scss
+++ b/styles/components/_card.scss
@@ -34,6 +34,10 @@
   color: $sprk-card-header-text-color;
 }
 
+.sprk-c-Card__highlighted-heading {
+  color: $sprk-card-highlighted-heading-color;
+}
+
 .sprk-c-Card__media,
 .sprk-c-Card__header {
   border-radius: $sprk-card-border-radius $sprk-card-border-radius 0 0;

--- a/styles/components/_dropdown.scss
+++ b/styles/components/_dropdown.scss
@@ -86,6 +86,14 @@
   }
 }
 
+.sprk-c-Dropdown__trigger--informational {
+  margin: $sprk-dropdown-trigger-informational-margin;
+}
+
+.sprk-c-Dropdown__trigger-icon {
+  margin: $sprk-dropdown-trigger-icon-margin;
+}
+
 /// Adds styles to indicate that the dropdown
 /// link is currently active.
 .sprk-c-Dropdown__link--active {

--- a/styles/components/_dropdown.scss
+++ b/styles/components/_dropdown.scss
@@ -5,7 +5,6 @@
 ////
 /// @group dropdown
 ////
-
 .sprk-c-Dropdown {
   background-color: $sprk-white;
   border: $sprk-dropdown-border;
@@ -18,6 +17,10 @@
   margin-top: $sprk-space-xs;
   width: auto;
   z-index: $sprk-layer-height-m;
+}
+
+.sprk-c-Dropdown--is-hidden {
+  display: $sprk-dropdown-display-hidden;
 }
 
 .sprk-c-Dropdown__header {

--- a/styles/components/_footer.scss
+++ b/styles/components/_footer.scss
@@ -13,8 +13,24 @@
   color: $sprk-footer-text-color;
 }
 
+.sprk-c-Footer__awards {
+  padding: $sprk-footer-awards-padding;
+}
+
+.sprk-c-Footer__awards-media {
+  margin: $sprk-footer-awards-media-margin;
+}
+
 .sprk-c-Footer__divider {
   margin: $sprk-footer-divider-margin;
+}
+
+.sprk-c-Footer__global-links {
+  padding: $sprk-footer-global-links-padding;
+}
+
+.sprk-c-Footer__local-links {
+  padding: $sprk-footer-local-links-padding;
 }
 
 .sprk-c-Footer__link {

--- a/styles/components/_footer.scss
+++ b/styles/components/_footer.scss
@@ -13,6 +13,10 @@
   color: $sprk-footer-text-color;
 }
 
+.sprk-c-Footer__divider {
+  margin: $sprk-footer-divider-margin;
+}
+
 .sprk-c-Footer__link {
   color: $sprk-footer-link-color;
   font-weight: $sprk-footer-link-font-weight;

--- a/styles/components/_masthead.scss
+++ b/styles/components/_masthead.scss
@@ -83,6 +83,11 @@
   }
 }
 
+.sprk-c-Masthead__dropdown {
+  margin: $sprk-masthead-dropdown-margin;
+  right: $sprk-masthead-dropdown-right;
+}
+
 // When open, adjust box shadow and border styles
 .sprk-c-Masthead--open .sprk-c-Masthead__content,
 .sprk-c-Masthead--is-open .sprk-c-Masthead__content {
@@ -194,6 +199,10 @@
   .sprk-c-Icon {
     color: $sprk-masthead-simple-link-icon-hover-color;
   }
+}
+
+.sprk-c-Masthead__selector-container {
+  position: $sprk-masthead-selector-container-position;
 }
 
 // Selector has 100% default width

--- a/styles/components/_masthead.scss
+++ b/styles/components/_masthead.scss
@@ -205,6 +205,10 @@
   position: $sprk-masthead-selector-container-position;
 }
 
+.sprk-c-Masthead__selector-icon {
+  margin: $sprk-masthead-selector-icon-margin;
+}
+
 // Selector has 100% default width
 // then grows to size of content on larger views
 .sprk-c-Masthead__selector {

--- a/styles/components/_masthead.scss
+++ b/styles/components/_masthead.scss
@@ -484,6 +484,10 @@
   flex: 0 0 auto;
 }
 
+.sprk-c-MastheadAccordion__icon--leading {
+  margin: $sprk-masthead-accordion-icon-leading-margin;
+}
+
 .sprk-c-MastheadAccordion__summary {
   align-items: center;
   color: $sprk-masthead-accordion-font-color;

--- a/styles/components/_modals.scss
+++ b/styles/components/_modals.scss
@@ -75,3 +75,8 @@
   color: $sprk-black-tint-50;
   flex: 0 1 auto;
 }
+
+.sprk-c-Modal--is-hidden,
+.sprk-c-ModalMask--is-hidden {
+  display: $sprk-modal-display-hidden;
+}

--- a/styles/components/_stepper.scss
+++ b/styles/components/_stepper.scss
@@ -10,7 +10,6 @@
   max-width: $sprk-stepper-max-width;
   position: relative;
 }
-
 .sprk-c-Stepper__slider {
   position: absolute;
   top: 0;
@@ -32,6 +31,10 @@
   .sprk-c-Stepper__step-icon {
     transition: opacity $sprk-stepper-slide-timing ease;
   }
+}
+
+.sprk-c-Stepper__container-dark {
+  background-color: $sprk-stepper-dark-bg;
 }
 
 .sprk-c-Stepper__slider--active .sprk-c-Stepper__step-heading,

--- a/styles/components/_toggle.scss
+++ b/styles/components/_toggle.scss
@@ -8,7 +8,6 @@
 
 // Future proofing classes that don't have styles right now but might later.
 // .sprk-c-Toggle
-// .sprk-c-Toggle__content
 .sprk-c-Toggle__trigger {
   border-bottom: $sprk-toggle-trigger-border-bottom;
   text-decoration: $sprk-toggle-trigger-text-decoration;
@@ -39,6 +38,15 @@
   &:focus:not(.focus-visible) {
     outline: none;
   }
+}
+
+.sprk-c-Toggle__content {
+  padding-top: $sprk-toggle-content-padding-top;
+  padding-bottom: $sprk-toggle-content-padding-bottom;
+}
+
+.sprk-c-Toggle__trigger-icon {
+  margin: $sprk-toggle-trigger-icon-margin;
 }
 
 /// A toggle with a smaller font.

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -550,7 +550,6 @@ public class SparkDesignTokens {
     public static let sprkLineHeightDisplayTwoWide = CGFloat(16.00)
     public static let sprkLinkDisabledUnderlineWidth = CGFloat(0.00)
     public static let sprkLinkHasIconUnderlineWidth = CGFloat(0.00)
-    public static let sprkLinkIconMargin = 0 CGFloat(8.00) 0 0
     public static let sprkLinkInlineLightHoverUnderlineWidth = CGFloat(2.00)
     public static let sprkLinkInlineLightUnderlineWidth = CGFloat(2.00)
     public static let sprkLinkLightHoverAfterLeft = CGFloat(0.00)
@@ -711,7 +710,6 @@ public class SparkDesignTokens {
     public static let sprkTextareaWidth = CGFloat(1600.00)
     public static let sprkToggleContentPaddingBottom = CGFloat(8.00)
     public static let sprkToggleContentPaddingTop = CGFloat(8.00)
-    public static let sprkToggleTriggerIconMargin = 0 CGFloat(8.00) 0 0
     public static let sprkToggleTriggerPaddingBottom = CGFloat(0.00)
     public static let sprkToggleTriggerPaddingLeft = CGFloat(0.00)
     public static let sprkToggleTriggerPaddingRight = CGFloat(0.00)

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -576,6 +576,7 @@ public class SparkDesignTokens {
     public static let sprkMastheadContentItemPaddingTopWide = CGFloat(8.00)
     public static let sprkMastheadContentPadding = CGFloat(8.00)
     public static let sprkMastheadContentPaddingWide = CGFloat(16.00)
+    public static let sprkMastheadDropdownRight = CGFloat(0.00)
     public static let sprkMastheadLogoMaxWidth = CGFloat(192.00)
     public static let sprkMastheadLogoMinWidth = CGFloat(174.00)
     public static let sprkMastheadMenuIconHeight = CGFloat(32.00)

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -195,6 +195,7 @@ public class SparkDesignTokens {
     public static let sprkPurpleLightest = UIColor(red: 0.906, green: 0.886, blue: 0.949, alpha:1)
     public static let sprkPurpleNavy = UIColor(red: 0.110, green: 0.004, blue: 0.322, alpha:1)
     public static let sprkRed = UIColor(red: 0.784, green: 0.063, blue: 0.180, alpha:1)
+    public static let sprkStepperDarkBg = UIColor(red: 0.235, green: 0.192, blue: 0.455, alpha:1)
     public static let sprkStepperIconBorderColor = UIColor(red: 0.553, green: 0.553, blue: 0.549, alpha:1)
     public static let sprkStepperIconBorderColorSelected = UIColor(red: 0.235, green: 0.192, blue: 0.455, alpha:1)
     public static let sprkStepperIconBorderColorSelectedDarkBg = UIColor(red: 0.906, green: 0.886, blue: 0.949, alpha:1)

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -550,6 +550,7 @@ public class SparkDesignTokens {
     public static let sprkLineHeightDisplayTwoWide = CGFloat(16.00)
     public static let sprkLinkDisabledUnderlineWidth = CGFloat(0.00)
     public static let sprkLinkHasIconUnderlineWidth = CGFloat(0.00)
+    public static let sprkLinkIconMargin = 0 CGFloat(8.00) 0 0
     public static let sprkLinkInlineLightHoverUnderlineWidth = CGFloat(2.00)
     public static let sprkLinkInlineLightUnderlineWidth = CGFloat(2.00)
     public static let sprkLinkLightHoverAfterLeft = CGFloat(0.00)
@@ -708,6 +709,9 @@ public class SparkDesignTokens {
     public static let sprkTextareaMinHeight = CGFloat(125.00)
     public static let sprkTextareaPadding = CGFloat(16.00)
     public static let sprkTextareaWidth = CGFloat(1600.00)
+    public static let sprkToggleContentPaddingBottom = CGFloat(8.00)
+    public static let sprkToggleContentPaddingTop = CGFloat(8.00)
+    public static let sprkToggleTriggerIconMargin = 0 CGFloat(8.00) 0 0
     public static let sprkToggleTriggerPaddingBottom = CGFloat(0.00)
     public static let sprkToggleTriggerPaddingLeft = CGFloat(0.00)
     public static let sprkToggleTriggerPaddingRight = CGFloat(0.00)

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -206,6 +206,7 @@ public class SparkDesignTokens {
     public static let sprkWhite = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
     public static let sprkWisteria = UIColor(red: 0.871, green: 0.694, blue: 0.992, alpha:1)
     public static let sprkYellow = UIColor(red: 0.929, green: 0.639, blue: 0.008, alpha:1)
+    public static let sprkAlertDisplayHidden = none
     public static let sprkDatePickerArrowColor = UIColor(red: 0.110, green: 0.106, blue: 0.102, alpha:1)
     public static let sprkDatePickerBackground = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
     public static let sprkDatePickerDayColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
@@ -724,6 +725,8 @@ public class SparkDesignTokens {
     public static let sprkTooltipMinWidth = CGFloat(60.00)
     public static let sprkTooltipTriggerHoverOffset = CGFloat(16.00)
     public static let sprkTooltipTriggerPadding = CGFloat(0.00)
+    public static let sprkTypeCropNoneMarginBottom = CGFloat(0.00)
+    public static let sprkTypeCropNoneMarginTop = CGFloat(0.00)
     public static let sprkTypeDisplayOneBreakpoint = CGFloat(700.00)
     public static let sprkTypeDisplayThreeBreakpoint = CGFloat(700.00)
     public static let sprkTypeDisplayTwoBreakpoint = CGFloat(700.00)

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -125,6 +125,7 @@ public class SparkDesignTokens {
     public static let sprkBtnTextColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
     public static let sprkCardHeaderBgColor = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
     public static let sprkCardHeaderTextColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
+    public static let sprkCardHighlightedHeadingColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
     public static let sprkCardShadowColorStandout = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha:0.1)
     public static let sprkCardShadowColorStandoutWideViewport = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha:0.1)
     public static let sprkCardShadowColorWideViewport = UIColor(red: 0.000, green: 0.000, blue: 0.000, alpha:0.08)

--- a/styles/objects/_stack.scss
+++ b/styles/objects/_stack.scss
@@ -15,6 +15,12 @@
   width: 100%;
 }
 
+/// Centers children of the Stack.
+.sprk-o-Stack--center-all {
+  align-items: center;
+  justify-content: center;
+}
+
 /// When placed on a container, its children will be
 /// centered along the main-axis of the container.
 .sprk-o-Stack--center-row {
@@ -388,7 +394,7 @@
     &.sprk-o-Stack--misc-d > .sprk-o-Stack__item {
       margin-right: $sprk-stack-spacing-misc-d;
     }
-    
+
     /* stylelint-enable selector-class-pattern */
     > .sprk-o-Stack__item--sixth\@xxs {
       flex: 0 0 16.666666667%;

--- a/styles/tokens/accordion.json
+++ b/styles/tokens/accordion.json
@@ -18,6 +18,15 @@
       "file": "settings",
       "themable": true
     },
+    "icon-leading-margin": {
+      "comment": "The margin of leading icon in Accordions.",
+      "value": "0 {space.s.value} 0 0",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "settings",
+      "themable": true
+    },
     "summary": {
       "text": {
         "decoration": {

--- a/styles/tokens/alert.json
+++ b/styles/tokens/alert.json
@@ -9,6 +9,15 @@
       "file": "settings",
       "themable": true
     },
+    "display-hidden": {
+      "comment": "Value for display for the hidden Alert component.",
+      "value": "none",
+      "attributes": {
+        "category": "contemt"
+      },
+      "file": "settings",
+      "themable": true
+    },
     "border-color": {
       "comment": "Value for border color on the Alert component.",
       "value": "{gray.value}",

--- a/styles/tokens/card.json
+++ b/styles/tokens/card.json
@@ -105,6 +105,15 @@
         "file": "settings",
         "themable": true
       },
+      "highlighted-heading-color": {
+        "comment": "The color of the highlighted heading for the Highlighted Header Card.",
+        "value": "{white.value}",
+         "attributes": {
+          "category": "color"
+        },
+        "file": "settings",
+        "themable": true
+      },
       "header-text-color": {
         "comment": "The text color for the Highlighted Header Card.",
         "value": "{white.value}",

--- a/styles/tokens/dropdown.json
+++ b/styles/tokens/dropdown.json
@@ -1,7 +1,7 @@
   {
     "dropdown": {
       "display-hidden": {
-        "comment": "The display value of dropdown when hidden.",
+        "comment": "The display value of Dropdown when hidden.",
         "value": "none",
         "attributes": {
           "category": "content"

--- a/styles/tokens/dropdown.json
+++ b/styles/tokens/dropdown.json
@@ -1,5 +1,14 @@
   {
     "dropdown": {
+      "display-hidden": {
+        "comment": "The display value of dropdown when hidden.",
+        "value": "none",
+        "attributes": {
+          "category": "content"
+        },
+        "file": "settings",
+        "themable": true
+      },
       "active": {
         "background-color": {
           "comment": "Background color of the Dropdown items that are active or hovered.",

--- a/styles/tokens/dropdown.json
+++ b/styles/tokens/dropdown.json
@@ -137,6 +137,24 @@
         }
       },
       "trigger": {
+        "icon-margin": {
+          "comment": "The default margin on the icon inside the Dropdown trigger.",
+          "value": "0 0 0 {space.s.value}",
+          "attributes": {
+            "category": "content"
+          },
+          "file": "settings",
+          "themable": true
+        },
+        "informational-margin": {
+          "comment": "The default margin on the informational trigger for the Dropdown.",
+          "value": "0 {space.s.value} 0 0",
+          "attributes": {
+            "category": "content"
+          },
+          "file": "settings",
+          "themable": true
+        },
         "color": {
           "comment": "The color of the Dropdown trigger.",
           "value": "{black.value}",

--- a/styles/tokens/footer.json
+++ b/styles/tokens/footer.json
@@ -18,6 +18,15 @@
       "file": "settings",
       "themable": true
     },
+    "divider-margin": {
+      "comment": "Margin value for the Divider in the Footer.",
+      "value": "0 {space.m.value} 0 {space.m.value}",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "settings",
+      "themable": true
+    },
     "link": {
       "color": {
         "comment": "Link color on the Footer.",

--- a/styles/tokens/footer.json
+++ b/styles/tokens/footer.json
@@ -18,6 +18,42 @@
       "file": "settings",
       "themable": true
     },
+    "awards-media-margin": {
+      "comment": "Margin setting for the awards media section in the Footer.",
+      "value": "0 0 {space.m.value} 0",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "settings",
+      "themable": true
+    },
+    "global-links-padding": {
+      "comment": "Padding setting for the global links section in the Footer.",
+      "value": "{space.m.value} {space.h.value} {space.m.value} {space.m.value}",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "settings",
+      "themable": true
+    },
+    "local-links-padding": {
+      "comment": "Padding setting for the local links section in the Footer.",
+      "value": "{space.m.value} {space.misc.a.value} {space.m.value} {space.m.value}",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "settings",
+      "themable": true
+    },
+    "awards-padding": {
+      "comment": "Padding setting for the awards section in the Footer.",
+      "value": "{space.misc.b.value} {space.m.value} {space.m.value} {space.m.value}",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "settings",
+      "themable": true
+    },
     "divider-margin": {
       "comment": "Margin value for the Divider in the Footer.",
       "value": "0 {space.m.value} 0 {space.m.value}",

--- a/styles/tokens/link.json
+++ b/styles/tokens/link.json
@@ -9,6 +9,15 @@
       "file": "settings",
       "themable": true
     },
+    "icon-margin": {
+      "comment": "The default margin on icons inside Links.",
+      "value": "0 {space.s.value} 0 0",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "settings",
+      "themable": true
+    },
     "color": {
       "comment": "The default color on Links.",
       "value": "{purple.value}",

--- a/styles/tokens/masthead.json
+++ b/styles/tokens/masthead.json
@@ -26,6 +26,26 @@
         "file": "settings",
         "themable": true
       },
+      "dropdown": {
+        "margin": {
+          "comment": "The margin color of the dropdown in the Masthead.",
+          "value": "0 {space.m.value} 0 0",
+          "attributes": {
+            "category": "content"
+          },
+          "file": "settings",
+          "themable": true
+        },
+        "right": {
+          "comment": "The right value of the dropdown in the Masthead.",
+          "value": "0",
+          "attributes": {
+            "category": "size"
+          },
+          "file": "settings",
+          "themable": true
+        }
+      },
       "content": {
         "padding": {
           "comment": "The padding around the content section in the Masthead on wide viewports.",
@@ -262,6 +282,15 @@
         "border": {
           "comment": "The border of the Selector, found in a Masthead with Extended Navigation.",
           "value": "2px solid {black-tint.30.value}",
+          "attributes": {
+            "category": "content"
+          },
+          "file": "settings",
+          "themable": true
+        },
+        "container-position": {
+          "comment": "The position setting of the Selector in the Masthead.",
+          "value": "relative",
           "attributes": {
             "category": "content"
           },

--- a/styles/tokens/masthead.json
+++ b/styles/tokens/masthead.json
@@ -583,6 +583,17 @@
         "themable": true
       },
       "accordion": {
+        "icon": {
+          "leading-margin": {
+            "comment": "The margin for the leading Masthead accordion icon",
+            "value": "0 {space.s.value} 0 0",
+            "attributes": {
+              "category": "content"
+            },
+            "file": "settings",
+            "themable": true
+          }
+        },
         "active": {
           "left-border": {
             "comment": "The left border of the active item in the navigation links when masthead is on narrow viewports.",

--- a/styles/tokens/masthead.json
+++ b/styles/tokens/masthead.json
@@ -288,6 +288,15 @@
           "file": "settings",
           "themable": true
         },
+        "icon-margin": {
+          "comment": "The margin for the icon in the selector in the Masthead.",
+          "value": " 0 {space.s.value} 0 {space.s.value}",
+          "attributes": {
+            "category": "content"
+          },
+          "file": "settings",
+          "themable": true
+        },
         "container-position": {
           "comment": "The position setting of the Selector in the Masthead.",
           "value": "relative",

--- a/styles/tokens/modal.json
+++ b/styles/tokens/modal.json
@@ -29,6 +29,15 @@
         "file": "settings",
         "themable": true
       },
+      "display-hidden": {
+        "comment": "The value for the display property when Modal is hidden.",
+        "value": "none",
+        "attributes": {
+          "category": "content"
+        },
+        "file": "settings",
+        "themable": true
+      },
       "color": {
         "comment": "The background color of the Modal.",
         "value": "{white.value}",

--- a/styles/tokens/stepper.json
+++ b/styles/tokens/stepper.json
@@ -9,6 +9,15 @@
         "file": "settings",
         "themable": true
       },
+      "dark-bg": {
+        "comment": "The background color of the Stepper with a dark background.",
+        "value": "{purple-dark.value}",
+        "attributes": {
+          "category": "color"
+        },
+        "file": "settings",
+        "themable": true
+      },
       "breakpoint": {
         "comment": "The minimum width at which the Stepper switches between narrow and wide layouts.",
         "value": "{split.breakpoint.xl.value}",

--- a/styles/tokens/toggle.json
+++ b/styles/tokens/toggle.json
@@ -1,6 +1,15 @@
   {
     "toggle": {
       "trigger": {
+        "icon-margin": {
+          "comment": "The default margin on the icon inside the Toggle trigger.",
+          "value": "0 {space.s.value} 0 0",
+          "attributes": {
+            "category": "content"
+          },
+          "file": "settings",
+          "themable": true
+        },
         "border": {
           "top": {
             "comment": "The top border style for Toggle Trigger.",
@@ -150,6 +159,28 @@
         "value": "{toggle.trigger.hover.color.value}",
         "file": "settings",
         "themable": true
+      },
+      "content": {
+        "padding": {
+          "top": {
+            "comment": "The padding top for the content in the Toggle.",
+            "value": "{space.s.value}",
+            "attributes": {
+              "category": "size"
+            },
+            "file": "settings",
+            "themable": true
+          },
+          "bottom": {
+            "comment": "The padding bottom for the content in the Toggle.",
+            "value": "{space.s.value}",
+            "attributes": {
+              "category": "size"
+            },
+            "file": "settings",
+            "themable": true
+          }
+        }
       },
       "transition-timing": {
         "comment": "The transition timing for the rotation of the icon when the Toggle is opened.",

--- a/styles/tokens/typography.json
+++ b/styles/tokens/typography.json
@@ -1,11 +1,11 @@
 {
-  "typography":{
+  "typography": {
     "breakpoint": {
       "comment": "The breakpoint used for typography.",
       "value": "54rem",
       "attributes": {
-          "category": "size"
-        },
+        "category": "size"
+      },
       "file": "typography",
       "themable": true
     }
@@ -18,6 +18,35 @@
     },
     "file": "typography",
     "themable": true
+  },
+  "type": {
+    "right": {
+      "comment": "The text align right value.",
+      "value": "right",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "typography",
+      "themable": true
+    },
+    "left": {
+      "comment": "The text align left value.",
+      "value": "left",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "typography",
+      "themable": true
+    },
+    "center": {
+      "comment": "The text align center value.",
+      "value": "center",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "typography",
+      "themable": true
+    }
   },
   "narrow-measure": {
     "comment": "The max-width value for the narrow measure.",

--- a/styles/tokens/typography.json
+++ b/styles/tokens/typography.json
@@ -29,6 +29,35 @@
       "file": "typography",
       "themable": true
     },
+    "crop-none": {
+      "content": {
+        "comment": "The content value for the crop none helper class.",
+        "value": "none",
+        "attributes": {
+          "category": "content"
+        },
+        "file": "typography",
+        "themable": true
+      },
+      "margin-bottom": {
+        "comment": "The margin bottom value for the crop none helper class.",
+        "value": "0",
+        "attributes": {
+          "category": "size"
+        },
+        "file": "typography",
+        "themable": true
+      },
+      "margin-top": {
+        "comment": "The margin top value for the crop none helper class.",
+        "value": "0",
+        "attributes": {
+          "category": "size"
+        },
+        "file": "typography",
+        "themable": true
+      }
+    },
     "left": {
       "comment": "The text align left value.",
       "value": "left",


### PR DESCRIPTION
## What does this PR do?
Removes the use of utility classes from Spark, this touches all three frameworks. It does not remove the height--100, overflow hidden (from masthead) and hidewhenjs, and visibility hidden (from stepper). We decided those were ok to leave in.

### Associated Issue
Request

### Documentation
 - [ ] Update Spark Docs

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team