### PR TITLE
Footer inline link fix

### DIFF
--- a/react/src/components/footer/SprkFooter.stories.js
+++ b/react/src/components/footer/SprkFooter.stories.js
@@ -236,7 +236,7 @@ export const defaultStory = () => (
     paragraphs={[
       {
         text:
-          '*Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam',
+          '*Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.',
       },
       {
         text:

--- a/react/src/components/footer/SprkFooter.stories.js
+++ b/react/src/components/footer/SprkFooter.stories.js
@@ -257,7 +257,7 @@ export const defaultStory = () => (
           additionalClasses="sprk-c-Footer__text"
           element="p"
         >
-          Sed ut perspiciatis unde omnis iste natus error sit <SprkLink href="#nogo" additionalClasses="sprk-b-Link--inline-light"> inline link </SprkLink> accusantium doloremque laudantiu.
+          Sed et ut perspiciatis unde omnis iste natus error sit <SprkLink href="#nogo" additionalClasses="sprk-b-Link--inline-light"> inline link </SprkLink> accusantium doloremque laudantiu.
         </SprkText>
       </SprkStackItem>
     }

--- a/styles/android/spark_design_tokens_strings.xml
+++ b/styles/android/spark_design_tokens_strings.xml
@@ -200,7 +200,7 @@
   <string name="sprk_link_inline_light_hover_border_bottom">2.00dp solid #ffdeb1fd</string><!-- The underline style of inline Links on a dark background on hover. -->
   <string name="sprk_link_inline_light_underline_color">#ffffffff</string><!-- The underline color value of inline Links on a dark background -->
   <string name="sprk_link_inline_light_border_bottom">2.00dp solid #ffffffff</string><!-- The underline style of inline Links on a dark background. -->
-  <string name="sprk_link_inline_light_visited_border_bottom">2.00dp solid transparent</string><!-- The underline style of visited inline Links on a dark background. -->
+  <string name="sprk_link_inline_light_visited_border_bottom">2.00dp solid #ffffffff</string><!-- The underline style of visited inline Links on a dark background. -->
   <string name="sprk_link_plain_border">none</string><!-- The border settings for Plain Links. -->
   <string name="sprk_link_plain_visited_border">none</string><!-- The border settings for Plain Links in the visited state. -->
   <string name="sprk_link_has_icon_transition">0.3s</string><!-- The transition timing for hover, active and focus styles on Links that have icon. -->

--- a/styles/tokens/link.json
+++ b/styles/tokens/link.json
@@ -431,17 +431,6 @@
           "themable": true
         }
       },
-      "visited":{
-        "border-bottom": {
-          "comment": "The underline style of inline Links on a dark background.",
-          "value": "{link.inline-light.underline.width.value} {link.border.bottom-style.value} {link.inline-light.underline.color.value}",
-          "attributes": {
-            "category": "content"
-          },
-          "file": "settings",
-          "themable": true
-        }
-      },
       "font-weight": {
         "comment": "The font weight of inline Links on a dark background.",
         "value": "{font.weight.body.two.value}",
@@ -450,6 +439,15 @@
       },
       "border-bottom": {
         "comment": "The underline style of inline Links on a dark background.",
+        "value": "{link.inline-light.underline.width.value} {link.border.bottom-style.value} {link.inline-light.underline.color.value}",
+        "attributes": {
+          "category": "content"
+        },
+        "file": "settings",
+        "themable": true
+      },
+      "visited-border-bottom": {
+        "comment": "The underline style of visited inline Links on a dark background.",
         "value": "{link.inline-light.underline.width.value} {link.border.bottom-style.value} {link.inline-light.underline.color.value}",
         "attributes": {
           "category": "content"

--- a/styles/tokens/link.json
+++ b/styles/tokens/link.json
@@ -431,6 +431,17 @@
           "themable": true
         }
       },
+      "visited":{
+        "border-bottom": {
+          "comment": "The underline style of inline Links on a dark background.",
+          "value": "{link.inline-light.underline.width.value} {link.border.bottom-style.value} {link.inline-light.underline.color.value}",
+          "attributes": {
+            "category": "content"
+          },
+          "file": "settings",
+          "themable": true
+        }
+      },
       "font-weight": {
         "comment": "The font weight of inline Links on a dark background.",
         "value": "{font.weight.body.two.value}",
@@ -440,15 +451,6 @@
       "border-bottom": {
         "comment": "The underline style of inline Links on a dark background.",
         "value": "{link.inline-light.underline.width.value} {link.border.bottom-style.value} {link.inline-light.underline.color.value}",
-        "attributes": {
-          "category": "content"
-        },
-        "file": "settings",
-        "themable": true
-      },
-      "visited-border-bottom": {
-        "comment": "The underline style of visited inline Links on a dark background.",
-        "value": "{link.light.underline.width.value} {link.border.bottom-style.value} {link.light.underline.color.value}",
         "attributes": {
           "category": "content"
         },


### PR DESCRIPTION
## What does this PR do?
This PR fixes the footer inline link bug that appears on the visited state. The underline color was transparent on visited and should now be white. Changed the tokens style values for visited-border-bottom. Should apply to all frameworks.

### Associated Issue
2689258

