### PR TITLE
Resolve Dropdown console error

### DIFF
--- a/react/src/components/dropdown/SprkDropdown.js
+++ b/react/src/components/dropdown/SprkDropdown.js
@@ -231,6 +231,7 @@ class SprkDropdown extends Component {
                   value,
                   // eslint-disable-next-line no-shadow
                   idString,
+                  isDefault,
                   ...choicesRest
                 } = choice;
                 const TagName = element || 'a';


### PR DESCRIPTION
## What does this PR do?
Remove `isDefault` from being passed through the spread operator and resolving the console error. 

### Associated Issue
Fixes 2527686

### Code
 - [x] Build Component in React
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
