### PR TITLE
React Accordion Console Error Fix

### DIFF
--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.js
@@ -11,7 +11,7 @@ class SprkAccordionItem extends Component {
     // TODO: Remove isDefaultOpen in future issue #1299
     const { isDefaultOpen, isOpen = isDefaultOpen } = this.props;
     this.state = {
-      isOpen: isOpen || false,
+      isItemOpen: isOpen || false,
       height: isOpen ? 'auto' : 0,
     };
     this.toggle = this.toggle.bind(this);
@@ -21,8 +21,8 @@ class SprkAccordionItem extends Component {
     const { onToggle } = this.props;
     e.preventDefault();
     this.setState((prevState) => ({
-      isOpen: !prevState.isOpen,
-      height: !prevState.isOpen ? 'auto' : 0,
+      isItemOpen: !prevState.isItemOpen,
+      height: !prevState.isItemOpen ? 'auto' : 0,
     }));
     if (onToggle) onToggle(e);
   }
@@ -47,19 +47,21 @@ class SprkAccordionItem extends Component {
       iconNameClosed,
       leadingIcon,
       leadingIconAdditionalClasses,
+      isOpen,
+      isDefaultOpen,
       ...other
     } = this.props;
-    const { isOpen, height } = this.state;
+    const { isItemOpen, height } = this.state;
 
     const iconClasses = classnames(
       'sprk-c-Icon--toggle sprk-c-Accordion__icon sprk-c-Icon--xl',
-      { 'sprk-c-Icon--open': isOpen },
+      { 'sprk-c-Icon--open': isItemOpen },
       iconAdditionalClasses,
     );
 
     const itemClassNames = classnames(
       'sprk-c-Accordion__item',
-      { 'sprk-c-Accordion__item--open': isOpen },
+      { 'sprk-c-Accordion__item--open': isItemOpen },
       additionalClasses,
     );
 
@@ -86,7 +88,7 @@ class SprkAccordionItem extends Component {
           additionalClasses="sprk-c-Accordion__summary"
           data-analytics={analyticsString}
           onClick={this.toggle}
-          aria-expanded={isOpen ? 'true' : 'false'}
+          aria-expanded={isItemOpen ? 'true' : 'false'}
         >
           {leadingIcon && (
             <SprkIcon
@@ -96,7 +98,7 @@ class SprkAccordionItem extends Component {
           )}
           <h3 className={headingClassNames}>{heading}</h3>
           <SprkIcon
-            iconName={isOpen ? iconNameOpen : iconNameClosed}
+            iconName={isItemOpen ? iconNameOpen : iconNameClosed}
             additionalClasses={iconClasses}
           />
         </SprkLink>

--- a/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
+++ b/react/src/components/accordions/components/SprkAccordionItem/SprkAccordionItem.test.js
@@ -23,7 +23,7 @@ describe('SprkAccordionItem:', () => {
         test
       </SprkAccordionItem>,
     );
-    expect(wrapper.state().isOpen).toBe(true);
+    expect(wrapper.state().isItemOpen).toBe(true);
   });
 
   it('should default to open if isDefaultOpen is true', () => {
@@ -32,18 +32,18 @@ describe('SprkAccordionItem:', () => {
         test
       </SprkAccordionItem>,
     );
-    expect(wrapper.state().isOpen).toBe(true);
+    expect(wrapper.state().isItemOpen).toBe(true);
   });
 
   it('should toggle open on click', () => {
     const wrapper = mount(
       <SprkAccordionItem heading="test">test</SprkAccordionItem>,
     );
-    expect(wrapper.state().isOpen).toBe(false);
+    expect(wrapper.state().isItemOpen).toBe(false);
     wrapper.find('button').simulate('click');
-    expect(wrapper.state().isOpen).toBe(true);
+    expect(wrapper.state().isItemOpen).toBe(true);
     wrapper.find('button').simulate('click');
-    expect(wrapper.state().isOpen).toBe(false);
+    expect(wrapper.state().isItemOpen).toBe(false);
   });
 
   it('should add a class to icon when opened', () => {


### PR DESCRIPTION
## What does this PR do?
Updates the `SprkAccordionItem` component so that there are no more console errors when passing the props `isDefaultOpen` or `isOpen`.

### Associated Issue
Fixes 2518810

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome

### Screenshots
<img width="926" alt="Screen Shot 2021-07-16 at 10 31 45 AM" src="https://user-images.githubusercontent.com/15703773/125964290-ecb60fdf-9b61-44b7-8fb5-82dfc81effdf.png">

