### PR TITLE
Add additionalClasses input for Angular Modal

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.spec.ts
@@ -1,4 +1,6 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import _ from 'lodash';
+import { cpuUsage } from 'process';
 import { SprkIconComponent } from '../sprk-icon/sprk-icon.component';
 import { SprkModalComponent } from './sprk-modal.component';
 
@@ -41,6 +43,12 @@ describe('SprkModalComponent', () => {
 
   it('should show the modal when isVisible is true', () => {
     expect(modalElement.classList.contains('sprk-c-Modal')).toEqual(true);
+  });
+
+  it('should add additionalClasses if present', () => {
+    component.additionalClasses = 'test';
+    fixture.detectChanges();
+    expect(modalElement.classList.contains('test')).toEqual(true);
   });
 
   it('should not show the modal when isVisible is false', () => {

--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.spec.ts
@@ -1,6 +1,4 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import _ from 'lodash';
-import { cpuUsage } from 'process';
 import { SprkIconComponent } from '../sprk-icon/sprk-icon.component';
 import { SprkModalComponent } from './sprk-modal.component';
 

--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.ts
@@ -12,10 +12,7 @@ import { uniqueId } from 'lodash';
   template: `
     <div
       *ngIf="isVisible"
-      [ngClass]="{
-        'sprk-c-Modal': true,
-        'sprk-c-Modal--wait': modalType === 'wait'
-      }"
+      [ngClass]="getClasses()"
       role="dialog"
       tabindex="1"
       [attr.aria-labelledby]="heading_id"
@@ -104,6 +101,17 @@ import { uniqueId } from 'lodash';
   `,
 })
 export class SprkModalComponent {
+  /**
+   * Expects a space separated string
+   * of classes to be added to the
+   * component.
+   */
+  @Input()
+  additionalClasses: string;
+  /**
+   * The value supplied will be
+   * rendered as the text for the Modal title.
+   */
   @Input()
   title: string;
   /**
@@ -242,5 +250,23 @@ export class SprkModalComponent {
     event.preventDefault();
     this.cancelClick.emit(event);
     this.closeModal(event);
+  }
+
+  /**
+   * @ignore
+   */
+  getClasses(): string {
+    const classArray: string[] = ['sprk-c-Modal'];
+    if (this.modalType === 'wait') {
+      classArray.push('sprk-c-Modal--wait');
+    }
+
+    if (this.additionalClasses) {
+      this.additionalClasses.split(' ').forEach((className) => {
+        classArray.push(className);
+      });
+    }
+
+    return classArray.join(' ');
   }
 }


### PR DESCRIPTION
## What does this PR do?
Adds the `additionalClasses` input on `sprk-modal` in Angular.

### Associated Issue
Fixes 2397868

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome

