### PR TITLE
update angular 11 pkg json version

### DIFF
--- a/angular/projects/spark-angular/package.json
+++ b/angular/projects/spark-angular/package.json
@@ -12,15 +12,15 @@
   },
   "schematics": "./schematics/collection.json",
   "peerDependencies": {
-    "@angular/animations": ">=7.0.0 < 9.2.0",
-    "@angular/common": ">=7.0.0 < 9.2.0",
-    "@angular/compiler": ">=7.0.0 < 9.2.0",
-    "@angular/compiler-cli": ">=7.0.0 < 9.2.0",
-    "@angular/core": ">=7.0.0 < 9.2.0",
-    "@angular/forms": ">=7.0.0 < 9.2.0",
-    "@angular/platform-browser": ">=7.0.0 < 9.2.0",
-    "@angular/platform-browser-dynamic": ">=7.0.0 < 9.2.0",
-    "@angular/router": ">=7.0.0 < 9.2.0"
+    "@angular/animations": ">=7.0.0 < 11.2.14",
+    "@angular/common": ">=7.0.0 < 11.2.14",
+    "@angular/compiler": ">=7.0.0 < 11.2.14",
+    "@angular/compiler-cli": ">=7.0.0 < 11.2.14",
+    "@angular/core": ">=7.0.0 < 11.2.14",
+    "@angular/forms": ">=7.0.0 < 11.2.14",
+    "@angular/platform-browser": ">=7.0.0 < 11.2.14",
+    "@angular/platform-browser-dynamic": ">=7.0.0 < 11.2.14",
+    "@angular/router": ">=7.0.0 < 11.2.14"
   },
   "dependencies": {
     "@sparkdesignsystem/spark-styles": "^3.0.0",


### PR DESCRIPTION
## What does this PR do?
Doesn't change how package is built, just changes the pkg.json to remove the warning. Works in angular 11 on local. I tested the current spark package in my starter repo app that i upgraded to angular 11 in the browsers on my local mac. 

### Associated Issue
Fixes (Issue Number that this PR is closing out) - not sure if there is an issue

### Code
 - [x] Build Component in Angular
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [x] Apple Safari
  - [ ] Apple Safari (Mobile)
