### PR TITLE
Modal & spinner accessibility bug fix

### DIFF
--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.ts
@@ -14,7 +14,7 @@ import { uniqueId } from 'lodash';
       *ngIf="isVisible"
       [ngClass]="getClasses()"
       role="dialog"
-      tabindex="1"
+      tabindex="-1"
       [attr.aria-labelledby]="heading_id"
       aria-modal="true"
       [attr.aria-describedby]="content_id"

--- a/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.ts
+++ b/angular/projects/spark-angular/src/lib/components/sprk-modal/sprk-modal.component.ts
@@ -14,7 +14,7 @@ import { uniqueId } from 'lodash';
       *ngIf="isVisible"
       [ngClass]="getClasses()"
       role="dialog"
-      tabindex="-1"
+      tabindex="0"
       [attr.aria-labelledby]="heading_id"
       aria-modal="true"
       [attr.aria-describedby]="content_id"

--- a/angular/projects/spark-angular/src/lib/directives/sprk-spinner/sprk-spinner.directive.ts
+++ b/angular/projects/spark-angular/src/lib/directives/sprk-spinner/sprk-spinner.directive.ts
@@ -49,7 +49,7 @@ export class SprkSpinnerDirective implements OnInit {
    * The value supplied will be assigned to the
    * `data-analytics` attribute on the element.
    * Intended for an outside
-   * library to capture data.
+   * library to capture data. 
    */
   @HostBinding('attr.data-analytics')
   @Input()
@@ -96,6 +96,13 @@ export class SprkSpinnerDirective implements OnInit {
     this.renderer.setAttribute(
       this.el.nativeElement,
       'aria-valuetext',
+      this.altText,
+    );
+    
+    this.renderer.setAttribute(this.el.nativeElement, 'role', this.role);
+    this.renderer.setAttribute(
+      this.el.nativeElement,
+      'aria-label',
       this.altText,
     );
 


### PR DESCRIPTION
## What does this PR do?
This PR fixes the tab index for the Angular modal causing an accessibility error. It also adds an aria-label to the spinner which was also causing an accessibility error.

### Associated Issue
2703251
