### PR TITLE
Footer social icons hover color changed to wisteria

### DIFF
--- a/styles/android/spark_design_tokens_colors.xml
+++ b/styles/android/spark_design_tokens_colors.xml
@@ -75,7 +75,7 @@
   <color name="sprk_footer_link_color">#ffffffff</color><!-- Link color on the Footer. -->
   <color name="sprk_footer_icon_color">#ffffffff</color><!-- Icon color on the Footer. -->
   <color name="sprk_footer_trigger_color">#ffffffff</color><!-- Toggle trigger color on the Footer. -->
-  <color name="sprk_footer_trigger_hover_color">#ffffffff</color><!-- Toggle trigger hover color on the Footer. -->
+  <color name="sprk_footer_trigger_hover_color">#ffdeb1fd</color><!-- Toggle trigger hover color on the Footer. -->
   <color name="sprk_highlight_board_color">#ffffffff</color><!-- The background color of the Highlight Board. -->
   <color name="sprk_highlight_board_content_box_color">#ffffffff</color><!-- The background color of the content box in the Highlight Board. -->
   <color name="sprk_icon_fill_color">#ff1c1b1a</color><!-- Value for the fill property of the Icon component. -->

--- a/styles/components/_footer.scss
+++ b/styles/components/_footer.scss
@@ -41,6 +41,14 @@
 .sprk-c-Footer__icon {
   fill: $sprk-footer-icon-color;
   color: $sprk-footer-icon-color;
+
+  &:hover,
+  &:active,
+  &:focus {
+    fill: $sprk-footer-trigger-hover-color;
+    stroke: $sprk-footer-trigger-hover-color;
+    transition: $sprk-footer-toggle-transition;
+  }
 }
 
 // Override toggle trigger styles to work on a dark background.

--- a/styles/ios/SparkDesignTokens.swift
+++ b/styles/ios/SparkDesignTokens.swift
@@ -153,7 +153,7 @@ public class SparkDesignTokens {
     public static let sprkFooterLinkColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
     public static let sprkFooterTextColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
     public static let sprkFooterTriggerColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
-    public static let sprkFooterTriggerHoverColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)
+    public static let sprkFooterTriggerHoverColor = UIColor(red: 0.871, green: 0.694, blue: 0.992, alpha:1)
     public static let sprkGray = UIColor(red: 0.969, green: 0.969, blue: 0.969, alpha:1)
     public static let sprkGreen = UIColor(red: 0.161, green: 0.522, blue: 0.251, alpha:1)
     public static let sprkHighlightBoardColor = UIColor(red: 1.000, green: 1.000, blue: 1.000, alpha:1)

--- a/styles/tokens/footer.json
+++ b/styles/tokens/footer.json
@@ -114,7 +114,7 @@
       "hover": {
         "color": {
           "comment": "Toggle trigger hover color on the Footer.",
-          "value": "{white.value}",
+          "value": "{wisteria.value}",
           "attributes": {
             "category": "color"
           },


### PR DESCRIPTION
## What does this PR do?
This PR adds a hover state to footer social icons. Changed hover color in tokens to wisteria. Added hover, active, and focus state to Footer icon style.

### Associated Issue
2465680