### PR TITLE
HTML Spinner Hotfix

### DIFF
--- a/html/components/button.stories.js
+++ b/html/components/button.stories.js
@@ -47,6 +47,9 @@ after Spark's JavaScript functions run.
   spinning. Defaults to an empty string.
   - \`data-sprk-spinner-variant="primary|secondary|dark"\` – The variant
   for the spinning icon.
+  - \`data-sprk-spinner="is-not-disabled"\` – This is identical to
+  \`data-sprk-spinner="click"\` except the button will not be disabled when it
+  is clicked. This should be used for buttons that submit a form.
 
 
 ###### Example Spinner Implementation

--- a/html/components/spinners.js
+++ b/html/components/spinners.js
@@ -32,13 +32,19 @@ const setSpinning = (element, options) => {
   const spinningAriaLabel = options.ariaLabel || 'Loading';
   const ariaValueText = options.ariaValueText || 'Loading';
   const role = options.role || 'progressbar';
+  const doNotDisable = options.doNotDisable || false;
 
   el.classList.add('sprk-c-Button--has-spinner');
   el.setAttribute('aria-label', spinningAriaLabel);
   el.setAttribute('data-sprk-spinner-text', el.textContent);
-  el.setAttribute('disabled', '');
   el.setAttribute('data-sprk-has-spinner', 'true');
   el.setAttribute('style', `width: ${width}px`);
+
+  // This flag should be used for submit buttons so that
+  // the disabled attribute does not suppress the submit behavior.
+  if (!doNotDisable) {
+    el.setAttribute('disabled', '');
+  }
 
   el.innerHTML = `
     <div
@@ -77,6 +83,37 @@ const spinners = () => {
     options.ariaValueText = spinnerContainer.getAttribute(
       'data-sprk-aria-valuetext',
     );
+
+    spinnerContainer.addEventListener('click', (e) => {
+      if (!e.target.hasAttribute('data-sprk-has-spinner')) {
+        setSpinning(e.target, options);
+      }
+    });
+  });
+
+  /**
+   * This selector is exactly the same as data-sprk-spinner="click" except
+   * the disabled attribute will not be added to the button when it is
+   * spinning.
+   */
+  getElements('[data-sprk-spinner="is-not-disabled"]', (spinnerContainer) => {
+    const options = {};
+    options.size = spinnerContainer.getAttribute('data-sprk-spinner-size');
+    // TODO: Deprecate lightness option in favor of variant - issue #1292
+    options.lightness = spinnerContainer.getAttribute(
+      'data-sprk-spinner-lightness',
+    );
+    options.ariaLabel = spinnerContainer.getAttribute(
+      'data-sprk-spinner-aria-label',
+    );
+    options.variant = spinnerContainer.getAttribute(
+      'data-sprk-spinner-variant',
+    );
+    options.role = spinnerContainer.getAttribute('data-sprk-spinner-role');
+    options.ariaValueText = spinnerContainer.getAttribute(
+      'data-sprk-aria-valuetext',
+    );
+    options.doNotDisable = true;
 
     spinnerContainer.addEventListener('click', (e) => {
       if (!e.target.hasAttribute('data-sprk-has-spinner')) {

--- a/html/components/spinners.js
+++ b/html/components/spinners.js
@@ -32,7 +32,7 @@ const setSpinning = (element, options) => {
   const spinningAriaLabel = options.ariaLabel || 'Loading';
   const ariaValueText = options.ariaValueText || 'Loading';
   const role = options.role || 'progressbar';
-  const doNotDisable = options.doNotDisable || false;
+  const hasDoNotDisable = options.hasDoNotDisable || false;
 
   el.classList.add('sprk-c-Button--has-spinner');
   el.setAttribute('aria-label', spinningAriaLabel);
@@ -42,7 +42,7 @@ const setSpinning = (element, options) => {
 
   // This flag should be used for submit buttons so that
   // the disabled attribute does not suppress the submit behavior.
-  if (!doNotDisable) {
+  if (!hasDoNotDisable) {
     el.setAttribute('disabled', '');
   }
 
@@ -72,7 +72,7 @@ const spinners = () => {
     const options = {};
 
     if (spinnerType === 'is-not-disabled') {
-      options.doNotDisable = true;
+      options.hasDoNotDisable = true;
     }
 
     options.size = spinnerContainer.getAttribute('data-sprk-spinner-size');

--- a/html/components/spinners.js
+++ b/html/components/spinners.js
@@ -66,8 +66,15 @@ const cancelSpinning = (element) => {
 };
 
 const spinners = () => {
-  getElements('[data-sprk-spinner="click"]', (spinnerContainer) => {
+  getElements('[data-sprk-spinner]', (spinnerContainer) => {
+    const spinnerType = spinnerContainer.getAttribute('data-sprk-spinner');
+
     const options = {};
+
+    if (spinnerType === 'is-not-disabled') {
+      options.doNotDisable = true;
+    }
+
     options.size = spinnerContainer.getAttribute('data-sprk-spinner-size');
     // TODO: Deprecate lightness option in favor of variant - issue #1292
     options.lightness = spinnerContainer.getAttribute(
@@ -83,37 +90,6 @@ const spinners = () => {
     options.ariaValueText = spinnerContainer.getAttribute(
       'data-sprk-aria-valuetext',
     );
-
-    spinnerContainer.addEventListener('click', (e) => {
-      if (!e.target.hasAttribute('data-sprk-has-spinner')) {
-        setSpinning(e.target, options);
-      }
-    });
-  });
-
-  /**
-   * This selector is exactly the same as data-sprk-spinner="click" except
-   * the disabled attribute will not be added to the button when it is
-   * spinning.
-   */
-  getElements('[data-sprk-spinner="is-not-disabled"]', (spinnerContainer) => {
-    const options = {};
-    options.size = spinnerContainer.getAttribute('data-sprk-spinner-size');
-    // TODO: Deprecate lightness option in favor of variant - issue #1292
-    options.lightness = spinnerContainer.getAttribute(
-      'data-sprk-spinner-lightness',
-    );
-    options.ariaLabel = spinnerContainer.getAttribute(
-      'data-sprk-spinner-aria-label',
-    );
-    options.variant = spinnerContainer.getAttribute(
-      'data-sprk-spinner-variant',
-    );
-    options.role = spinnerContainer.getAttribute('data-sprk-spinner-role');
-    options.ariaValueText = spinnerContainer.getAttribute(
-      'data-sprk-aria-valuetext',
-    );
-    options.doNotDisable = true;
 
     spinnerContainer.addEventListener('click', (e) => {
       if (!e.target.hasAttribute('data-sprk-has-spinner')) {

--- a/html/package-lock.json
+++ b/html/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkdesignsystem/spark",
-  "version": "17.0.0",
+  "version": "17.0.1-alpha.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/html/package.json
+++ b/html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sparkdesignsystem/spark",
-  "version": "17.0.0",
+  "version": "17.0.1-alpha.0",
   "description": "Spark is the main package for the Spark Design System. This package contains the JavaScript and components that make up the basic interfaces for Quicken Loans Fintech products.",
   "main": "es5/sparkExports.js",
   "scripts": {

--- a/html/tests/spinners.tests.js
+++ b/html/tests/spinners.tests.js
@@ -287,3 +287,47 @@ describe('cancelSpinning tests', () => {
     ).toBe(false);
   });
 });
+
+describe('spinners with is-not-disabled', () => {
+  let spinnerContainer;
+
+  beforeEach(() => {
+    spinnerContainer = document.createElement('button');
+    spinnerContainer.setAttribute('data-sprk-spinner', 'is-not-disabled');
+    spinnerContainer.textContent = 'Submit';
+
+    sinon.spy(spinnerContainer, 'addEventListener');
+    sinon.spy(spinnerContainer, 'setAttribute');
+
+    document.body.append(spinnerContainer);
+    spinners();
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = '';
+    spinnerContainer.addEventListener.restore();
+    spinnerContainer.setAttribute.restore();
+  });
+
+  it('should start spinning and not be disabled if its clicked', () => {
+    spinnerContainer.click();
+
+    expect(
+      spinnerContainer
+        .querySelector('div')
+        .classList.contains('sprk-c-Spinner--circle'),
+    ).toBe(true);
+
+    expect(spinnerContainer.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('should not start spinning if its already spinning', () => {
+    spinnerContainer.setAttribute('data-sprk-has-spinner', 'true');
+
+    spinnerContainer.click();
+
+    expect(spinnerContainer.querySelector('div')).toBe(null);
+
+    expect(spinnerContainer.hasAttribute('disabled')).toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?
Adds a new data attribute to the HTML Spinner API that allows submit buttons to skip the `disabled` behavior.

![image](https://user-images.githubusercontent.com/1424560/125689863-7caa7ac1-e4c9-4759-8ccf-6cba5045048d.png)

### Documentation
 - [x] Update Spark Docs

### Code
 - [x] Build Component in HTML
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)

![image](https://user-images.githubusercontent.com/1424560/125688691-054a39c0-0dea-499e-80d1-419eda34f5f8.png)


### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
  - [ ] Jaws Inspect
  - [x] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team
