### PR TITLE
Spark Accordion Item - using slot in place of input() for item header

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.spec.ts
@@ -109,31 +109,6 @@ describe('SprkAccordionItemComponent', () => {
     expect(component.isOpen).toEqual(false);
   });
 
-  // TODO - Remove as part of Issue 3597
-  it('should set the heading to title', () => {
-    component.title = 'This is a title';
-    fixture.detectChanges();
-    expect(accordionHeadingElement.textContent.trim()).toEqual(
-      'This is a title',
-    );
-  });
-
-  it('should set the heading to heading', () => {
-    component.heading = 'This is a title';
-    fixture.detectChanges();
-    expect(accordionHeadingElement.textContent.trim()).toEqual(
-      'This is a title',
-    );
-  });
-
-  // TODO - Remove as part of Issue 3597
-  it('should prefer heading over title', () => {
-    component.heading = 'heading';
-    component.title = 'title';
-    fixture.detectChanges();
-    expect(accordionHeadingElement.textContent.trim()).toEqual('heading');
-  });
-
   it('details should not be present if isOpen is false', () => {
     component.isOpen = false;
     fixture.detectChanges();

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -25,7 +25,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
             [iconName]="leadingIcon"
             [additionalClasses]="getLeadingIconClasses()"
           ></sprk-icon>
-          {{ heading || title }}
+          <ng-content select="[sprkAccordionHeading]"></ng-content>
         </span>
 
         <sprk-icon
@@ -44,19 +44,6 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
   animations: [toggleAnimations.toggleContent],
 })
 export class SprkAccordionItemComponent implements OnInit {
-  // TODO - Remove as part of Issue 3597
-  /**
-   * Deprecated: use `heading` instead. The value supplied will be
-   * rendered inside the heading area of the Accordion Item.
-   */
-  @Input()
-  title: string;
-  /**
-   * The value supplied will be rendered inside the heading area of the
-   * Accordion Item.
-   */
-  @Input()
-  heading: string;
   /**
    * The value supplied will be assigned to the `data-analytics` attribute
    * on the component. Intended for an outside library to capture data.


### PR DESCRIPTION
## What does this PR do?
Remove Component Inputs in favor of angular slot.
Updating Coverage.

### Associated Issue
Fixes (Issue Number that this PR is closing out)

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Documentation
 - [ ] Update Spark Docs

### Code
 - [ ] Build Component in HTML
 - [X] Build Component in Angular
 - [ ] Build Component in React
 - [ ] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [X] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [ ] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [ ] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
