### PR TITLE
added aria roles to ul and li

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion-item/sprk-accordion-item.component.ts
@@ -7,7 +7,7 @@ import { toggleAnimations } from '../sprk-toggle/sprk-toggle-animations';
 @Component({
   selector: 'sprk-accordion-item',
   template: `
-    <li [ngClass]="getClasses()">
+    <li [ngClass]="getClasses()" role="listitem">
       <button
         sprkLink
         variant="unstyled"

--- a/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-accordion/sprk-accordion.component.ts
@@ -3,7 +3,7 @@ import { Component, Input } from '@angular/core';
 @Component({
   selector: 'sprk-accordion',
   template: `
-    <ul [ngClass]="getClasses()" [attr.data-id]="idString">
+    <ul [ngClass]="getClasses()" [attr.data-id]="idString" role="list">
       <ng-content></ng-content>
     </ul>
   `,


### PR DESCRIPTION
## What does this PR do?
Adds aria roles to the `ul` and `li` of an Angular Accordion so the accessibility checks pass.

### Associated Issue
2670578

## Please check off completed items as you work.
If a checklist item or section does not apply to your PR then please remove it.

### Code
 - [x] Build Component in Angular
 
### Browser Testing (current version and 1 prior)
  - [x] Google Chrome
  - [x] Google Chrome (Mobile)
  - [x] Mozilla Firefox
  - [x] Mozilla Firefox (Mobile)
  - [x] Microsoft Internet Explorer 11 (only this specific version of IE)
  - [x] Microsoft Edge
  - [x] Apple Safari
  - [x] Apple Safari (Mobile)
  
### Accessibility Testing
  - [x] Axe browser extension
