### PR TITLE
Fix broken typography link

### DIFF
--- a/src/pages/using-spark/foundations/typography.mdx
+++ b/src/pages/using-spark/foundations/typography.mdx
@@ -103,7 +103,7 @@ Our guidelines optimize content hierarchy by using text sizes, line heights, col
 
 Use one Page Title per page to serve as the main heading. They differentiate themselves from other headings with their red accent line.
 
-Use either [Display One](#display-one) or [Display Two](display-two) to style this heading.
+Use either [Display One](#display-one) or [Display Two](#display-two) to style this heading.
 
 <ComponentPreview
   componentName="typography--page-title"


### PR DESCRIPTION
## What does this PR do?
Fixes this "Display Two" jump link on the Typography page.

![image](https://user-images.githubusercontent.com/1424560/127189983-afc42f62-521f-497b-81e0-176c74d4ff7b.png)


Preview: https://deploy-preview-4042--spark-design-system.netlify.app/using-spark/foundations/typography#headers