### PR TITLE
update icon position in select

### DIFF
--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -122,6 +122,7 @@
   <string name="sprk_select_error_box_shadow">0 0 0 1px #ffd47500</string><!-- The box shadow of the outer circle in the radio input when there is an error. -->
   <string name="sprk_select_moz_focusring_color">transparent</string><!-- The value for the Firefox specific -moz-focusring color setting. -->
   <string name="sprk_select_moz_focusring_text_shadow">0 0 0 #ff1c1b1a</string><!-- The value for the Firefox specific -moz-focusring text-shadow setting. -->
+  <string name="sprk_select_arrow_position">relative</string><!-- The position style of the icon in Selects. -->
   <string name="sprk_textarea_margin">0.00dp</string><!-- The margin surrounding Textarea. -->
   <string name="sprk_helper_margin">8.00dp 0 0 0</string><!-- The margin of the helper text for Inputs. -->
   <string name="sprk_selection_container_margin">0 0 16.00dp 0</string><!-- The margin of the selection container for Inputs. -->

--- a/styles/base/inputs/_select.scss
+++ b/styles/base/inputs/_select.scss
@@ -45,6 +45,7 @@
   float: right;
   margin-top: $sprk-select-arrow-offset-y;
   margin-right: $sprk-select-arrow-offset-x;
+  position: $sprk-select-arrow-position;
 }
 
 .sprk-b-Select[disabled] {

--- a/styles/tokens/input.json
+++ b/styles/tokens/input.json
@@ -1020,6 +1020,15 @@
       },
       "file": "settings",
       "themable": true
+    },
+    "arrow-position": {
+      "comment": "The position style of the icon in Selects.",
+      "value": "relative",
+      "attributes": {
+        "category": "content"
+      },
+      "file": "settings",
+      "themable": true
     }
   },
   "textarea": {


### PR DESCRIPTION
## What does this PR do?
Updates the icon position for selects so that it isn't masked by the autofill.

### Associated Issue
Fixes 2546822

### Code
 - [x] Build Component in HTML
 - [x] Build Component in Angular
 - [x] Build Component in React
 - [x] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [x] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [x] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Firefox
  - [x]  Safari

