### PR TITLE
Revert overzealous font-family change

### DIFF
--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -213,7 +213,7 @@ public class SparkDesignTokens {
     public static let sprkDatePickerDayEdgeDayColor = UIColor(red: 0.553, green: 0.553, blue: 0.549, alpha:1)
     public static let sprkDatePickerDayHoverColor = UIColor(red: 0.110, green: 0.106, blue: 0.102, alpha:1)
     public static let sprkDatePickerDayInteractColor = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
-    public static let sprkDatePickerFontFamily = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkDatePickerFontFamily = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkDatePickerFontWeight = 300
     public static let sprkDatePickerHeaderFontSize = CGFloat(14.00)
     public static let sprkDatePickerHeaderFontWeight = 700
@@ -236,9 +236,9 @@ public class SparkDesignTokens {
     public static let sprkBtnFontFamily = "RocketSansMedium, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkBtnFontSize = "1rem"
     public static let sprkFontFamilyBodyFour = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
-    public static let sprkFontFamilyBodyOne = "RocketSansMedium, Helvetica, 'Helvetica Neue', Arial, sans-serif"
-    public static let sprkFontFamilyBodyThree = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
-    public static let sprkFontFamilyBodyTwo = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkFontFamilyBodyOne = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkFontFamilyBodyThree = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkFontFamilyBodyTwo = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkFontFamilyDisplayFive = "RocketSansMedium, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkFontFamilyDisplayFour = "RocketSansBold, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkFontFamilyDisplayOne = "RocketSansBold, Helvetica, 'Helvetica Neue', Arial, sans-serif"
@@ -254,10 +254,10 @@ public class SparkDesignTokens {
     public static let sprkFontWeightDisplaySeven = "700"
     public static let sprkFontWeightDisplaySix = "500"
     public static let sprkFontWeightDisplayThree = "300"
-    public static let sprkInputErrorTextFontFamily = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
-    public static let sprkLabelFontFamily = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkInputErrorTextFontFamily = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkLabelFontFamily = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkHelperColor = UIColor(red: 0.376, green: 0.373, blue: 0.369, alpha:1)
-    public static let sprkHelperFontFamily = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkHelperFontFamily = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkHelperFontWeight = 300
     public static let sprkHelperLineHeight = 1.3
     public static let sprkHorizontalListSpacing = CGFloat(16.00)
@@ -370,7 +370,7 @@ public class SparkDesignTokens {
     public static let sprkPagSelectionLinkColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
     public static let sprkPagSelectionLinkColorHover = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
     public static let sprkPlaceholderColor = UIColor(red: 0.553, green: 0.553, blue: 0.549, alpha:1)
-    public static let sprkPlaceholderFontFamily = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkPlaceholderFontFamily = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkPlaceholderFontSize = CGFloat(16.00)
     public static let sprkPlaceholderFontWeight = 300
     public static let sprkPromoBackgroundColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
@@ -402,7 +402,7 @@ public class SparkDesignTokens {
     public static let sprkSelectDisabledCursor = "not-allowed"
     public static let sprkSelectErrorBorderColor = UIColor(red: 0.831, green: 0.459, blue: 0.000, alpha:1)
     public static let sprkSelectFocusBorderColor = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
-    public static let sprkSelectFontFamily = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkSelectFontFamily = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkSelectFontSize = CGFloat(16.00)
     public static let sprkSelectFontWeight = 300
     public static let sprkSelectLineHeight = 1.3
@@ -816,7 +816,7 @@ public class SparkDesignTokens {
     public static let sprkTextInputDisabledColor = UIColor(red: 0.553, green: 0.553, blue: 0.549, alpha:1)
     public static let sprkTextInputErrorBorderColor = UIColor(red: 0.831, green: 0.459, blue: 0.000, alpha:1)
     public static let sprkTextInputFocusBorderColor = UIColor(red: 0.376, green: 0.227, blue: 0.631, alpha:1)
-    public static let sprkTextInputFontFamily = "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif"
+    public static let sprkTextInputFontFamily = "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif"
     public static let sprkTextInputFontWeight = 300
     public static let sprkTextInputHugeActivePlaceholderOpacity = 1
     public static let sprkTextInputHugeCompleteLabelColor = UIColor(red: 0.110, green: 0.106, blue: 0.102, alpha:1)

--- a/styles/tokens/typography.json
+++ b/styles/tokens/typography.json
@@ -166,7 +166,7 @@
       "body": {
         "one": {
           "comment": "The font-family, including fallbacks of TypeBodyOne.",
-          "value": "RocketSansMedium, Helvetica, 'Helvetica Neue', Arial, sans-serif",
+          "value": "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif",
           "file": "typography",
           "attributes": {
             "category": "font"
@@ -175,7 +175,7 @@
         },
         "two": {
           "comment": "The font-family, including fallbacks of TypeBodyTwo.",
-          "value": "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif",
+          "value": "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif",
           "file": "typography",
           "attributes": {
             "category": "font"
@@ -184,7 +184,7 @@
         },
         "three": {
           "comment": "The font-family, including fallbacks of TypeBodyThree.",
-          "value": "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif",
+          "value": "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif",
           "file": "typography",
           "attributes": {
             "category": "font"
@@ -193,7 +193,7 @@
         },
         "four": {
           "comment": "The font-family, including fallbacks of TypeBodyFour.",
-          "value": "RocketSansLight, Helvetica, 'Helvetica Neue', Arial, sans-serif",
+          "value": "RocketSans, Helvetica, 'Helvetica Neue', Arial, sans-serif",
           "file": "typography",
           "attributes": {
             "category": "font"


### PR DESCRIPTION
## What does this PR do?
- Font family should be the general "RocketSans", and not set explicitly. Will be handled by font-weight choices.
- We were too overzealous in changing the font-weights via font-family
- Breaks app typography because if body text is set to "RocketSansLight" it can't be anything other than the font weight of "RocketSansLight"
- A light visual/code check confirms that reverting to "RocketSans"  still retains our typography changes. Double check please!


### Associated Issue
Fixes (Issue Number that this PR is closing out)

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Documentation
 - [ ] Update Spark Docs

### Code
 - [ ] Build Component in HTML
 - [ ] Build Component in Angular
 - [ ] Build Component in React
 - [ ] Unit Testing in HTML with `npm run test` in `html/` (100% coverage, 100% passing)
 - [ ] Unit Testing in Angular with `npm run test` in `angular/` (100% coverage, 100% passing)
 - [ ] Unit Testing in React with `npm run test` in `react/` (100% coverage, 100% passing)

### Browser Testing (current version and 1 prior)
  - [ ] Google Chrome
  - [ ] Google Chrome (Mobile)
  - [ ] Mozilla Firefox
  - [ ] Mozilla Firefox (Mobile)
  - [ ] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [ ] Microsoft Edge
  - [ ] Apple Safari
  - [ ] Apple Safari (Mobile)
  
### Accessibility Testing
  - [ ] Axe browser extension
  - [ ] Jaws Inspect
  - [ ] VoiceOver (iOS) or Talkback (Android)

### Deploy Preview Reviewed and Approved
 - [ ] Design Team
 - [ ] Accessibility Team

### Screenshots
Add screenshots to help explain your PR if you'd like. However, this is not
expected.
